### PR TITLE
feat: notify primary instructor on grading accept/result

### DIFF
--- a/docs/gradings.md
+++ b/docs/gradings.md
@@ -174,6 +174,14 @@ added/removed (including when an event link makes/removes someone as a manager).
 Notifications are de-duplicated per grading, so a manager only ever has one
 "current" notification per grading.
 
+The student's **primary instructor** (sifu — `member.primaryInstructorId`) is
+also kept in the loop on their students' progress: they are notified when a
+student's grading request is **accepted** and when the **result is recorded**
+(passed/not-passed). To avoid redundant self-notifications, the sifu is **not**
+notified when they are the member who performed that action — i.e. when they
+accepted the request (`acceptedByMemberDocId`) or recorded the result
+(`statusChangedByMemberDocId`) themselves.
+
 ## Admin view
 
 Admins have a view to list all gradings, create, edit, or delete them, and to

--- a/functions/src/on-grading-update.ts
+++ b/functions/src/on-grading-update.ts
@@ -195,6 +195,28 @@ async function getPrimaryInstructorId(memberDocId: string | undefined): Promise<
 }
 
 /**
+ * Resolve the student's primary instructor (sifu) to notify about a grading
+ * action, plus the student's display name. Returns undefined (i.e. don't
+ * notify) when the student has no resolvable primary instructor, or when the
+ * sifu is the member who performed the action (`actorMemberDocId`) or is the
+ * student themselves. `actorMemberDocId` is who accepted or recorded the
+ * result, so the sifu is never notified about their own action.
+ */
+async function resolvePrimaryInstructorToNotify(
+  grading: Grading,
+  actorMemberDocId: string,
+): Promise<{ sifuMemberDocId: string; studentName: string } | undefined> {
+  const primaryInstructorId = await getPrimaryInstructorId(grading.studentMemberDocId);
+  if (!primaryInstructorId) return undefined;
+  const sifuMemberDocId = await findInstructorMemberDocId(primaryInstructorId);
+  if (!sifuMemberDocId) return undefined;
+  if (sifuMemberDocId === actorMemberDocId) return undefined;
+  if (sifuMemberDocId === grading.studentMemberDocId) return undefined;
+  const studentName = await getMemberName(grading.studentMemberDocId, 'Your student');
+  return { sifuMemberDocId, studentName };
+}
+
+/**
  * Mirror the grading to all relevant instructors (primary + assistants + sifu).
  */
 async function mirrorGradingToAllInstructors(
@@ -550,6 +572,26 @@ export const onGradingUpdated = onDocumentUpdated(
             },
           }
         );
+        // Also notify the student's primary instructor (sifu), unless they are
+        // the one who recorded the result.
+        const sifu = await resolvePrimaryInstructorToNotify(
+          grading,
+          grading.statusChangedByMemberDocId,
+        );
+        if (sifu) {
+          await createNotification(sifu.sifuMemberDocId, {
+            markdown:
+              `🎉 Your student **${sifu.studentName}** passed their grading for **${grading.level}**. ` +
+              `[See the result](${gradingHref}).`,
+            createdAt: new Date().toISOString(),
+            dismissed: false,
+            kind: NotificationKind.GradingPassed,
+            data: {
+              gradingDocId,
+              level: grading.level,
+            },
+          });
+        }
       } else if (
         grading.status === GradingStatus.NotPassed &&
         previous.status !== GradingStatus.NotPassed
@@ -570,6 +612,26 @@ export const onGradingUpdated = onDocumentUpdated(
             },
           }
         );
+        // Also notify the student's primary instructor (sifu), unless they are
+        // the one who recorded the result.
+        const sifu = await resolvePrimaryInstructorToNotify(
+          grading,
+          grading.statusChangedByMemberDocId,
+        );
+        if (sifu) {
+          await createNotification(sifu.sifuMemberDocId, {
+            markdown:
+              `Your student **${sifu.studentName}**'s grading result for **${grading.level}** is in: ` +
+              `not passed this time. [See the result](${gradingHref}).`,
+            createdAt: new Date().toISOString(),
+            dismissed: false,
+            kind: NotificationKind.GradingNotPassed,
+            data: {
+              gradingDocId,
+              level: grading.level,
+            },
+          });
+        }
       }
     }
 
@@ -623,6 +685,30 @@ export const onGradingUpdated = onDocumentUpdated(
           },
         }
       );
+
+      // Also notify the student's primary instructor (sifu) that their
+      // student's grading request was accepted, unless the sifu is the one who
+      // accepted it.
+      const sifu = await resolvePrimaryInstructorToNotify(
+        grading,
+        grading.acceptedByMemberDocId,
+      );
+      if (sifu) {
+        const gradingHref = `#/gradings/${gradingDocId}`;
+        const acceptorName = grading.acceptedByName || 'a grading manager';
+        await createNotification(sifu.sifuMemberDocId, {
+          markdown:
+            `Your student **${sifu.studentName}**'s grading request for **${grading.level}** ` +
+            `has been accepted by **${acceptorName}**. [Open the grading](${gradingHref}).`,
+          createdAt: new Date().toISOString(),
+          dismissed: false,
+          kind: NotificationKind.GradingRequestAccepted,
+          data: {
+            gradingDocId,
+            level: grading.level,
+          },
+        });
+      }
     }
 
     // Notify student if instructor declined grading request


### PR DESCRIPTION
## What

Notify a student's **primary instructor (sifu)** about their students' grading progress:

- when a grading **request is accepted**, and
- when a grading **result is recorded** (passed / not-passed).

The sifu is **not** notified when they are the member who performed that action — i.e. they accepted the request (`acceptedByMemberDocId`) or recorded the result (`statusChangedByMemberDocId`) themselves — avoiding redundant self-notifications.

## How

- New helper `resolvePrimaryInstructorToNotify()` in `on-grading-update.ts` resolves the student's `primaryInstructorId` → sifu member docId + student name, returning `undefined` (skip) when there's no sifu, or the sifu is the actor, or the sifu is the student.
- Reuses existing `GradingRequestAccepted` / `GradingPassed` / `GradingNotPassed` notification kinds with sifu-tailored markdown; inherits per-grading de-duplication.
- Documented in `docs/gradings.md`.

## Testing

- `pnpm build:functions` ✅
- `pnpm test:functions` ✅ (185 passing)

> Note: these Firestore triggers have no existing unit-test harness (the module captures `db` at load time). E2E coverage via the Firebase emulator is planned as a follow-up (user-stories + emulator-driven tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)