### PR TITLE
Event-linked grading managers + status-actor tracking

### DIFF
--- a/.agent/skills/codebase-architecture/SKILL.md
+++ b/.agent/skills/codebase-architecture/SKILL.md
@@ -9,6 +9,40 @@ Read this before exploring code. It records the non-obvious patterns discovered 
 
 ---
 
+## Concept → Files Map
+
+A quick index from the high-level domain concepts to where they live in code. Use this to jump straight
+to the relevant files instead of re-exploring.
+
+### Gradings
+| Aspect | Where |
+|---|---|
+| Type, converter, `initGrading()`, `GradingStatus` | [functions/src/data-model.ts](../../functions/src/data-model.ts) |
+| Security rules (read/update per role) | `gradings` match block in [firestore.rules](../../firestore.rules) |
+| Server triggers (mirroring, notifications, level-on-pass) | [functions/src/on-grading-update.ts](../../functions/src/on-grading-update.ts) |
+| List / row / edit / detail / progress UI | see "Grading Component Map" below |
+| Event-link picker (link a grading to an IlcEvent) | [src/app/grading-event-input/](../../src/app/grading-event-input/) |
+| Client data access (`addGrading`, `updateGrading`, `getGradingById`) | [src/app/data-manager.service.ts](../../src/app/data-manager.service.ts) |
+
+### Events
+| Aspect | Where |
+|---|---|
+| `IlcEvent` type, `initEvent()`, `EventStatus`, `EventSourceKind` | [functions/src/data-model.ts](../../functions/src/data-model.ts) |
+| Security rules (public read; owner/manager edit via ACL memberDocIds) | `events` match block in [firestore.rules](../../firestore.rules) |
+| Event detail / edit / calendar UI | `src/app/event-view/`, `src/app/event-edit/`, `src/app/events-calendar/` |
+| Event search + `getEventById` | [src/app/data-manager.service.ts](../../src/app/data-manager.service.ts) |
+
+### Associations between concepts
+| Association | How it is represented |
+|---|---|
+| Grading ↔ Event | `Grading.gradingEventDocId` points at an `IlcEvent`. The event's organizer (`ownerDocId`) and `managerDocIds` become **grading managers** — derived **live** from the link (no cached field on the grading). See `isGradingEventManager()` in [firestore.rules](../../firestore.rules) and `userIsEventManager` in [grading-edit](../../src/app/grading-edit/grading-edit.ts) / [grading-progress](../../src/app/grading-progress/grading-progress.ts). Linking/unlinking notifies those members via the `GradingManagerAdded`/`GradingManagerRemoved` notifications (handled in [on-grading-update.ts](../../functions/src/on-grading-update.ts)). |
+| Grading ↔ Instructor(s) / School | Whole grading doc is mirrored to `/instructors/{id}/gradings/{id}` and `/schools/{id}/gradings/{id}` by `on-grading-update.ts` (`ref.set(grading)`). Primary instructor = `gradingInstructorId`; grading managers = `assistantInstructorIds` (legacy field name; UI calls them "Grading Managers"). |
+| Grading ↔ Student | `Member.gradingDocIds` (maintained by the trigger) and `Grading.studentMemberDocId`. |
+| Who accepted / who last changed status | Two pairs (member docId + name snapshot): `acceptedByMemberDocId`/`acceptedByName` (the acceptance milestone; cleared on decline; shown as "Accepted by X" and used to tell co-managers who accepted) and `statusChangedByMemberDocId`/`statusChangedByName` (the latest status transition of any kind; shown as "Moved back by X"). Set client-side in [grading-progress.ts](../../src/app/grading-progress/grading-progress.ts). Backfill: `pnpm --prefix functions run backfill-grading-status-actor`. |
+| Login email ↔ members/schools/instructor licences | `/acl/{email}` caches `memberDocIds`, `schoolDocIds`, `instructorIds`, expiry dates (built by member/school triggers; read by rules). |
+
+---
+
 ## Collections & Data Model
 
 Firestore collections and their TypeScript types (all defined in [functions/src/data-model.ts](../../functions/src/data-model.ts)):
