### PR TITLE
chore: seed-data subcollections in a sub-folder

### DIFF
--- a/functions/scripts/export-anonymized-data.ts
+++ b/functions/scripts/export-anonymized-data.ts
@@ -38,7 +38,13 @@ if (!projectId) {
 // Output directory
 // ============================================================
 const outputDir = path.resolve(__dirname, '../../tmp/seed-data');
+// Subcollection JSON files live in their own folder to keep the top-level
+// directory (one file per top-level collection) easy to scan. Files keep the
+// `{parent}__{parentId}__{subcollection}.json` naming; seed-emulator.ts reads
+// them back from here.
+const subcollectionsDir = path.join(outputDir, 'subcollections');
 fs.mkdirSync(outputDir, { recursive: true });
+fs.mkdirSync(subcollectionsDir, { recursive: true });
 
 // ============================================================
 // Firebase Admin init
@@ -151,6 +157,13 @@ function save(filename: string, data: unknown): void {
   console.log(`  Saved ${filePath} (${(Array.isArray(data) ? data.length : 1)} docs)`);
 }
 
+// Save a subcollection file into the subcollections/ sub-folder.
+function saveSub(filename: string, data: unknown): void {
+  const filePath = path.join(subcollectionsDir, filename);
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2), 'utf-8');
+  console.log(`  Saved ${filePath} (${(Array.isArray(data) ? data.length : 1)} docs)`);
+}
+
 // ============================================================
 // Main
 // ============================================================
@@ -187,7 +200,7 @@ async function main(): Promise<void> {
           sub === 'members'
             ? subDocs.map((m) => anonymiseMember(m, (m['memberId'] as string) || m.id))
             : subDocs;
-        save(`schools__${s.id}__${sub}.json`, anonymised);
+        saveSub(`schools__${s.id}__${sub}.json`, anonymised);
         console.log(`    schools/${schoolId}/${sub}: ${subDocs.length} docs`);
       }
     }
@@ -211,7 +224,7 @@ async function main(): Promise<void> {
           sub === 'members'
             ? subDocs.map((m) => anonymiseMember(m, (m['memberId'] as string) || m.id))
             : subDocs;
-        save(`instructors__${inst.id}__${sub}.json`, anonymised);
+        saveSub(`instructors__${inst.id}__${sub}.json`, anonymised);
         console.log(`    instructors/${instructorId}/${sub}: ${subDocs.length} docs`);
       }
     }

--- a/functions/scripts/seed-emulator.ts
+++ b/functions/scripts/seed-emulator.ts
@@ -3,8 +3,9 @@
  *
  * Reads anonymized JSON files from <repo-root>/tmp/seed-data/ and imports
  * them into the local Firestore emulator. Top-level collection files are
- * named `{collection}.json`; subcollection files use the naming convention
- * `{collection}__{parentId}__{subcollection}.json`.
+ * named `{collection}.json` and live directly in tmp/seed-data/. Subcollection
+ * files live in the tmp/seed-data/subcollections/ sub-folder and use the naming
+ * convention `{collection}__{parentId}__{subcollection}.json`.
  *
  * Requires the Firebase emulator suite to be running:
  *   pnpm emulator:start   (from repo root)
@@ -106,26 +107,30 @@ async function seedCollection(collectionPath: string, docs: RawDoc[]): Promise<v
 async function main(): Promise<void> {
   console.log(`Seeding Firestore emulator (project: ${projectId}) from ${seedDir}`);
 
-  const files = fs.readdirSync(seedDir).filter((f) => f.endsWith('.json'));
+  // Top-level collection files live in seedDir; subcollection files live in
+  // seedDir/subcollections/. Gather both as absolute paths, top-level first so
+  // parent documents exist before their subcollections are seeded.
+  const topLevelFiles = fs
+    .readdirSync(seedDir)
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => path.join(seedDir, f));
+  const subDir = path.join(seedDir, 'subcollections');
+  const subFiles = fs.existsSync(subDir)
+    ? fs
+        .readdirSync(subDir)
+        .filter((f) => f.endsWith('.json'))
+        .map((f) => path.join(subDir, f))
+    : [];
+  const files = [...topLevelFiles.sort(), ...subFiles.sort()];
 
-  // Sort so top-level collections are seeded before subcollections
-  files.sort((a, b) => {
-    const aSub = a.includes('__');
-    const bSub = b.includes('__');
-    if (aSub && !bSub) return 1;
-    if (!aSub && bSub) return -1;
-    return a.localeCompare(b);
-  });
-
-  for (const file of files) {
-    const filePath = path.join(seedDir, file);
+  for (const filePath of files) {
     const raw = fs.readFileSync(filePath, 'utf-8');
     const docs = JSON.parse(raw) as RawDoc[];
 
     // Derive the Firestore collection path from the filename.
     // Top-level:     members.json                → members
     // Subcollection: schools__abc123__gradings.json → schools/abc123/gradings
-    const basename = path.basename(file, '.json');
+    const basename = path.basename(filePath, '.json');
     let collectionPath: string;
     if (basename.includes('__')) {
       const parts = basename.split('__');


### PR DESCRIPTION
## What

Tidies the local e2e seed-data layout. The `{parent}__{id}__{sub}.json` subcollection files (155 of them) cluttered the top of `tmp/seed-data/`; they now live in a `tmp/seed-data/subcollections/` sub-folder, leaving the top level as one file per top-level collection.

- `export-anonymized-data.ts` writes subcollection files into `subcollections/` (via a new `saveSub()`); top-level collections are unchanged.
- `seed-emulator.ts` reads top-level files first, then the `subcollections/` sub-folder, so parent docs are seeded before their subcollections.

## Testing

- Re-exported anonymized prod data (`pnpm export:anonymized`) → clean top level + populated `subcollections/`.
- Seeded the emulator end to end (`firebase emulators:exec --only firestore,auth … seed-emulator.ts`): all collections + subcollections seeded with correct paths (e.g. `instructors/{id}/members`), 1394 Auth accounts created, "All collections seeded successfully."

> `tmp/seed-data/` is git-ignored, so this PR only changes the two scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)