@@ -42,8 +76,16 @@ Firestore collections and their TypeScript types (all defined in [functions/src/
 gradingEventDate: string;    // YYYY-MM-DD, when grading takes place
 gradingEvent: string;        // free-text location/event description
 gradingEventDocId: string;   // Firestore docId of a linked IlcEvent ('' if none)
+acceptedByMemberDocId: string;      // member docId of who accepted (cleared on decline)
+acceptedByName: string;             // their display name (snapshot)
+statusChangedByMemberDocId: string; // member docId of last status actor
+statusChangedByName: string;        // their display name (snapshot)
 status: GradingStatus;
 ```
+
+When `gradingEventDocId` is set, the linked event's `ownerDocId` + `managerDocIds` become grading
+managers (full edit/accept rights) — derived live, never cached on the grading. Students may change the
+linked event at any time until the grading is finalised (passed/not-passed/in-review).
 
 ---
 
@@ -55,8 +97,9 @@ File: [firestore.rules](../../firestore.rules)
 
 ### Grading update permissions (key rule)
 - **Admin**: full write via `allow write`
-- **Instructor** (`isGradingInstructor()`): can update `status`, `gradingEventDate`, `gradingEvent`, `gradingEventDocId`, `notes`, `instructorAcceptedDate`, `resultNotes`, `assistantInstructorIds`, `declineNotes`
-- **Student** (`isGradingStudent()`): can update `status`, `gradingEvent`, `gradingEventDocId`, `gradingInstructorId`, `studentNotes`, `declineNotes`
+- **Manager** (`isGradingManager()` = primary/assistant instructors, OR `isGradingEventManager()` = organizer/managers of the linked event): can update `status`, `gradingEventDate`, `gradingEvent`, `gradingEventDocId`, `notes`, `instructorAcceptedDate`, `acceptedByMemberDocId`, `acceptedByName`, `statusChangedByMemberDocId`, `statusChangedByName`, `gradingInstructorId`, `resultNotes`, `assistantInstructorIds`, `declineNotes`
+- **Student** (`isGradingStudent()`): can update `status`, `gradingEvent`, `gradingEventDate`, `gradingEventDocId`, `gradingInstructorId`, `studentNotes`, `declineNotes`, `statusChangedByMemberDocId`, `statusChangedByName`
+- `isGradingEventManager()` does a guarded `get()` on `/events/{gradingEventDocId}` (only when linked) and checks the user's ACL `memberDocIds` against the event owner/managers. This is what lets non-instructor event staff manage the grading.
 - All non-admin updates require `lastUpdated == request.time` (use `serverTimestamp()` on write)
 
 > **When adding new Grading fields**: add them to the appropriate `affectedKeys().hasOnly(...)` list in [firestore.rules](../../firestore.rules), and add tests in [tests/firestore.rules.spec.ts](../../tests/firestore.rules.spec.ts).
@@ -112,10 +155,12 @@ placeholder="Search..."
 | `GradingProgressComponent` | [src/app/grading-progress/](../../src/app/grading-progress/) | Visual 3-step workflow indicator |
 
 ### GradingEditComponent form permission summary
-Uses Angular Signal Forms (`form()` from `@angular/forms/signals`). Disabled rules:
+Uses Angular Signal Forms (`form()` from `@angular/forms/signals`). "Grading manager" (`userIsGradingInstructor`)
+means the primary/assistant instructor OR the organizer/manager of the linked event (`userIsEventManager`,
+which loads the event by `gradingEventDocId` and checks the user's `member.docId`). Disabled rules:
 - **Admin-only**: `gradingPurchaseDate`, `orderId`, `level`, `studentMemberId`, `studentMemberDocId`, `assistantInstructorIds`, `schoolId`, `reviewIssue`
-- **Instructor or admin**: `status`, `gradingEventDate`, `notes`, `instructorAcceptedDate`, `resultNotes`
-- **Instructor, student, or admin**: `gradingEvent`, `gradingEventDocId`, `gradingInstructorId`
+- **Grading manager or admin**: `status`, `gradingEventDate`, `notes`, `instructorAcceptedDate`, `resultNotes`
+- **Grading manager, student, or admin**: `gradingEvent`, `gradingEventDocId`, `gradingInstructorId`
 - **Student or admin**: `studentNotes`
 
 ---

--- a/docs/gradings.md
+++ b/docs/gradings.md
@@ -1,52 +1,198 @@
 # Gradings
 
-This document describes how gradings should work in this system.
+This document describes how gradings work in this system: how they are created,
+who can see and act on them, the workflow they move through, how they can be
+linked to events, and the notifications they generate.
 
-## New gradings and how they are created from orders
+The authoritative data type is `Grading` in
+[`functions/src/data-model.ts`](../functions/src/data-model.ts). Access control is
+in [`firestore.rules`](../firestore.rules). Server-side automation (mirroring,
+notifications, level updates) is in
+[`functions/src/on-grading-update.ts`](../functions/src/on-grading-update.ts). The
+member-facing UI is the grading components under `src/app/grading-*`.
 
-To add a new grading, the student should first have payed for the grading, which will have created a document in the `orders` collection. Once the payment is confirmed, a `grading` document should be created in the `gradings` collection, and the `grading` document ID should be added to the student's `member` document (via a cloud function in `functions/src`; exact path to be determined). This should also trigger the creation of a cached `grading` document in the `gradings` collection of the instructor who will conduct the grading (if set), and (optionally) the `gradings` collection of the school that will host the grading (if set).
+## How gradings are created
 
-### The Data model for gradings
+A grading is normally created from a paid order: the student pays (creating a
+document in the `orders` collection), and once the payment is processed a
+`grading` document is created in the `gradings` collection. Admins can also
+create a grading manually (then `orderId` is the empty string and
+`gradingPurchaseDate` is the creation date).
 
-A `grading` document should contain the following information:
+When a grading document is created, the `onGradingCreated` cloud function:
 
-- `gradingPurchaseDate`: The date the grading was purchased.
-- `orderId`: The ID of the order that was created when the grading was purchased (or empty if created manually).
-- `level`: The level the grading is aimed for.
-- `gradingInstructorId`: The ID of the instructor who conducted the grading.
-- `assistantInstructorIds`: A list of IDs of the assistant instructors who are helping conduct the grading.
-- `schoolId`: The ID of the school where the grading was conducted. Optional.
-- `studentId`: The ID of the student who was graded.
-- `status`: The status of the grading (e.g. `pending`, `passed`, `rejected`, `requiresReview`). The `requiresReview` status is automatically assigned if the submitted order properties (such as Email, Current Student Level, or Current Application Level) do not explicitly match the current data on the linked `member` document.
-- `gradingEventDate`: The date of the grading. Initially not set. Should be set when the grading is conducted, and its status is changed to `passed` or `rejected`.
-- `lastUpdated`: The last date this grading record was updated. 
-- `notes`: Any notes about the grading.
+- adds the grading's docId to the student's `member.gradingDocIds`;
+- mirrors a cached copy of the whole grading document into the relevant
+  instructor and school subcollections (see [Mirroring](#mirroring-cached-copies));
+- notifies the student that the grading is ready (and, if an instructor is
+  already selected, that the request has been sent);
+- if the grading is already linked to an event, notifies that event's
+  organizer and managers that they are now grading managers.
 
-Whenever a grading document is updated and set to `passed`, the student's `level` should be updated to the `level` of the grading. (via a cloud function in `functions/src`; exact path to be determined)
+## The data model
 
-Gradings documents should be visible to (controlled by the firestore rules file: `firestore.rules`):
+Key fields on a `Grading` (see `data-model.ts` for the full list and comments):
 
-- The student who was graded.
-- The instructor who conducted the grading.
-- Any school managers or the owner of the school where the grading was conducted.
-- All admins.
+| Field | Meaning |
+|---|---|
+| `gradingPurchaseDate` | Date the grading was purchased (or manually created). |
+| `orderId` | Order that created it, or `''` if manual. |
+| `level` | The level being graded for, e.g. `Student 3`, `Application 2`. |
+| `gradingInstructorId` | Human-readable instructorId of the **primary** grading instructor. |
+| `assistantInstructorIds` | Human-readable instructorIds of additional **grading managers**. (Legacy field name; the UI labels these "Grading Managers". They have the same edit/accept rights as the primary instructor.) |
+| `schoolId` / `schoolDocId` | School hosting the grading (optional). |
+| `studentMemberId` / `studentMemberDocId` | The student being graded. |
+| `status` | Workflow status — see [Workflow](#the-workflow). |
+| `gradingEventDate` | Date the grading takes/took place (`YYYY-MM-DD`). |
+| `gradingEvent` | Free-text event/location description. |
+| `gradingEventDocId` | DocId of a linked `IlcEvent`, or `''` — see [Linking a grading to an event](#linking-a-grading-to-an-event). |
+| `instructorAcceptedDate` | Date the request was accepted. |
+| `acceptedByMemberDocId` / `acceptedByName` | Who accepted the request (the acceptance milestone; cleared if later declined). The name is a snapshot for display. |
+| `statusChangedByMemberDocId` / `statusChangedByName` | Who most recently changed the status (any transition). Used for the "Moved back by X" display. |
+| `notes` | Instructor/manager notes about the grading. |
+| `studentNotes` | Optional note from the student with their request. |
+| `resultNotes` | Feedback from the instructor to the student after grading. |
+| `declineNotes` | Reason given when a request is declined. |
+| `reviewIssue` | Why the grading needs admin review (if any). |
 
-Students should have a `gradings` object in their `member` document. This should be a list of IDs for gradings that the student has purchased.
+When a grading is set to `passed`, the student's `studentLevel` /
+`applicationLevel` is updated to match the grading's `level` (via
+`onGradingUpdated`).
 
-### Instructors
+## The workflow
 
-Instructors should have a `gradings` collection under their `instructor` document. This collection should contain the a cached copy of the `grading` documents for all gradings the instructor conducted, or was an assistant for. These should be mirrored here when the `grading` document is created or when the `gradingInstructorId` or `assistantInstructorIds` is changed: if these are edited, the `grading` document should be removed from the old instructor's `gradings` collection and added to the new instructor's `gradings` collection. Access to an instructor's `gradings` collection should be controlled by the firestore rules file: `firestore.rules`, and allow the insturctor to see the entries. But when they make changes, it should be to the `grading` document itself, not the cached copy in the `gradings` collection. Also, they should only be able to edit the entries where they are the `gradingInstructorId`, and only update the `status`, `gradingEventDate`, and `notes` fields.
+Statuses are defined by the `GradingStatus` enum:
 
-There should also be a gradings view ("Gradings Assessed") for instructors that allows them to see all the gradings that they have conducted or assisted in. It should also allow the `gradingInstructorId` to update the status of the gradings (marking it as `passed` or `rejected`) and set the `gradingEventDate`.
+1. **Awaiting instructor selection** (`pending`) — the student chooses the
+   grading instructor and (optionally) the event/date, then submits the request.
+2. **Awaiting acceptance** (`awaiting-instructor-acceptance`) — a manager
+   accepts or declines.
+3. **Awaiting grading** (`awaiting-instructor-grading`) — accepted; waiting for
+   the grading to happen and the result to be recorded.
+4. **Passed** (`passed`) / **Not passed** (`not-passed`) — the result is
+   recorded with notes. Passing updates the student's level.
 
-### Schools
+Other states: **Declined** (`declined`, the student should pick a different
+instructor) and **Requires review** (`in-review`, flagged for an admin when an
+order's properties don't match the member record).
 
-Schools should have a `gradings` collection under their `school` document. This collection should contain the a cached copy of the `grading` documents for the gradings that the school has conducted. These should be mirrored here when the `grading` document is created or when the `schoolId` is changed. When the `schoolId` is changed, the `grading` document should be removed from the old school's `gradings` collection and added to the new school's `gradings` collection. Access to a school's `gradings` collection should be controlled by the firestore rules file: `firestore.rules`, and allow the school manager and owner to see the entries. But they cannot make any changes.
+The 3-step workflow is rendered by
+[`GradingProgressComponent`](../src/app/grading-progress/grading-progress.ts),
+which shows each viewer (student, manager, admin) the contextual message and the
+fields they can edit for the current step.
 
-There should also be a gradings view ("Gradings Hosted") for schools that allows them to see all the gradings that have been hosted at the school.
+### Who can accept
 
-### Admins
+Any **grading manager** can accept (or decline) a request — not just the primary
+instructor. Grading managers are:
 
-A grading record can also be created manually by an admin, in which case the `gradingPurchaseDate` should be set to the date the grading was created, and the `status` should be set to `pending`. Admins can also manually update the status of a grading, and set the `gradingEventDate`, and other fields. Manually created gradings do not have an orderId associated (it is the empty string).
+- the primary instructor (`gradingInstructorId`),
+- the assistant managers (`assistantInstructorIds`), and
+- the organizer and managers of a [linked event](#linking-a-grading-to-an-event).
 
-There should be a view for admins to see all gradings, add new gradings, update existing gradings, or delete them. This view should allow admins to search gradings by students, instructors, and schools, and to filter by status, level, and date. This can be done similarly to the way that the "Members" view allows admins to search for members and filter by status, country, and school.
+When someone accepts, the grading records `acceptedByMemberDocId` /
+`acceptedByName`, and the progress view shows **"Accepted by X"**. If the status
+is later moved back (e.g. declined), the view shows **"Moved back by X"** based on
+`statusChangedBy*`. When one manager accepts, the other managers' "you are now a
+manager" notifications are updated to note who accepted.
+
+## Linking a grading to an event
+
+A student (or a manager/admin) can link a grading to a listed `IlcEvent` using
+the event picker
+([`GradingEventInputComponent`](../src/app/grading-event-input/grading-event-input.ts)).
+This sets `gradingEventDocId` (and copies the event's title/date into
+`gradingEvent` / `gradingEventDate`).
+
+**Consequence of linking:** the event's **organizer** (`ownerDocId`) and
+**managers** (`managerDocIds`) automatically become **grading managers** — they
+can view, edit, and accept the grading. This is derived **live** from the link:
+there is no cached list of event managers on the grading. Unlinking (or linking
+to a different event) therefore revokes/grants access automatically.
+
+- This works even for event staff who are **not** licensed instructors — access
+  is matched on member docId (via the ACL `memberDocIds`), see
+  `isGradingEventManager()` in `firestore.rules` and `userIsEventManager` in the
+  grading components.
+- Linking notifies the added event managers (`GradingManagerAdded`); unlinking
+  notifies the removed ones (`GradingManagerRemoved`) that the student is no
+  longer requesting them as a manager.
+
+**Students may change or remove the linked event at any time** until the grading
+is finalised (i.e. not yet `passed`, `not-passed`, or `in-review`).
+
+> Note: a grading linked to an event is readable by event managers and reachable
+> from their notification link, but it does **not** appear in the cached
+> per-instructor / per-school grading lists (those are keyed by instructorId).
+
+## Visibility and permissions
+
+A grading document is **readable** by (enforced in `firestore.rules`):
+
+- the student being graded,
+- the grading managers (primary instructor, assistant managers, and the
+  organizer/managers of a linked event),
+- managers/owner of the hosting school, and
+- admins.
+
+**Editable fields by role** (all non-admin writes must set `lastUpdated` to the
+server timestamp):
+
+- **Admin** — everything.
+- **Grading manager** — `status`, `gradingEvent`, `gradingEventDate`,
+  `gradingEventDocId`, `gradingInstructorId`, `assistantInstructorIds`, `notes`,
+  `resultNotes`, `declineNotes`, `instructorAcceptedDate`, the `acceptedBy*` and
+  `statusChangedBy*` pairs.
+- **Student** — `status`, `gradingEvent`, `gradingEventDate`,
+  `gradingEventDocId`, `gradingInstructorId`, `studentNotes`, `declineNotes`, and
+  the `statusChangedBy*` pair.
+
+All edits are made to the canonical `gradings/{docId}` document, never to the
+cached copies.
+
+## Mirroring (cached copies)
+
+To make queries efficient, the whole grading document is mirrored by
+`on-grading-update.ts`:
+
+- **Instructors** — `instructors/{instructorMemberDocId}/gradings/{gradingDocId}`
+  for the primary instructor, each assistant manager, and the student's primary
+  instructor. Re-mirrored on create/update; removed when an instructor is no
+  longer associated. Powers the "Gradings Assessed" view.
+- **Schools** — `schools/{schoolDocId}/gradings/{gradingDocId}` for the hosting
+  school. Powers the "Gradings Hosted" view.
+
+Because the entire document is mirrored, new `Grading` fields propagate to the
+caches automatically — no mirroring changes are needed when fields are added.
+
+## Notifications
+
+`on-grading-update.ts` creates member notifications (see `NotificationKind`) for
+the key transitions, including: grading purchased, request sent to an instructor,
+request accepted/declined, result passed/not-passed, and grading-manager
+added/removed (including when an event link makes/removes someone as a manager).
+Notifications are de-duplicated per grading, so a manager only ever has one
+"current" notification per grading.
+
+## Admin view
+
+Admins have a view to list all gradings, create, edit, or delete them, and to
+search by student, instructor, and school and filter by status, level, and date
+— mirroring the "Members" view's search/filter pattern.
+
+## Migrations
+
+`acceptedBy*` / `statusChangedBy*` are newer fields. To backfill existing grading
+documents (fill in `acceptedByName`, and seed `statusChangedBy*` from a recorded
+acceptance), run:
+
+```bash
+cd functions
+pnpm run backfill-grading-status-actor --project <projectId> --dry-run   # preview
+pnpm run backfill-grading-status-actor --project <projectId>             # apply
+```
+
+The script is idempotent (see
+[`functions/scripts/data-migrations/backfill-grading-status-actor.ts`](../functions/scripts/data-migrations/backfill-grading-status-actor.ts)).
+Reads never break on missing fields because `firestoreDocToGrading()` merges over
+`initGrading()` defaults.

--- a/firestore.rules
+++ b/firestore.rules
@@ -210,6 +210,18 @@ service cloud.firestore {
         let assigned = resource.data.get('assignedInstructorId', '');
         return resource.data.gradingInstructorId in instructorIds || instructorIds.hasAny(asst) || (assigned != '' && assigned in instructorIds);
       }
+      // True when the user is the organizer or a manager of the event this
+      // grading is linked to (via gradingEventDocId). Derived live from the
+      // event document so unlinking/relinking automatically revokes/grants
+      // access. Guarded so the extra get() only happens when actually linked.
+      function isGradingEventManager() {
+        let eventDocId = resource.data.get('gradingEventDocId', '');
+        let eventPath = /databases/$(database)/documents/events/$(eventDocId);
+        return eventDocId != '' && exists(eventPath) && (
+          get(eventPath).data.ownerDocId in getUserMemberDocIds() ||
+          getUserMemberDocIds().hasAny(get(eventPath).data.get('managerDocIds', []))
+        );
+      }
       // Uses the ACL's cached schoolDocIds instead of looking up
       // ownerEmails/managerEmails on the school document.
       function isGradingSchoolManager() {
@@ -219,18 +231,20 @@ service cloud.firestore {
       function hasValidEditUpdate() {
         return request.resource.data.lastUpdated == request.time;
       }
-      allow read: if isAdmin() || isGradingStudent() || isGradingManager() || isGradingSchoolManager();
+      allow read: if isAdmin() || isGradingStudent() || isGradingManager() || isGradingSchoolManager() || isGradingEventManager();
       allow write: if hasValidEditUpdate() && isAdmin();
       allow delete: if isAdmin();
-      allow update: if hasValidEditUpdate() && isGradingManager() &&
+      allow update: if hasValidEditUpdate() && (isGradingManager() || isGradingEventManager()) &&
           request.resource.data.diff(resource.data).affectedKeys().hasOnly(
             ['lastUpdated', 'status', 'gradingEventDate', 'gradingEvent', 'gradingEventDocId',
-             'notes', 'instructorAcceptedDate', 'gradingInstructorId',
-             'resultNotes', 'assistantInstructorIds', 'declineNotes']);
+             'notes', 'instructorAcceptedDate', 'acceptedByMemberDocId', 'acceptedByName',
+             'statusChangedByMemberDocId', 'statusChangedByName',
+             'gradingInstructorId', 'resultNotes', 'assistantInstructorIds', 'declineNotes']);
       allow update: if hasValidEditUpdate() && isGradingStudent() &&
           request.resource.data.diff(resource.data).affectedKeys().hasOnly(
-            ['lastUpdated', 'status', 'gradingEvent', 'gradingEventDocId',
-             'gradingInstructorId', 'studentNotes', 'declineNotes']);
+            ['lastUpdated', 'status', 'gradingEvent', 'gradingEventDate', 'gradingEventDocId',
+             'gradingInstructorId', 'studentNotes', 'declineNotes',
+             'statusChangedByMemberDocId', 'statusChangedByName']);
     }
   }
 }

--- a/functions/package.json
+++ b/functions/package.json
@@ -15,6 +15,7 @@
     "update-life-members": "ts-node scripts/update-life-members.ts",
     "grant-video-library-access": "ts-node scripts/grant-video-library-access.ts",
     "normalize-members-schools": "ts-node scripts/data-migrations/normalize-members-schools.ts",
+    "backfill-grading-status-actor": "ts-node scripts/data-migrations/backfill-grading-status-actor.ts",
     "test": "vitest run --no-color"
   },
   "main": "dist/index.js",

--- a/functions/scripts/data-migrations/backfill-grading-status-actor.ts
+++ b/functions/scripts/data-migrations/backfill-grading-status-actor.ts
@@ -1,0 +1,166 @@
+import * as admin from 'firebase-admin';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+import { initGrading } from '../../src/data-model';
+
+/*
+ Data migration: backfill grading status-actor fields.
+
+ Two pairs of fields track "who did what" on a grading:
+   - acceptedByMemberDocId / acceptedByName        — who accepted the request
+   - statusChangedByMemberDocId / statusChangedByName — who last changed status
+
+ Older grading documents either lack these entirely, or were written during
+ development with the now-removed flat `acceptedByMemberDocId` only. This script
+ brings every grading up to date:
+
+   1. Ensures all four fields exist (defaulting to '' via initGrading()).
+   2. If `acceptedByMemberDocId` is set but `acceptedByName` is empty, looks up
+      the member's name and fills it in.
+   3. If the grading was accepted (acceptedByMemberDocId set) but the
+      statusChangedBy* pair is empty, seeds it from the acceptance — the
+      acceptance was the most recent recorded status action we know of.
+
+ The script is idempotent: re-running it makes no further changes.
+
+ Usage:
+   cd functions
+   pnpm run backfill-grading-status-actor --project ilc-paris-class-tracker --dry-run
+
+ If running against the local emulator or with GCLOUD_PROJECT set:
+   pnpm run backfill-grading-status-actor --dry-run
+
+ Remove --dry-run to actually save changes.
+*/
+
+const argv = yargs(hideBin(process.argv))
+  .option('project', {
+    type: 'string',
+    description: 'Firebase Project ID',
+    demandOption: false,
+  })
+  .option('dry-run', {
+    type: 'boolean',
+    description: 'If true, no changes will be made to Firestore',
+    default: false,
+  })
+  .parseSync();
+
+const projectId =
+  argv.project || process.env.GCLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT;
+if (!projectId) {
+  console.error(
+    'Error: Project ID is required. Use --project or GCLOUD_PROJECT env var.',
+  );
+  process.exit(1);
+}
+
+admin.initializeApp({ projectId });
+const db = admin.firestore();
+
+// Cache member-docId → name lookups so we don't re-read the same member.
+const nameCache = new Map<string, string>();
+async function memberName(docId: string): Promise<string> {
+  if (!docId) return '';
+  if (nameCache.has(docId)) return nameCache.get(docId)!;
+  const snap = await db.collection('members').doc(docId).get();
+  const name = snap.exists ? (snap.data()?.name as string) || '' : '';
+  nameCache.set(docId, name);
+  return name;
+}
+
+async function run() {
+  const isDryRun = argv['dry-run'];
+  console.log(`Backfilling grading status-actor fields for project: ${projectId}`);
+  if (isDryRun) {
+    console.log('--- DRY RUN MODE: No changes will be saved ---');
+  }
+
+  const defaults = initGrading();
+  const stats = { total: 0, updated: 0, namesFilled: 0, statusSeeded: 0 };
+
+  const snap = await db.collection('gradings').get();
+  stats.total = snap.size;
+  console.log(`Found ${stats.total} gradings.`);
+
+  let batch = db.batch();
+  let batchCount = 0;
+
+  for (const doc of snap.docs) {
+    const data = doc.data() as Record<string, unknown>;
+    const update: Record<string, unknown> = {};
+
+    // 1. Ensure all four actor fields exist (default '').
+    for (const key of [
+      'acceptedByMemberDocId',
+      'acceptedByName',
+      'statusChangedByMemberDocId',
+      'statusChangedByName',
+    ] as const) {
+      if (data[key] === undefined) {
+        update[key] = defaults[key];
+      }
+    }
+
+    const acceptedByDocId =
+      (update.acceptedByMemberDocId as string | undefined) ??
+      (data.acceptedByMemberDocId as string | undefined) ??
+      '';
+
+    // 2. Fill acceptedByName from the member if we have a docId but no name.
+    const acceptedByName =
+      (update.acceptedByName as string | undefined) ??
+      (data.acceptedByName as string | undefined) ??
+      '';
+    if (acceptedByDocId && !acceptedByName) {
+      update.acceptedByName = await memberName(acceptedByDocId);
+      stats.namesFilled++;
+    }
+
+    // 3. Seed statusChangedBy* from the acceptance if it is still empty.
+    const statusDocId =
+      (update.statusChangedByMemberDocId as string | undefined) ??
+      (data.statusChangedByMemberDocId as string | undefined) ??
+      '';
+    if (acceptedByDocId && !statusDocId) {
+      update.statusChangedByMemberDocId = acceptedByDocId;
+      update.statusChangedByName =
+        (update.acceptedByName as string | undefined) ||
+        acceptedByName ||
+        (await memberName(acceptedByDocId));
+      stats.statusSeeded++;
+    }
+
+    if (Object.keys(update).length === 0) continue;
+
+    stats.updated++;
+    console.log(`  Grading ${doc.id}: ${Object.keys(update).join(', ')}`);
+    if (!isDryRun) {
+      batch.update(doc.ref, update);
+      batchCount++;
+      if (batchCount >= 100) {
+        await batch.commit();
+        batch = db.batch();
+        batchCount = 0;
+      }
+    }
+  }
+
+  if (!isDryRun && batchCount > 0) {
+    await batch.commit();
+  }
+
+  console.log('\n--- Summary ---');
+  console.log(`Total gradings:        ${stats.total}`);
+  console.log(`Updated:               ${stats.updated}`);
+  console.log(`acceptedByName filled: ${stats.namesFilled}`);
+  console.log(`statusChangedBy seeded: ${stats.statusSeeded}`);
+  if (isDryRun) console.log('(dry run — nothing was saved)');
+}
+
+run()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/functions/src/data-model.ts
+++ b/functions/src/data-model.ts
@@ -349,8 +349,13 @@ export enum NotificationKind {
   GradingRequestAccepted = 'GradingRequestAccepted',
   GradingRequestDeclined = 'GradingRequestDeclined',
   GradingRequestsYouAsInstructor = 'GradingRequestsYouAsInstructor',
-  GradingInstructorAdded = 'GradingInstructorAdded',
-  GradingInstructorRemoved = 'GradingInstructorRemoved',
+  // Sent to someone who has become a manager of a grading (the primary/assistant
+  // grading instructors, or the organizer/managers of an event the grading is
+  // linked to). The string values are kept as 'GradingInstructorAdded'/'...Removed'
+  // for backward compatibility with already-stored notifications and per-kind
+  // notification settings.
+  GradingManagerAdded = 'GradingInstructorAdded',
+  GradingManagerRemoved = 'GradingInstructorRemoved',
   // Sent to the student when a grading is purchased, guiding them to the next
   // step (e.g. choosing an instructor) for that grading.
   GradingPurchased = 'GradingPurchased',
@@ -385,6 +390,11 @@ export interface NotificationInstructorGradingData {
   gradingDocId: string;
   studentName: string;
   level: string;
+  // When the manager role came from an event the grading is linked to, these
+  // carry the event context for the message/link. Absent for instructor-role
+  // additions not tied to an event.
+  eventDocId?: string;
+  eventTitle?: string;
 }
 
 export interface NotificationBlogPostData {
@@ -431,11 +441,11 @@ export type MemberNotification = MemberNotificationCommon & (
     data: NotificationInstructorGradingData;
   }
   | {
-    kind: NotificationKind.GradingInstructorAdded;
+    kind: NotificationKind.GradingManagerAdded;
     data: NotificationInstructorGradingData;
   }
   | {
-    kind: NotificationKind.GradingInstructorRemoved;
+    kind: NotificationKind.GradingManagerRemoved;
     data: NotificationInstructorGradingData;
   }
   | {
@@ -970,6 +980,18 @@ export type Grading = {
   notes: string; // Any notes about the grading.
   studentNotes: string; // Optional note from the student when requesting the grading.
   instructorAcceptedDate: string; // YYYY-MM-DD, date the instructor accepted.
+  // Who accepted the grading request (a distinct milestone — the manager who
+  // took it on). Set when the status moves to AwaitingGrading; cleared if it is
+  // later declined. '' if never accepted. The name is a denormalized snapshot so
+  // it displays without a member lookup.
+  acceptedByMemberDocId: string; // Firestore doc ID of the accepting member.
+  acceptedByName: string; // Display name of the accepting member at the time.
+  // Who most recently changed the grading's status via the workflow (accept,
+  // decline, revert, record result). Used to show "Moved back by X" and to tell
+  // co-managers who acted. Distinct from acceptedBy*: this tracks the latest
+  // status transition regardless of kind. '' until the first status change.
+  statusChangedByMemberDocId: string; // Firestore doc ID of the member who acted.
+  statusChangedByName: string; // Display name of that member at the time.
   resultNotes: string; // Notes from the grading/assigned instructor to the student after grading.
   declineNotes: string; // Notes from the instructor explaining why they declined.
   reviewIssue: string; // Store the issue/reason when grading processing requires admin review.
@@ -1014,6 +1036,10 @@ export function initGrading(): Grading {
     notes: '',
     studentNotes: '',
     instructorAcceptedDate: '',
+    acceptedByMemberDocId: '',
+    acceptedByName: '',
+    statusChangedByMemberDocId: '',
+    statusChangedByName: '',
     resultNotes: '',
     declineNotes: '',
     reviewIssue: '',

--- a/functions/src/on-grading-update.ts
+++ b/functions/src/on-grading-update.ts
@@ -149,6 +149,42 @@ async function removeGradingFromSchool(
   await ref.delete();
 }
 
+// The member docIds of an event's organizer + managers, plus the event title.
+interface EventManagers {
+  docIds: string[];
+  title: string;
+}
+
+/**
+ * Resolve the member docIds of the owner and managers of a linked event, plus
+ * the event title (for notification messages). Returns an empty result when the
+ * eventDocId is empty or the event document no longer exists. Grading-manager
+ * status for event staff is derived live from these (never cached on the
+ * grading), so unlinking/relinking automatically revokes/grants access.
+ */
+async function resolveEventManagers(
+  eventDocId: string | undefined,
+): Promise<EventManagers> {
+  if (!eventDocId) return { docIds: [], title: '' };
+  const snap = await db.collection('events').doc(eventDocId).get();
+  if (!snap.exists) return { docIds: [], title: '' };
+  const data = snap.data() || {};
+  const docIds = [data.ownerDocId, ...(data.managerDocIds || [])].filter(
+    (id) => id && id !== '',
+  ) as string[];
+  return { docIds: [...new Set(docIds)], title: data.title || '' };
+}
+
+/** Look up a member's display name by their Firestore doc ID. */
+async function getMemberName(
+  memberDocId: string | undefined,
+  fallback: string,
+): Promise<string> {
+  if (!memberDocId) return fallback;
+  const snap = await db.collection('members').doc(memberDocId).get();
+  return snap.exists ? snap.data()?.name || fallback : fallback;
+}
+
 async function getPrimaryInstructorId(memberDocId: string | undefined): Promise<string | undefined> {
   if (!memberDocId) return undefined;
   const snap = await db.collection('members').doc(memberDocId).get();
@@ -193,6 +229,47 @@ async function removeGradingFromAllInstructors(
 
   for (const instructorId of instructorIds) {
     await removeGradingFromInstructor(gradingDocId, instructorId);
+  }
+}
+
+/**
+ * Notify a set of event organizers/managers that they have been added as (or
+ * removed as) managers of a grading because it was linked to (or unlinked from)
+ * their event. Skips the student themselves.
+ */
+async function notifyEventManagers(
+  memberDocIds: string[],
+  added: boolean,
+  grading: Grading,
+  gradingDocId: string,
+  studentName: string,
+  event: EventManagers,
+  eventDocId: string,
+): Promise<void> {
+  const gradingHref = `#/gradings/${gradingDocId}`;
+  for (const memberDocId of memberDocIds) {
+    if (memberDocId === grading.studentMemberDocId) continue;
+    const msg = added
+      ? `You are now a manager of **${studentName}**'s grading for **${grading.level}**, ` +
+        `linked to your event **${event.title}**. ` +
+        `[Open the grading](${gradingHref}) to accept or record the result.`
+      : `**${studentName}** has unlinked their grading for **${grading.level}** from your event ` +
+        `**${event.title}**, so they are no longer requesting you as one of its grading managers.`;
+    await createNotification(memberDocId, {
+      markdown: msg,
+      createdAt: new Date().toISOString(),
+      dismissed: false,
+      kind: added
+        ? NotificationKind.GradingManagerAdded
+        : NotificationKind.GradingManagerRemoved,
+      data: {
+        gradingDocId,
+        studentName,
+        level: grading.level,
+        eventDocId,
+        eventTitle: event.title,
+      },
+    });
   }
 }
 
@@ -278,6 +355,24 @@ export const onGradingCreated = onDocumentCreated(
       }
     }
 
+    // If the grading is created already linked to an event, notify the event's
+    // organizer and managers that they are now managers of this grading.
+    if (grading.gradingEventDocId) {
+      const event = await resolveEventManagers(grading.gradingEventDocId);
+      if (event.docIds.length > 0) {
+        const studentName = await getMemberName(grading.studentMemberDocId, 'A student');
+        await notifyEventManagers(
+          event.docIds,
+          true,
+          grading,
+          gradingDocId,
+          studentName,
+          event,
+          grading.gradingEventDocId,
+        );
+      }
+    }
+
     logger.info(`Grading ${gradingDocId} created and mirrored.`);
   },
 );
@@ -351,7 +446,7 @@ export const onGradingUpdated = onDocumentUpdated(
               markdown: msg,
               createdAt: new Date().toISOString(),
               dismissed: false,
-              kind: NotificationKind.GradingInstructorAdded,
+              kind: NotificationKind.GradingManagerAdded,
               data: {
                 gradingDocId,
                 studentName,
@@ -372,7 +467,7 @@ export const onGradingUpdated = onDocumentUpdated(
               markdown: msg,
               createdAt: new Date().toISOString(),
               dismissed: false,
-              kind: NotificationKind.GradingInstructorRemoved,
+              kind: NotificationKind.GradingManagerRemoved,
               data: {
                 gradingDocId,
                 studentName,
@@ -604,9 +699,86 @@ export const onGradingUpdated = onDocumentUpdated(
       }
     }
 
+    // Handle event-link change: notify event organizers/managers that they have
+    // gained or lost grading-manager status. Status is derived live from the
+    // link (no cached field), so we only need to notify on the transition.
+    if (previous.gradingEventDocId !== grading.gradingEventDocId) {
+      const beforeEvent = await resolveEventManagers(previous.gradingEventDocId);
+      const afterEvent = await resolveEventManagers(grading.gradingEventDocId);
+      const added = afterEvent.docIds.filter((id) => !beforeEvent.docIds.includes(id));
+      const removed = beforeEvent.docIds.filter((id) => !afterEvent.docIds.includes(id));
+      if (added.length > 0 || removed.length > 0) {
+        const studentName = await getMemberName(grading.studentMemberDocId, 'A student');
+        await notifyEventManagers(
+          added, true, grading, gradingDocId, studentName, afterEvent, grading.gradingEventDocId,
+        );
+        await notifyEventManagers(
+          removed, false, grading, gradingDocId, studentName, beforeEvent, previous.gradingEventDocId,
+        );
+      }
+    }
+
+    // When a grading manager accepts the request, update the other managers'
+    // "you are now a manager" notifications to say who accepted it.
+    if (
+      grading.status === GradingStatus.AwaitingGrading &&
+      previous.status === GradingStatus.AwaitingAcceptance
+    ) {
+      await annotateManagerNotificationsWithAcceptor(grading, gradingDocId);
+    }
+
     logger.info(`Grading ${gradingDocId} updated and re-mirrored.`);
   },
 );
+
+/**
+ * After a grading is accepted, find the other managers' GradingManagerAdded
+ * notifications for this grading and append a note naming who accepted it.
+ * Managers are: the event organizer/managers (derived live from the linked
+ * event) plus the primary and assistant grading instructors. The acceptor
+ * (grading.acceptedByMemberDocId) is skipped.
+ */
+async function annotateManagerNotificationsWithAcceptor(
+  grading: Grading,
+  gradingDocId: string,
+): Promise<void> {
+  const acceptorName =
+    grading.acceptedByName ||
+    (await getMemberName(grading.acceptedByMemberDocId, 'A grading manager'));
+
+  const managerDocIds = new Set<string>();
+  const event = await resolveEventManagers(grading.gradingEventDocId);
+  for (const id of event.docIds) managerDocIds.add(id);
+  const instructorIds = [grading.gradingInstructorId, ...(grading.assistantInstructorIds || [])].filter(
+    (id) => id && id !== '',
+  ) as string[];
+  for (const instructorId of instructorIds) {
+    const docId = await findInstructorMemberDocId(instructorId);
+    if (docId) managerDocIds.add(docId);
+  }
+  managerDocIds.delete(grading.acceptedByMemberDocId);
+
+  for (const memberDocId of managerDocIds) {
+    const snap = await db
+      .collection('members')
+      .doc(memberDocId)
+      .collection('notifications')
+      .where('kind', '==', NotificationKind.GradingManagerAdded)
+      .where('data.gradingDocId', '==', gradingDocId)
+      .get();
+    if (snap.empty) continue;
+    const batch = db.batch();
+    for (const doc of snap.docs) {
+      const data = doc.data() as MemberNotification;
+      if (data.markdown.includes('accepted by')) continue;
+      batch.update(doc.ref, {
+        markdown: `${data.markdown}\n\n_Accepted by **${acceptorName}**._`,
+        lastUpdated: admin.firestore.FieldValue.serverTimestamp(),
+      });
+    }
+    await batch.commit();
+  }
+}
 
 export const onGradingDeleted = onDocumentDeleted(
   'gradings/{gradingId}',
@@ -649,6 +821,12 @@ export const onGradingDeleted = onDocumentDeleted(
       if (instructorMemberDocId) {
         await cancelAndDismissGradingNotifications(instructorMemberDocId, gradingDocId);
       }
+    }
+
+    // Cancel and dismiss event organizers'/managers' grading notifications.
+    const linkedEvent = await resolveEventManagers(grading.gradingEventDocId);
+    for (const memberDocId of linkedEvent.docIds) {
+      await cancelAndDismissGradingNotifications(memberDocId, gradingDocId);
     }
 
     logger.info(`Grading ${gradingDocId} deleted and mirrors removed.`);

--- a/functions/src/send-push.ts
+++ b/functions/src/send-push.ts
@@ -43,10 +43,10 @@ function notificationTitle(kind: NotificationKind): string {
       return 'Grading request update';
     case NotificationKind.GradingRequestsYouAsInstructor:
       return 'New grading request';
-    case NotificationKind.GradingInstructorAdded:
-      return 'Assigned to a grading';
-    case NotificationKind.GradingInstructorRemoved:
-      return 'Grading assignment update';
+    case NotificationKind.GradingManagerAdded:
+      return 'Grading request';
+    case NotificationKind.GradingManagerRemoved:
+      return 'Grading request update';
     case NotificationKind.GradingPurchased:
       return 'Your grading is ready 🥋';
     case NotificationKind.GradingPassed:

--- a/src/app/grading-edit/grading-edit.ts
+++ b/src/app/grading-edit/grading-edit.ts
@@ -20,6 +20,7 @@ import {
   initGrading,
   InstructorPublicData,
   School,
+  IlcEvent,
 } from '../../../functions/src/data-model';
 import {
   form,
@@ -168,12 +169,34 @@ export class GradingEditComponent {
     return user?.isAdmin ?? false;
   });
 
-  // Returns true for the primary instructor AND for grading managers (stored in
-  // `assistantInstructorIds` — TODO: rename field to `gradingManagerIds` after data migration).
-  // Both roles are displayed as having the same edit permissions in the UI.
+  // The event the grading is linked to (if any), loaded live by gradingEventDocId.
+  private linkedEvent = signal<IlcEvent | undefined>(undefined);
+  private _loadLinkedEvent = effect(async () => {
+    const docId = this.editableGrading().gradingEventDocId;
+    if (!docId) {
+      this.linkedEvent.set(undefined);
+      return;
+    }
+    this.linkedEvent.set(await this.dataService.getEventById(docId));
+  });
+
+  // True when the current user is the organizer or a manager of the linked event.
+  // Such users become managers of the grading (derived live from the link).
+  userIsEventManager = computed(() => {
+    const user = this.firebaseState.user();
+    const event = this.linkedEvent();
+    if (!user || !event) return false;
+    const docId = user.member.docId;
+    return event.ownerDocId === docId || (event.managerDocIds || []).includes(docId);
+  });
+
+  // Returns true for the primary instructor, grading managers (stored in
+  // `assistantInstructorIds` — TODO: rename field to `gradingManagerIds` after data migration),
+  // and the organizer/managers of a linked event. All share the same edit permissions.
   userIsGradingInstructor = computed(() => {
     const user = this.firebaseState.user();
     if (!user) return false;
+    if (this.userIsEventManager()) return true;
     const grading = this.editableGrading();
     return user.member.instructorId === grading.gradingInstructorId ||
       (grading.assistantInstructorIds || []).includes(user.member.instructorId);

--- a/src/app/grading-progress/grading-progress.html
+++ b/src/app/grading-progress/grading-progress.html
@@ -147,6 +147,9 @@
         @if (g.declineNotes) {
           <p class="detail-note result-detail">Reason: {{ g.declineNotes }}</p>
         }
+        @if (statusActorName()) {
+          <p class="detail-note result-detail">Moved back by <strong>{{ statusActorName() }}</strong>.</p>
+        }
       }
 
       <!-- Context message -->
@@ -208,7 +211,7 @@
                 } @else {
                   {{ g.gradingEvent }}
                 }
-                @if (canEditGradingDetails()) {
+                @if (canEditEvent()) {
                   <button class="icon-only-button detail-edit-btn" (click)="isEditingEvent.set(true)" title="Edit event details"><app-icon name="edit"></app-icon></button>
                 }
               </p>
@@ -216,12 +219,12 @@
             @if (g.gradingEventDate && !eventLink()) {
               <p class="detail-note">
                 Preferred date: {{ g.gradingEventDate }}
-                @if (canEditGradingDetails()) {
+                @if (canEditEvent()) {
                   <button class="icon-only-button detail-edit-btn" (click)="isEditingEvent.set(true)" title="Edit event details"><app-icon name="edit"></app-icon></button>
                 }
               </p>
             }
-            @if (canEditGradingDetails() && !g.gradingEvent && !g.gradingEventDate) {
+            @if (canEditEvent() && !g.gradingEvent && !g.gradingEventDate) {
               <p class="detail-note">
                 <button class="subtle-button detail-edit-btn" (click)="isEditingEvent.set(true)"><app-icon name="edit"></app-icon> Set event details</button>
               </p>
@@ -440,12 +443,12 @@
               } @else {
                 {{ g.gradingEvent }}
               }
-              @if (canEditGradingDetails()) {
+              @if (canEditEvent()) {
                 <button class="icon-only-button detail-edit-btn" (click)="isEditingEvent.set(true)" title="Edit event details"><app-icon name="edit"></app-icon></button>
               }
             </p>
           }
-          @if (canEditGradingDetails() && !g.gradingEvent) {
+          @if (canEditEvent() && !g.gradingEvent) {
             <p class="detail-note">
               <button class="subtle-button detail-edit-btn" (click)="isEditingEvent.set(true)"><app-icon name="edit"></app-icon> Set event details</button>
             </p>
@@ -459,6 +462,12 @@
        ==================================================================== -->
   } @else if (g.status === GradingStatus.AwaitingGrading) {
     <div class="action-panel">
+      @if (acceptedByName()) {
+        <p class="detail-note">
+          <app-icon name="check" width="16" height="16" fill="#155724"></app-icon>
+          Accepted by <strong>{{ acceptedByName() }}</strong>.
+        </p>
+      }
       @if (userIsStudent()) {
         <!-- Student: read-only accepted status -->
         <p class="action-message">
@@ -532,7 +541,7 @@
               } @else {
                 {{ g.gradingEvent }}
               }
-              @if (canEditGradingDetails()) {
+              @if (canEditEvent()) {
                 <button class="icon-only-button detail-edit-btn" (click)="isEditingEvent.set(true)" title="Edit event details"><app-icon name="edit"></app-icon></button>
               }
             </p>
@@ -540,12 +549,12 @@
           @if (g.gradingEventDate && !eventLink()) {
             <p class="detail-note">
               Scheduled date: {{ g.gradingEventDate }}
-              @if (canEditGradingDetails()) {
+              @if (canEditEvent()) {
                 <button class="icon-only-button detail-edit-btn" (click)="isEditingEvent.set(true)" title="Edit event details"><app-icon name="edit"></app-icon></button>
               }
             </p>
           }
-          @if (canEditGradingDetails() && !g.gradingEvent && !g.gradingEventDate) {
+          @if (canEditEvent() && !g.gradingEvent && !g.gradingEventDate) {
             <p class="detail-note">
               <button class="subtle-button detail-edit-btn" (click)="isEditingEvent.set(true)"><app-icon name="edit"></app-icon> Set event details</button>
             </p>
@@ -757,7 +766,7 @@
               } @else {
                 {{ g.gradingEvent }}
               }
-              @if (canEditGradingDetails()) {
+              @if (canEditEvent()) {
                 <button class="icon-only-button detail-edit-btn" (click)="isEditingEvent.set(true)" title="Edit event details"><app-icon name="edit"></app-icon></button>
               }
             </p>
@@ -765,12 +774,12 @@
           @if (g.gradingEventDate && !eventLink()) {
             <p class="detail-note">
               Date: {{ g.gradingEventDate }}
-              @if (canEditGradingDetails()) {
+              @if (canEditEvent()) {
                 <button class="icon-only-button detail-edit-btn" (click)="isEditingEvent.set(true)" title="Edit event details"><app-icon name="edit"></app-icon></button>
               }
             </p>
           }
-          @if (canEditGradingDetails() && !g.gradingEvent && !g.gradingEventDate) {
+          @if (canEditEvent() && !g.gradingEvent && !g.gradingEventDate) {
             <p class="detail-note">
               <button class="subtle-button detail-edit-btn" (click)="isEditingEvent.set(true)"><app-icon name="edit"></app-icon> Set event details</button>
             </p>
@@ -853,7 +862,7 @@
             <span class="detail-label">Date</span>
             <span class="detail-value">
               {{ g.gradingEventDate }}
-              @if (canEditGradingDetails()) {
+              @if (canEditEvent()) {
                 <button class="icon-only-button detail-edit-btn" (click)="isEditingEvent.set(true)" title="Edit event details"><app-icon name="edit"></app-icon></button>
               }
             </span>
@@ -866,12 +875,12 @@
               } @else {
                 {{ g.gradingEvent }}
               }
-              @if (canEditGradingDetails()) {
+              @if (canEditEvent()) {
                 <button class="icon-only-button detail-edit-btn" (click)="isEditingEvent.set(true)" title="Edit event details"><app-icon name="edit"></app-icon></button>
               }
             </span>
           }
-          @if (canEditGradingDetails() && !g.gradingEventDate && !g.gradingEvent) {
+          @if (canEditEvent() && !g.gradingEventDate && !g.gradingEvent) {
             <span class="detail-label"></span>
             <span class="detail-value">
               <button class="subtle-button detail-edit-btn" (click)="isEditingEvent.set(true)">

--- a/src/app/grading-progress/grading-progress.ts
+++ b/src/app/grading-progress/grading-progress.ts
@@ -28,6 +28,7 @@ import {
 import {
   Grading,
   GradingStatus,
+  IlcEvent,
   InstructorPublicData,
   Member,
 } from '../../../functions/src/data-model';
@@ -70,12 +71,37 @@ export class GradingProgressComponent implements OnDestroy {
     return this.grading().studentMemberDocId === user.member.docId;
   });
 
-  // Returns true for the primary instructor AND for grading managers (stored in
-  // `assistantInstructorIds` — TODO: rename field to `gradingManagerIds` after data migration).
-  // Both roles share the same edit permissions.
+  // The event this grading is linked to (if any), loaded live by gradingEventDocId.
+  // Used to derive event-organizer/manager grading-manager status.
+  private linkedEvent = signal<IlcEvent | undefined>(undefined);
+  private _loadLinkedEvent = effect(async () => {
+    const docId = this.grading().gradingEventDocId;
+    if (!docId) {
+      this.linkedEvent.set(undefined);
+      return;
+    }
+    this.linkedEvent.set(await this.dataService.getEventById(docId));
+  });
+
+  // True when the current user is the organizer or a manager of the linked
+  // event. Such users become managers of the grading (derived live from the
+  // link, never cached on the grading).
+  userIsEventManager = computed(() => {
+    const user = this.firebaseState.user();
+    const event = this.linkedEvent();
+    if (!user || !event) return false;
+    const docId = user.member.docId;
+    return event.ownerDocId === docId || (event.managerDocIds || []).includes(docId);
+  });
+
+  // Returns true for the primary instructor, for grading managers (stored in
+  // `assistantInstructorIds` — TODO: rename field to `gradingManagerIds` after data migration),
+  // and for the organizer/managers of a linked event. All share the same edit permissions.
   userIsGradingInstructor = computed(() => {
     const user = this.firebaseState.user();
-    if (!user || !user.member.instructorId) return false;
+    if (!user) return false;
+    if (this.userIsEventManager()) return true;
+    if (!user.member.instructorId) return false;
     return user.member.instructorId === this.grading().gradingInstructorId ||
       (this.grading().assistantInstructorIds || []).includes(user.member.instructorId);
   });
@@ -97,6 +123,25 @@ export class GradingProgressComponent implements OnDestroy {
   canEditStudentFields = computed(
     () => this.userIsStudent(),
   );
+
+  // Name of whoever accepted the grading, for the "Accepted by X" display.
+  acceptedByName = computed(() => this.grading().acceptedByName);
+
+  // Name of whoever last changed the status, for the "Moved back by X" display.
+  statusActorName = computed(() => this.grading().statusChangedByName);
+
+  // The student may change the linked event at any time until the grading is
+  // finalised (passed/not-passed/in-review). Managers/admins can edit it too.
+  canEditEvent = computed(() => {
+    if (this.canEditGradingDetails()) return true;
+    const status = this.grading().status;
+    return (
+      this.userIsStudent() &&
+      status !== GradingStatus.Passed &&
+      status !== GradingStatus.NotPassed &&
+      status !== GradingStatus.RequiresReview
+    );
+  });
 
   // --- Display helpers ---
   // Always render students in the standard "(MemberId) Student Name" form.
@@ -279,6 +324,7 @@ export class GradingProgressComponent implements OnDestroy {
       gradingEvent: this.editGradingEvent(),
       gradingEventDate: this.editGradingEventDate(),
       status: instructorId ? GradingStatus.AwaitingAcceptance : GradingStatus.AwaitingRequest,
+      ...this.statusActorFields(),
     };
 
     if (this.grading().status === GradingStatus.Declined) {
@@ -338,6 +384,7 @@ export class GradingProgressComponent implements OnDestroy {
       gradingEvent: '',
       gradingEventDate: '',
       status: GradingStatus.AwaitingRequest,
+      ...this.statusActorFields(),
     });
     this.isEditingRequest.set(false);
     this.isSaving.set(false);
@@ -364,17 +411,43 @@ export class GradingProgressComponent implements OnDestroy {
     this.gradingUpdated.emit({
       status: GradingStatus.Declined,
       declineNotes: this.editDeclineNotes(),
+      // Declining undoes the acceptance, so clear the acceptance milestone.
       instructorAcceptedDate: '',
+      acceptedByMemberDocId: '',
+      acceptedByName: '',
+      ...this.statusActorFields(),
     });
     this.isSaving.set(false);
+  }
+
+  // The current logged-in user's member docId + display name.
+  private currentActor(): { docId: string; name: string } {
+    const member = this.firebaseState.user()?.member;
+    return { docId: member?.docId ?? '', name: member?.name ?? '' };
+  }
+
+  // The "who last changed the status" fields, stamped with the current user on
+  // every workflow status transition so the UI can show "Moved back by X" and
+  // co-managers can be told who acted.
+  private statusActorFields(): Partial<Grading> {
+    const actor = this.currentActor();
+    return {
+      statusChangedByMemberDocId: actor.docId,
+      statusChangedByName: actor.name,
+    };
   }
 
   acceptAndGradeMyself() {
     this.isSaving.set(true);
     const today = new Date().toISOString().split('T')[0];
+    const actor = this.currentActor();
     this.gradingUpdated.emit({
       status: GradingStatus.AwaitingGrading,
       instructorAcceptedDate: today,
+      // Record both the acceptance milestone and the latest status actor.
+      acceptedByMemberDocId: actor.docId,
+      acceptedByName: actor.name,
+      ...this.statusActorFields(),
       gradingEvent: this.editGradingEvent(),
       gradingEventDate: this.editGradingEventDate(),
     });
@@ -393,6 +466,7 @@ export class GradingProgressComponent implements OnDestroy {
       resultNotes: this.editResultNotes(),
       gradingInstructorId: this.editInstructorId(),
       assistantInstructorIds: this.editGradingManagerIds().filter(id => id !== ''),
+      ...this.statusActorFields(),
     };
     this.gradingUpdated.emit(update);
     this.isSaving.set(false);

--- a/src/app/member-details/member-details.ts
+++ b/src/app/member-details/member-details.ts
@@ -102,10 +102,10 @@ export class MemberDetailsComponent {
         return 'Grading Request Accepted';
       case NotificationKind.GradingRequestsYouAsInstructor:
         return 'Grading Requests (You as Grading Manager)';
-      case NotificationKind.GradingInstructorAdded:
-        return 'Assigned as Grading Instructor';
-      case NotificationKind.GradingInstructorRemoved:
-        return 'Removed as Grading Instructor';
+      case NotificationKind.GradingManagerAdded:
+        return 'Added as Grading Manager';
+      case NotificationKind.GradingManagerRemoved:
+        return 'Removed as Grading Manager';
       case NotificationKind.GradingPurchased:
         return 'Grading Purchased';
       case NotificationKind.GradingPassed:

--- a/src/app/settings/notification-settings/notification-settings.component.ts
+++ b/src/app/settings/notification-settings/notification-settings.component.ts
@@ -135,10 +135,10 @@ export class NotificationSettingsComponent {
         return 'Grading Request Declined';
       case NotificationKind.GradingRequestsYouAsInstructor:
         return 'Grading Request Sent to You';
-      case NotificationKind.GradingInstructorAdded:
-        return 'Assigned as Grading Instructor';
-      case NotificationKind.GradingInstructorRemoved:
-        return 'Removed as Grading Instructor';
+      case NotificationKind.GradingManagerAdded:
+        return 'Added as Grading Manager';
+      case NotificationKind.GradingManagerRemoved:
+        return 'Removed as Grading Manager';
       case NotificationKind.GradingPurchased:
         return 'Grading Purchased';
       case NotificationKind.GradingPassed:

--- a/tests/firestore.rules.spec.ts
+++ b/tests/firestore.rules.spec.ts
@@ -778,6 +778,84 @@ describe('Firestore Rules', () => {
         }),
       );
     });
+
+    describe('Event-linked grading managers', () => {
+      // member1 (a non-instructor) owns/manages the event; grading-2 is the
+      // grading linked to that event.
+      beforeEach(async () => {
+        await testEnv.withSecurityRulesDisabled(async (context) => {
+          const db = context.firestore();
+          await db.collection('events').doc('event-linked').set({
+            title: 'Spring Gathering',
+            ownerDocId: 'FirestoreDocID-member1',
+            managerDocIds: ['FirestoreDocID-instructor2'],
+            status: 'listed',
+          });
+          await db.collection('gradings').doc('grading-2').set({
+            gradingInstructorId: 'INST-001',
+            assistantInstructorIds: [],
+            studentMemberDocId: 'FirestoreDocID-student2',
+            schoolId: '',
+            schoolDocId: '',
+            status: 'awaiting-instructor-acceptance',
+            gradingEventDocId: 'event-linked',
+            lastUpdated: new Date(),
+          });
+        });
+      });
+
+      it('should allow the event owner (non-instructor) to read a linked grading', async () => {
+        const db = testEnv
+          .authenticatedContext('member1', { email: 'member1@ilc.com' })
+          .firestore();
+        await assertSucceeds(db.collection('gradings').doc('grading-2').get());
+      });
+
+      it('should allow an event manager to read a linked grading', async () => {
+        const db = testEnv
+          .authenticatedContext('instructor2', { email: 'instructor2@ilc.com' })
+          .firestore();
+        await assertSucceeds(db.collection('gradings').doc('grading-2').get());
+      });
+
+      it('should allow the event owner to accept and record who changed the status', async () => {
+        const db = testEnv
+          .authenticatedContext('member1', { email: 'member1@ilc.com' })
+          .firestore();
+        await assertSucceeds(
+          db.collection('gradings').doc('grading-2').update({
+            status: 'awaiting-instructor-grading',
+            instructorAcceptedDate: '2026-06-07',
+            acceptedByMemberDocId: 'FirestoreDocID-member1',
+            acceptedByName: 'Test Member 1',
+            statusChangedByMemberDocId: 'FirestoreDocID-member1',
+            statusChangedByName: 'Test Member 1',
+            lastUpdated: serverTimestamp(),
+          }),
+        );
+      });
+
+      it('should deny event owner access once the grading is unlinked from the event', async () => {
+        await testEnv.withSecurityRulesDisabled(async (context) => {
+          await context
+            .firestore()
+            .collection('gradings')
+            .doc('grading-2')
+            .update({ gradingEventDocId: '' });
+        });
+        const db = testEnv
+          .authenticatedContext('member1', { email: 'member1@ilc.com' })
+          .firestore();
+        await assertFails(db.collection('gradings').doc('grading-2').get());
+      });
+
+      it('should deny an unrelated member from reading a linked grading', async () => {
+        const db = testEnv
+          .authenticatedContext('other_user', { email: 'other@test.com' })
+          .firestore();
+        await assertFails(db.collection('gradings').doc('grading-2').get());
+      });
+    });
   });
 
   describe('Member Notifications Subcollection', () => {


### PR DESCRIPTION
## Summary

Linking a grading to an event now has real consequences: the event's **organizer and managers** become **grading managers** (can view, edit, and accept the grading), are **notified** on link/unlink, and lose access automatically when the grading is unlinked. Access is derived **live** from `gradingEventDocId` (no cached field), and works for event staff who are **not** licensed instructors via a guarded event lookup in `firestore.rules`.

It also rounds out the grading workflow: any grading manager (not just the primary instructor) can accept, and the UI now shows **who accepted** and **who moved a grading back**.

## What's included

- **Event-linked managers**: `isGradingEventManager()` rule (guarded `get()` on the linked event, matched on ACL `memberDocIds`); `userIsEventManager` in `grading-edit` / `grading-progress`; live derivation means unlink/relink revokes/grants automatically.
- **Notifications**: renamed `GradingInstructor{Added,Removed}` → `GradingManager{Added,Removed}` (string values unchanged for back-compat), enriched with event context; co-managers' "you are now a manager" notifications are updated to note who accepted.
- **Status-actor tracking**: `acceptedByMemberDocId`/`acceptedByName` (acceptance milestone, cleared on decline) and `statusChangedByMemberDocId`/`statusChangedByName` (latest transition). Progress UI shows "Accepted by X" / "Moved back by X".
- **Student event control**: students can change/unlink the linked event any time until the grading is finalised (`gradingEventDate` added to student-writable fields).
- **Backfill script**: `functions/scripts/data-migrations/backfill-grading-status-actor.ts` (idempotent). Already run against `ilc-paris-class-tracker` (68 gradings initialized; nothing to copy).
- **Docs**: full rewrite of `docs/gradings.md`; updated `codebase-architecture` skill.

## Testing

- `pnpm build` and `pnpm build:functions` — pass
- `pnpm test` (grading specs) — 20 pass
- `pnpm test:functions` — 185 pass
- `pnpm test:rules` — 89 pass (incl. new event-manager read/update/unlink cases)
- Backfill idempotency verified empirically (re-run reports 0 updates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)