### PR TITLE
feat(school): dedicated school profile page + event/school association

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -114,7 +114,7 @@ service cloud.firestore {
       allow delete: if isAdmin();
       allow update: if hasValidEditUpdate() && isSchoolManager() && 
           request.resource.data.diff(resource.data).affectedKeys().hasOnly(
-            ['lastUpdated', 'schoolName', 'schoolAddress', 'schoolCity', 'schoolZipCode', 'schoolCountyOrState', 'schoolCountry', 'schoolWebsite', 'schoolClassGoogleCalendarId', 'managerInstructorIds']);
+            ['lastUpdated', 'schoolName', 'schoolAddress', 'schoolCity', 'schoolZipCode', 'schoolCountyOrState', 'schoolCountry', 'schoolWebsite', 'schoolClassGoogleCalendarId', 'managerInstructorIds', 'publicProfileImageUrl', 'publicProfileImageThumbUrl', 'publicCoverImageUrl', 'publicBioMarkdown']);
     
       match /members/{memberDocId} {
         allow read: if isAdmin() || isSchoolManager();

--- a/functions/src/data-model.ts
+++ b/functions/src/data-model.ts
@@ -1288,6 +1288,11 @@ export type IlcEvent = {
   ownerDocId: string;
   ownerEmails: string[];
   leadingInstructorId: string; // Primary instructor leading the event
+  // The human-readable schoolId (e.g. SCH-123) this event is hosted by /
+  // associated with, or '' if none. Used to list a school's events on its
+  // public profile page and to filter the events search page by school.
+  schoolId: string;
+  schoolDocId: string; // Firestore doc ID of the associated school, or ''.
   managerDocIds: string[];
   managerEmails: string[];
   // Attached documents (max 10). Each entry has a display name and a
@@ -1314,6 +1319,8 @@ export function initEvent(): IlcEvent {
     ownerDocId: '',
     ownerEmails: [],
     leadingInstructorId: '',
+    schoolId: '',
+    schoolDocId: '',
     managerDocIds: [],
     managerEmails: [],
     documents: [],

--- a/functions/src/data-model.ts
+++ b/functions/src/data-model.ts
@@ -302,6 +302,13 @@ export type School = {
   schoolWebsite: string; // Optional website URL
   schoolClassGoogleCalendarId: string; // Optional Google Calendar ID for public class schedule
 
+  // Public profile page fields. Shown on the school's dedicated public profile
+  // page (mirrors the instructor profile page).
+  publicProfileImageUrl: string; // Logo / profile picture (large).
+  publicProfileImageThumbUrl: string; // Logo / profile picture (thumbnail).
+  publicCoverImageUrl: string; // Cover / header image.
+  publicBioMarkdown: string; // Markdown description of the school.
+
   // The `instructorId` (human readable) of the owner of this school; can set the managers, and
   // change anything in the school.
   ownerInstructorId: string;
@@ -917,6 +924,10 @@ export function initSchool(): School {
     schoolCountry: '',
     schoolWebsite: '',
     schoolClassGoogleCalendarId: '',
+    publicProfileImageUrl: '',
+    publicProfileImageThumbUrl: '',
+    publicCoverImageUrl: '',
+    publicBioMarkdown: '',
     ownerInstructorId: '',
     managerInstructorIds: [],
     ownerEmails: [],

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start:find-instructor-wc": "ng serve --project find-an-instructor-wc",
     "start:events-wc": "ng serve --project events-viewer-wc",
     "stamp-version": "ts-node -O '{\"module\": \"commonjs\"}' scripts/stamp-version.ts",
+    "backfill:event-schools": "pnpm --prefix functions exec ts-node ../scripts/backfill-event-schools.ts",
     "prebuild": "pnpm run stamp-version",
     "build": "ng build --project ilc-members-manager",
     "build:find-instructor-wc": "ng build --project find-an-instructor-wc",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start:find-instructor-wc": "ng serve --project find-an-instructor-wc",
     "start:events-wc": "ng serve --project events-viewer-wc",
     "stamp-version": "ts-node -O '{\"module\": \"commonjs\"}' scripts/stamp-version.ts",
-    "backfill:event-schools": "pnpm --prefix functions exec ts-node ../scripts/backfill-event-schools.ts",
+    "backfill:event-schools": "pnpm --prefix functions exec ts-node -O '{\"module\":\"commonjs\"}' ../scripts/backfill-event-schools.ts",
     "prebuild": "pnpm run stamp-version",
     "build": "ng build --project ilc-members-manager",
     "build:find-instructor-wc": "ng build --project find-an-instructor-wc",

--- a/scripts/backfill-event-schools.ts
+++ b/scripts/backfill-event-schools.ts
@@ -17,6 +17,7 @@
  */
 
 import * as admin from 'firebase-admin';
+import { IlcEvent, Member } from '../functions/src/data-model';
 
 const COMMIT = process.argv.includes('--commit');
 
@@ -29,12 +30,12 @@ async function main() {
   const membersSnap = await db.collection('members').where('instructorId', '!=', '').get();
   const instructorSchools = new Map<string, { schoolId: string; schoolDocId: string }>();
   for (const doc of membersSnap.docs) {
-    const m = doc.data();
-    const instructorId = (m.instructorId as string) || '';
+    const m = doc.data() as Member;
+    const instructorId = m.instructorId || '';
     if (!instructorId) continue;
     instructorSchools.set(instructorId, {
-      schoolId: (m.primarySchoolId as string) || '',
-      schoolDocId: (m.primarySchoolDocId as string) || '',
+      schoolId: m.primarySchoolId || '',
+      schoolDocId: m.primarySchoolDocId || '',
     });
   }
   console.log(`Loaded ${instructorSchools.size} instructors with member records.`);
@@ -50,12 +51,12 @@ async function main() {
   let batchCount = 0;
 
   for (const doc of eventsSnap.docs) {
-    const ev = doc.data();
+    const ev = doc.data() as IlcEvent;
     if (ev.schoolId) {
       skippedHasSchool++;
       continue;
     }
-    const leadingInstructorId = (ev.leadingInstructorId as string) || '';
+    const leadingInstructorId = ev.leadingInstructorId || '';
     if (!leadingInstructorId) {
       skippedNoInstructor++;
       continue;

--- a/scripts/backfill-event-schools.ts
+++ b/scripts/backfill-event-schools.ts
@@ -1,0 +1,104 @@
+/* backfill-event-schools.ts
+ *
+ * One-off backfill: populate `schoolId` / `schoolDocId` on existing events that
+ * predate the event<->school association feature. For each event that has no
+ * schoolId yet but does have a `leadingInstructorId`, we look up that
+ * instructor's member record and copy their `primarySchoolId` /
+ * `primarySchoolDocId` onto the event.
+ *
+ * Events that already have a schoolId, or whose leading instructor has no
+ * primary school (HQ), are left unchanged.
+ *
+ * Usage (uses Application Default Credentials, like the other admin scripts):
+ *   # dry run — report what would change, write nothing:
+ *   pnpm backfill:event-schools
+ *   # apply the changes:
+ *   pnpm backfill:event-schools --commit
+ */
+
+import * as admin from 'firebase-admin';
+
+const COMMIT = process.argv.includes('--commit');
+
+async function main() {
+  admin.initializeApp();
+  const db = admin.firestore();
+
+  // Build a map: instructorId (human-readable) -> { primarySchoolId, primarySchoolDocId }.
+  // Members with an instructorId are the instructors that can lead events.
+  const membersSnap = await db.collection('members').where('instructorId', '!=', '').get();
+  const instructorSchools = new Map<string, { schoolId: string; schoolDocId: string }>();
+  for (const doc of membersSnap.docs) {
+    const m = doc.data();
+    const instructorId = (m.instructorId as string) || '';
+    if (!instructorId) continue;
+    instructorSchools.set(instructorId, {
+      schoolId: (m.primarySchoolId as string) || '',
+      schoolDocId: (m.primarySchoolDocId as string) || '',
+    });
+  }
+  console.log(`Loaded ${instructorSchools.size} instructors with member records.`);
+
+  const eventsSnap = await db.collection('events').get();
+  console.log(`Scanning ${eventsSnap.size} events...`);
+
+  let updated = 0;
+  let skippedHasSchool = 0;
+  let skippedNoInstructor = 0;
+  let skippedNoSchool = 0;
+  const batch = db.batch();
+  let batchCount = 0;
+
+  for (const doc of eventsSnap.docs) {
+    const ev = doc.data();
+    if (ev.schoolId) {
+      skippedHasSchool++;
+      continue;
+    }
+    const leadingInstructorId = (ev.leadingInstructorId as string) || '';
+    if (!leadingInstructorId) {
+      skippedNoInstructor++;
+      continue;
+    }
+    const school = instructorSchools.get(leadingInstructorId);
+    if (!school || !school.schoolId) {
+      skippedNoSchool++;
+      continue;
+    }
+
+    console.log(
+      `  ${doc.id} "${ev.title}" (instructor ${leadingInstructorId}) -> ${school.schoolId}`,
+    );
+    updated++;
+    if (COMMIT) {
+      batch.update(doc.ref, {
+        schoolId: school.schoolId,
+        schoolDocId: school.schoolDocId,
+      });
+      batchCount++;
+      // Firestore batches are limited to 500 writes.
+      if (batchCount === 450) {
+        await batch.commit();
+        batchCount = 0;
+      }
+    }
+  }
+
+  if (COMMIT && batchCount > 0) {
+    await batch.commit();
+  }
+
+  console.log('\nSummary:');
+  console.log(`  ${updated} events ${COMMIT ? 'updated' : 'would be updated'}`);
+  console.log(`  ${skippedHasSchool} skipped (already have a schoolId)`);
+  console.log(`  ${skippedNoInstructor} skipped (no leading instructor)`);
+  console.log(`  ${skippedNoSchool} skipped (instructor has no primary school)`);
+  if (!COMMIT) {
+    console.log('\nDry run — no changes written. Re-run with --commit to apply.');
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/backfill-event-schools.ts
+++ b/scripts/backfill-event-schools.ts
@@ -14,6 +14,8 @@
  *   pnpm backfill:event-schools
  *   # apply the changes:
  *   pnpm backfill:event-schools --commit
+ *   # target a different project (defaults to ilc-paris-class-tracker):
+ *   pnpm backfill:event-schools --project=<project-id>
  */
 
 import * as admin from 'firebase-admin';
@@ -21,8 +23,15 @@ import { IlcEvent, Member } from '../functions/src/data-model';
 
 const COMMIT = process.argv.includes('--commit');
 
+// Target Firestore project. Override with --project=<id>; defaults to the
+// live project.
+const DEFAULT_PROJECT = 'ilc-paris-class-tracker';
+const projectArg = process.argv.find((a) => a.startsWith('--project='));
+const PROJECT_ID = projectArg ? projectArg.split('=')[1] : DEFAULT_PROJECT;
+
 async function main() {
-  admin.initializeApp();
+  console.log(`Using project: ${PROJECT_ID}`);
+  admin.initializeApp({ projectId: PROJECT_ID });
   const db = admin.firestore();
 
   // Build a map: instructorId (human-readable) -> { primarySchoolId, primarySchoolDocId }.

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -23,6 +23,7 @@ export enum Views {
   FindAnInstructor = 'findAnInstructor',
   InstructorView = 'instructorView',
   FindSchool = 'findSchool',
+  SchoolView = 'schoolView',
   Home = 'home',
   ImportExport = 'importExport',
   InstructorsArea = 'instructorsArea',
@@ -106,6 +107,7 @@ export const initPathPatterns = {
   [Views.InstructorView]: pathPattern`instructors/${pv('instructorId')}`,
   [Views.FindSchool]: addUrlParams(pathPattern`find-school`, ['schoolId', 'q']),
   [Views.ManageSchools]: addUrlParams(pathPattern`schools`, ['q']),
+  [Views.SchoolView]: pathPattern`school-profile/${pv('schoolId')}`,
   [Views.ManageSchoolEdit]: pathPattern`schools/${pv('schoolId')}/edit`,
   [Views.MyProfile]: pathPattern`myProfile`,
   [Views.ManageMembers]: addUrlParams(pathPattern`members`, [

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -144,7 +144,7 @@ export const initPathPatterns = {
   [Views.InstructorsAreaPost]: pathPattern`instructors-area/post/${pv('blogPostPath')}`,
   [Views.NewMember]: addUrlParams(pathPattern`new-member`, ['basePath']),
   [Views.Statistics]: pathPattern`statistics`,
-  [Views.EventsCalendar]: addUrlParams(pathPattern`events`, ['q', 'fromDate']),
+  [Views.EventsCalendar]: addUrlParams(pathPattern`events`, ['q', 'fromDate', 'schoolId', 'instructorId']),
   [Views.EventView]: pathPattern`events/${pv('eventId')}`,
   [Views.MyEventView]: pathPattern`my-events/${pv('eventId')}`,
   [Views.ManageEventView]: pathPattern`manage-events/${pv('eventId')}`,

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -37,6 +37,12 @@
         @case (Views.FindSchool) {
           <app-find-school></app-find-school>
         }
+        @case (Views.SchoolView) {
+          <app-school-view
+            [schoolId]="routingService.signals[Views.SchoolView].pathVars.schoolId()"
+            (titleLoaded)="onSchoolTitleLoaded($event)"
+          ></app-school-view>
+        }
         @case (Views.ClassCalendarView) {
           <app-class-calendar
             [calendarId]="instructorCalendarId()"

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -19,6 +19,7 @@ import { InstructorStudentsComponent } from './instructor-students/instructor-st
 import { FilteredMembersComponent } from './filtered-members/filtered-members';
 import { MemberDetailsComponent } from './member-details/member-details';
 import { FindSchoolComponent } from './find-school/find-school';
+import { SchoolViewComponent } from './school-view/school-view';
 import { HomeComponent } from './home/home';
 import { ClassCalendarComponent } from './class-calendar/class-calendar';
 import { SquarespaceContentComponent } from './squarespace/squarespace-content.component';
@@ -67,6 +68,7 @@ import { APP_VERSION } from './version';
     FilteredMembersComponent,
     MemberDetailsComponent,
     FindSchoolComponent,
+    SchoolViewComponent,
     HomeComponent,
     ClassCalendarComponent,
     SquarespaceContentComponent,
@@ -116,6 +118,7 @@ export class App {
     Views.FindAnInstructor,
     Views.InstructorView,
     Views.FindSchool,
+    Views.SchoolView,
     Views.EventsCalendar,
     Views.EventView,
     Views.ClassCalendarView,
@@ -204,6 +207,8 @@ export class App {
         baseBreadcrumbs.push({ label: 'Find a School', url: '#/find-school' });
       } else if (view === Views.InstructorView) {
         baseBreadcrumbs.push({ label: 'Find an Instructor', url: '#/find-an-instructor' });
+      } else if (view === Views.SchoolView) {
+        baseBreadcrumbs.push({ label: 'Find a School', url: '#/find-school' });
       } else if (view === Views.EventsCalendar) {
         // No parent breadcrumb needed for events
       } else if (view === Views.EventView) {
@@ -314,7 +319,7 @@ export class App {
       if (view !== Views.OrderView) {
         this.loadedOrderTitle.set(null);
       }
-      if (!isSchoolEdit) {
+      if (!isSchoolEdit && view !== Views.SchoolView) {
         this.loadedSchoolTitle.set(null);
       }
       if (view !== Views.GradingView) {
@@ -385,6 +390,8 @@ export class App {
         return this.loadedSchoolTitle() || 'My School';
       case Views.FindSchool:
         return 'Find a School';
+      case Views.SchoolView:
+        return this.loadedSchoolTitle() || 'School';
       case Views.ClassCalendarView:
         const calInstructorId = this.routingService.signals[Views.ClassCalendarView].pathVars.instructorId();
         const calInstructor = calInstructorId

--- a/src/app/data-manager.service.ts
+++ b/src/app/data-manager.service.ts
@@ -690,6 +690,35 @@ export class DataManagerService {
     }
   }
 
+  // Fetches all events associated with the given human-readable schoolId and
+  // splits them into upcoming and past (relative to now). Events are publicly
+  // readable, so this works on the public school profile page. `pastLimit`
+  // caps the number of past events returned (most-recent first).
+  async getEventsForSchool(
+    schoolId: string,
+    pastLimit = 5,
+  ): Promise<{ upcoming: IlcEvent[]; past: IlcEvent[]; pastTotal: number }> {
+    if (!schoolId) return { upcoming: [], past: [], pastTotal: 0 };
+    try {
+      const q = query(this.eventsCollection, where('schoolId', '==', schoolId));
+      const snap = await getDocs(q);
+      const events = snap.docs
+        .map((d) => ({ ...initEvent(), ...d.data(), docId: d.id } as IlcEvent))
+        .filter((ev) => ev.status === EventStatus.Listed);
+      const now = new Date().toISOString();
+      const upcoming = events
+        .filter((ev) => (ev.end || ev.start) >= now)
+        .sort((a, b) => a.start.localeCompare(b.start));
+      const pastAll = events
+        .filter((ev) => (ev.end || ev.start) < now)
+        .sort((a, b) => b.start.localeCompare(a.start));
+      return { upcoming, past: pastAll.slice(0, pastLimit), pastTotal: pastAll.length };
+    } catch (error) {
+      console.error('Error getting events for school:', error);
+      return { upcoming: [], past: [], pastTotal: 0 };
+    }
+  }
+
   // Returns the schools the given instructor owns or manages, matched by their
   // human-readable instructorId. Schools are publicly readable, so this works
   // on the public instructor profile page without an authenticated session.

--- a/src/app/event-edit/event-edit.html
+++ b/src/app/event-edit/event-edit.html
@@ -93,6 +93,27 @@
             </div>
           }
         </div>
+
+        <label for="event-school">School</label>
+        <div class="rhs">
+          <app-autocomplete
+            [searchableSet]="dataService.schools"
+            [placeholder]="'Search for a school (optional)'"
+            [displayFns]="schoolDisplayFns"
+            [initSearchTerm]="eventFormModel().schoolId"
+            (textUpdated)="updateSchoolId($event)"
+          ></app-autocomplete>
+          @if (eventFormModel().schoolId && dataService.schools.get(eventFormModel().schoolId); as schoolData) {
+            <div class="note" style="display: flex; gap: 10px; align-items: center;">
+              <span>{{ schoolData.schoolName }}</span>
+              <span class="identifier-chip">{{ schoolData.schoolId }}</span>
+              <button type="button" class="subtle-button" (click)="clearSchool()">
+                <app-icon name="close" /> Clear
+              </button>
+            </div>
+          }
+        </div>
+
         <label for="event-hero-image">Image</label>
         <div class="rhs">
           @if (eventFormModel().heroImageUrl && !isEditingCrop()) {

--- a/src/app/event-edit/event-edit.spec.ts
+++ b/src/app/event-edit/event-edit.spec.ts
@@ -90,6 +90,8 @@ describe('EventEditComponent', () => {
       ownerDocId: 'owner-id',
       managerDocIds: [],
       leadingInstructorId: '',
+      schoolId: '',
+      schoolDocId: '',
       documents: [],
     });
 

--- a/src/app/event-edit/event-edit.ts
+++ b/src/app/event-edit/event-edit.ts
@@ -25,7 +25,7 @@ import {
   required,
   FieldTree,
 } from '@angular/forms/signals';
-import { IlcEvent, EventStatus, EventSourceKind, eventStatusLabel, initEvent, Member, InstructorPublicData, EventDocument } from '../../../functions/src/data-model';
+import { IlcEvent, EventStatus, EventSourceKind, eventStatusLabel, initEvent, Member, InstructorPublicData, EventDocument, School } from '../../../functions/src/data-model';
 import { IconComponent } from '../icons/icon.component';
 import { DataManagerService } from '../data-manager.service';
 import { SpinnerComponent } from '../spinner/spinner.component';
@@ -64,6 +64,8 @@ type EventFormModel = {
   ownerDocId: string;
   managerDocIds: string[];
   leadingInstructorId: string;
+  schoolId: string;
+  schoolDocId: string;
   documents: EventDocument[];
 };
 
@@ -94,6 +96,8 @@ function toFormModel(event: IlcEvent): EventFormModel {
     ownerDocId: event.ownerDocId || '',
     managerDocIds: event.managerDocIds || [],
     leadingInstructorId: event.leadingInstructorId || '',
+    schoolId: event.schoolId || '',
+    schoolDocId: event.schoolDocId || '',
     documents: event.documents || [],
   };
   if (event.heroImageLargeUrl !== undefined) {
@@ -149,6 +153,8 @@ export class EventEditComponent implements OnInit {
     ownerDocId: '',
     managerDocIds: [],
     leadingInstructorId: '',
+    schoolId: '',
+    schoolDocId: '',
     documents: [],
   });
 
@@ -421,9 +427,28 @@ export class EventEditComponent implements OnInit {
     toName: (m: Member) => m.memberId ? `(${m.memberId}) ${m.name}` : m.name,
   };
 
+  schoolDisplayFns = {
+    toChipId: (s: School) => s.schoolId,
+    toName: (s: School) => s.schoolId ? `${s.schoolName} [${s.schoolId}]` : s.schoolName,
+  };
+
   private extractInstructorId(value: string): string {
     const match = value.match(/\[([^\]]+)\]$/);
     return match ? match[1] : value;
+  }
+
+  updateSchoolId(value: string) {
+    const schoolId = this.extractInstructorId(value);
+    const school = this.dataService.schools.get(schoolId);
+    this.eventFormModel.update((m) => ({
+      ...m,
+      schoolId,
+      schoolDocId: school?.docId || '',
+    }));
+  }
+
+  clearSchool() {
+    this.eventFormModel.update((m) => ({ ...m, schoolId: '', schoolDocId: '' }));
   }
 
   updateLeadingInstructorId(value: string) {
@@ -743,6 +768,8 @@ export class EventEditComponent implements OnInit {
         ownerDocId: formData.ownerDocId,
         managerDocIds: formData.managerDocIds.filter(Boolean),
         leadingInstructorId: formData.leadingInstructorId,
+        schoolId: formData.schoolId,
+        schoolDocId: formData.schoolDocId,
         documents: formData.documents,
         kind: EventSourceKind.FirebaseSourced,
         lastUpdated: new Date().toISOString(),

--- a/src/app/events-calendar/event-list/event-list.html
+++ b/src/app/events-calendar/event-list/event-list.html
@@ -5,6 +5,15 @@
   </div>
 }
 
+@if (isFiltered()) {
+  <div class="filter-banner">
+    <span><app-icon name="filter_list" width="16px" height="16px"></app-icon> Showing events for <strong>{{ filterLabel() }}</strong></span>
+    <a class="subtle-button" [href]="clearFilterHref">
+      <app-icon name="close" width="16px" height="16px"></app-icon> Clear filter
+    </a>
+  </div>
+}
+
 @if (isLoading()) {
   <app-spinner>Loading events...</app-spinner>
 } @else if (hasLoaded()) {

--- a/src/app/events-calendar/event-list/event-list.scss
+++ b/src/app/events-calendar/event-list/event-list.scss
@@ -10,6 +10,31 @@
   flex-direction: column;
 }
 
+.filter-banner {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5em;
+  padding: 0.5em 0.8em;
+  margin-bottom: 0.8em;
+  border: 1px solid $border-color-light;
+  border-radius: 8px;
+  background: $theme-bg-color;
+
+  span {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4em;
+  }
+
+  .subtle-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3em;
+  }
+}
+
 .event-list {
   display: flex;
   flex-direction: column;

--- a/src/app/events-calendar/event-list/event-list.ts
+++ b/src/app/events-calendar/event-list/event-list.ts
@@ -27,6 +27,7 @@ import MiniSearch from 'minisearch';
 import { EventItemComponent } from '../event-item/event-item';
 import { IconComponent } from '../../icons/icon.component';
 import { SpinnerComponent } from '../../spinner/spinner.component';
+import { DataManagerService } from '../../data-manager.service';
 import { environment } from '../../../environments/environment';
 
 
@@ -108,6 +109,43 @@ export class EventListComponent implements OnDestroy {
     return '';
   });
 
+  // Optional Firestore-level filters (events search page only): show only events
+  // associated with a given school or instructor. When active, the default
+  // "upcoming only" date floor is dropped so past events are included too.
+  protected urlSchoolId = computed(() => {
+    if (this.routingService.matchedPatternId() === Views.EventsCalendar) {
+      return this.routingService.signals[Views.EventsCalendar].urlParams.schoolId();
+    }
+    return '';
+  });
+  protected urlInstructorId = computed(() => {
+    if (this.routingService.matchedPatternId() === Views.EventsCalendar) {
+      return this.routingService.signals[Views.EventsCalendar].urlParams.instructorId();
+    }
+    return '';
+  });
+
+  // True when a school/instructor filter is active.
+  protected isFiltered = computed(() => !!this.urlSchoolId() || !!this.urlInstructorId());
+
+  // Human-readable label for the active filter banner.
+  protected filterLabel = computed(() => {
+    const schoolId = this.urlSchoolId();
+    if (schoolId) {
+      const school = this.dataService?.schools.get(schoolId);
+      return school ? `${school.schoolName} [${schoolId}]` : `school ${schoolId}`;
+    }
+    const instructorId = this.urlInstructorId();
+    if (instructorId) {
+      const instructor = this.dataService?.instructors.get(instructorId);
+      return instructor ? `${instructor.name} [${instructorId}]` : `instructor ${instructorId}`;
+    }
+    return '';
+  });
+
+  // Link that clears the active filter (returns to the full events list).
+  protected clearFilterHref = '#/events';
+
   // This signal is bound to the search input field and updates on every keystroke.
   // It is seeded from the URL `q` param (if present) or `initialQuery` (for the
   // web component), and can still be freely edited by the user.
@@ -168,9 +206,17 @@ export class EventListComponent implements OnDestroy {
 
   // --- Firestore direct subscription ---
   private firebaseApp = inject(FIREBASE_APP);
+  // Optional: not provided in the standalone web-component context, where the
+  // school/instructor filter is never active.
+  private dataService = inject(DataManagerService, { optional: true });
   private db = getFirestore(this.firebaseApp);
-  private unsubscribe: Unsubscribe | null = null;
+  private unsubscribes: Unsubscribe[] = [];
   readonly isLoading = signal(true);
+
+  private unsubscribeAll(): void {
+    for (const u of this.unsubscribes) u();
+    this.unsubscribes = [];
+  }
 
   // --- Full-text Search Implementation ---
   private miniSearch: MiniSearch<SearchableCalendarEvent>;
@@ -250,10 +296,16 @@ export class EventListComponent implements OnDestroy {
       idField: 'id',
     });
 
-    // Re-subscribe whenever the collection path or the *committed* fromDate changes.
+    // Re-subscribe whenever the collection path, committed fromDate, or the
+    // active school/instructor filter changes.
     effect(() => {
-      this.unsubscribe?.();
-      this.subscribeToEvents(this.collectionPath(), this.activeFromDate());
+      this.unsubscribeAll();
+      this.subscribeToEvents(
+        this.collectionPath(),
+        this.activeFromDate(),
+        this.urlSchoolId(),
+        this.urlInstructorId(),
+      );
     });
 
     // Rebuild the MiniSearch index whenever the cache data changes.
@@ -283,12 +335,70 @@ export class EventListComponent implements OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.unsubscribe?.();
+    this.unsubscribeAll();
   }
 
-  private subscribeToEvents(path: string, fromDateValue: string): void {
-    console.info(`Subscribing to events at path: ${path}, fromDate: ${fromDateValue || '(default)'}`);
+  private subscribeToEvents(
+    path: string,
+    fromDateValue: string,
+    schoolId: string,
+    instructorId: string,
+  ): void {
     const eventsCollection = collection(this.db, path);
+
+    const onError = (error: unknown) => {
+      console.error(`Error subscribing to events at ${path}:`, error);
+      this.errorMessage.set('Failed to load events. Please try again later.');
+      this.isLoading.set(false);
+    };
+    const toEvent = (d: { id: string; data: () => unknown }) =>
+      ({ ...initEvent(), ...(d.data() as object), docId: d.id } as IlcEvent);
+
+    this.isLoading.set(true);
+    this.errorMessage.set(null);
+
+    // School/instructor filter (events search page only). Uses single-field
+    // equality / array-contains queries so no composite index is needed; the
+    // date floor is dropped so past events are included too.
+    if (path === 'events' && schoolId) {
+      console.info(`Subscribing to events for school: ${schoolId}`);
+      this.unsubscribes.push(onSnapshot(
+        query(eventsCollection, where('schoolId', '==', schoolId)),
+        (snap) => {
+          this.events.set(snap.docs.map(toEvent));
+          this.isLoading.set(false);
+        },
+        onError,
+      ));
+      return;
+    }
+    if (path === 'events' && instructorId) {
+      console.info(`Subscribing to events for instructor: ${instructorId}`);
+      // An instructor's events are those they lead, own, or co-manage. Owner /
+      // manager queries are keyed by member docId, resolved via the public
+      // instructors set (skipped if unavailable, e.g. before it loads).
+      const docId = this.dataService?.instructors.get(instructorId)?.docId;
+      const queries = [query(eventsCollection, where('leadingInstructorId', '==', instructorId))];
+      if (docId) {
+        queries.push(query(eventsCollection, where('ownerDocId', '==', docId)));
+        queries.push(query(eventsCollection, where('managerDocIds', 'array-contains', docId)));
+      }
+      const groups: Map<string, IlcEvent>[] = queries.map(() => new Map());
+      queries.forEach((qq, i) => {
+        this.unsubscribes.push(onSnapshot(
+          qq,
+          (snap) => {
+            groups[i] = new Map(snap.docs.map((d) => [d.id, toEvent(d)]));
+            const merged = new Map<string, IlcEvent>();
+            for (const g of groups) for (const [id, ev] of g) merged.set(id, ev);
+            this.events.set([...merged.values()]);
+            this.isLoading.set(false);
+          },
+          onError,
+        ));
+      });
+      return;
+    }
 
     let q = query(eventsCollection);
     if (path === 'events') {
@@ -296,25 +406,16 @@ export class EventListComponent implements OnDestroy {
       const startDateStr = fromDateValue || this.defaultFromDate;
       q = query(eventsCollection, where('end', '>=', startDateStr));
     }
+    console.info(`Subscribing to events at path: ${path}, fromDate: ${fromDateValue || '(default)'}`);
 
-    this.isLoading.set(true);
-    this.errorMessage.set(null);
-
-    this.unsubscribe = onSnapshot(
+    this.unsubscribes.push(onSnapshot(
       q,
       (snapshot) => {
-        const events = snapshot.docs.map(
-          (doc) => ({ ...initEvent(), ...doc.data(), docId: doc.id } as IlcEvent),
-        );
-        this.events.set(events);
+        this.events.set(snapshot.docs.map(toEvent));
         this.isLoading.set(false);
       },
-      (error) => {
-        console.error(`Error subscribing to events at ${path}:`, error);
-        this.errorMessage.set('Failed to load events. Please try again later.');
-        this.isLoading.set(false);
-      },
-    );
+      onError,
+    ));
   }
 
   private parseSearchTerm(term: string): {

--- a/src/app/find-school/find-school.html
+++ b/src/app/find-school/find-school.html
@@ -15,7 +15,7 @@
         @if (school.schoolId) {
           <span class="school-id-chip">{{ school.schoolId }}</span>
         }
-        <h3>{{ school.schoolName }}</h3>
+        <h3><a class="school-name-link" [href]="'#/school-profile/' + school.schoolId">{{ school.schoolName }}</a></h3>
         <div class="school-header-details">
           @if (dataManager.instructors.get(school.ownerInstructorId); as owner) {
             <div class="header-detail">

--- a/src/app/find-school/find-school.scss
+++ b/src/app/find-school/find-school.scss
@@ -69,6 +69,15 @@
         margin: 0.5em 0 0.5em 0;
         color: v.$text-primary;
         font-size: 0.95rem;
+
+        .school-name-link {
+          color: inherit;
+          text-decoration: none;
+
+          &:hover {
+            text-decoration: underline;
+          }
+        }
       }
 
       .school-id-chip {

--- a/src/app/grading-progress/grading-progress.spec.ts
+++ b/src/app/grading-progress/grading-progress.spec.ts
@@ -13,6 +13,7 @@ import { DataManagerService } from '../data-manager.service';
 import { FirebaseStateService, createFirebaseStateServiceMock } from '../firebase-state.service';
 import { RoutingService } from '../routing.service';
 import { initGrading, GradingStatus, initMember } from '../../../functions/src/data-model';
+import { SearchableSet } from '../searchable-set';
 
 @Component({ selector: 'app-grading-event-input', standalone: true, template: '' })
 class MockGradingEventInputComponent {
@@ -33,8 +34,8 @@ describe('GradingProgressComponent', () => {
 
   beforeEach(async () => {
     mockDataService = {
-      members: { entries: () => [], get: () => undefined } as never,
-      instructors: { entries: () => [], get: () => undefined } as never,
+      members: new SearchableSet(['memberId'], 'memberId', []) as never,
+      instructors: new SearchableSet(['instructorId'], 'instructorId', []) as never,
       getMemberByDocId: () => undefined,
       getMemberByMemberId: () => undefined,
       memberDisplayName: (docId: string, memberId: string) => memberId || docId || '',

--- a/src/app/instructor-view/instructor-view.html
+++ b/src/app/instructor-view/instructor-view.html
@@ -119,6 +119,9 @@
       } @else {
         <p class="note">No upcoming events listed.</p>
       }
+      <a class="show-more-link" [href]="allEventsHref()">
+        See all events <app-icon name="arrow_forward" width="16px" height="16px" />
+      </a>
     </section>
   }
 </div>

--- a/src/app/instructor-view/instructor-view.scss
+++ b/src/app/instructor-view/instructor-view.scss
@@ -206,6 +206,19 @@
   font-style: italic;
 }
 
+.show-more-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3em;
+  margin-top: 0.8em;
+  color: $text-secondary;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
 @media (max-width: 600px) {
   .header-body {
     flex-direction: column;

--- a/src/app/instructor-view/instructor-view.ts
+++ b/src/app/instructor-view/instructor-view.ts
@@ -168,6 +168,6 @@ export class InstructorViewComponent implements OnInit {
   }
 
   schoolHref(school: School): string {
-    return `#/find-school?schoolId=${encodeURIComponent(school.schoolId)}`;
+    return this.routingService.hrefForView(Views.SchoolView, { schoolId: school.schoolId });
   }
 }

--- a/src/app/instructor-view/instructor-view.ts
+++ b/src/app/instructor-view/instructor-view.ts
@@ -67,6 +67,13 @@ export class InstructorViewComponent implements OnInit {
 
   backHref = computed(() => this.routingService.hrefForView(Views.FindAnInstructor, {}));
 
+  // Link to the events search page, pre-filtered to this instructor.
+  allEventsHref = computed(() => {
+    const i = this.instructor();
+    if (!i) return '';
+    return `#/events?instructorId=${encodeURIComponent(i.instructorId)}`;
+  });
+
   // A short location summary line (region/city, county/state, country).
   locationLine = computed(() => {
     const i = this.instructor();

--- a/src/app/organise-events/organise-event/organise-event.spec.ts
+++ b/src/app/organise-events/organise-event/organise-event.spec.ts
@@ -4,6 +4,7 @@ import { FirebaseStateService, createFirebaseStateServiceMock } from '../../fire
 import { RoutingService } from '../../routing.service';
 import { DataManagerService } from '../../data-manager.service';
 import { FIREBASE_APP } from '../../app.config';
+import { SearchableSet } from '../../searchable-set';
 
 describe('ProposeEventComponent', () => {
   let component: ProposeEventComponent;
@@ -16,14 +17,11 @@ describe('ProposeEventComponent', () => {
         { provide: FirebaseStateService, useValue: createFirebaseStateServiceMock() },
         { provide: RoutingService, useValue: { navigateToParts: () => {} } },
         { provide: FIREBASE_APP, useValue: {} },
-        { 
-          provide: DataManagerService, 
-          useValue: { 
-            instructors: { 
-              get: () => null,
-              entries: () => []
-            } 
-          } 
+        {
+          provide: DataManagerService,
+          useValue: {
+            instructors: new SearchableSet(['instructorId'], 'instructorId', []),
+          }
         }
       ]
     })

--- a/src/app/school-edit/school-edit.html
+++ b/src/app/school-edit/school-edit.html
@@ -265,6 +265,94 @@
         </div>
       </div>
 
+      @if (userIsAdmin() || userIsSchoolManager()) {
+        <div class="form-section">
+          <h3>School Profile Page</h3>
+          <p class="note">
+            A logo, cover image, and description shown on the school's dedicated
+            public profile page, reachable by clicking the school's name in the
+            "Find a School" listing.
+          </p>
+
+          <label>Logo</label>
+          <div class="rhs">
+            @if (s.publicProfileImageUrl && !isEditingProfileCrop()) {
+              <div class="image-preview">
+                <img [src]="s.publicProfileImageUrl" alt="School logo" class="profile-image-preview" />
+                <div class="image-actions">
+                  <button type="button" class="subtle-button" (click)="editProfileCrop()">
+                    <app-icon name="edit" /> Edit Crop
+                  </button>
+                  <button type="button" class="subtle-button" (click)="removeProfileImage()">
+                    <app-icon name="close" /> Remove
+                  </button>
+                </div>
+              </div>
+            }
+            @if (!s.publicProfileImageUrl || isEditingProfileCrop()) {
+              <app-image-upload-preview
+                [aspectRatio]="1"
+                [largeDimensions]="profileLargeDimensions"
+                [thumbDimensions]="profileThumbDimensions"
+                uploadPromptText="select a square (400x400 or larger) image"
+                [initialImageUrl]="s.publicProfileImageUrl"
+                (imageCropped)="onProfileImageCropped($event)"
+                (cancel)="cancelProfileCrop()"
+              />
+            }
+            @if (isUploadingProfileImage()) {
+              <app-spinner>Uploading...</app-spinner>
+            }
+            @if (profileImageError(); as err) {
+              <div class="error-message">{{ err }}</div>
+            }
+          </div>
+
+          <label>Cover Image</label>
+          <div class="rhs">
+            @if (s.publicCoverImageUrl && !isEditingCoverCrop()) {
+              <div class="image-preview">
+                <img [src]="s.publicCoverImageUrl" alt="Cover image" class="cover-image-preview" />
+                <div class="image-actions">
+                  <button type="button" class="subtle-button" (click)="editCoverCrop()">
+                    <app-icon name="edit" /> Edit Crop
+                  </button>
+                  <button type="button" class="subtle-button" (click)="removeCoverImage()">
+                    <app-icon name="close" /> Remove
+                  </button>
+                </div>
+              </div>
+            }
+            @if (!s.publicCoverImageUrl || isEditingCoverCrop()) {
+              <app-image-upload-preview
+                [aspectRatio]="800 / 600"
+                [largeDimensions]="coverLargeDimensions"
+                [thumbDimensions]="coverThumbDimensions"
+                uploadPromptText="select an 800x600 or larger image"
+                [initialImageUrl]="s.publicCoverImageUrl"
+                (imageCropped)="onCoverImageCropped($event)"
+                (cancel)="cancelCoverCrop()"
+              />
+            }
+            @if (isUploadingCoverImage()) {
+              <app-spinner>Uploading...</app-spinner>
+            }
+            @if (coverImageError(); as err) {
+              <div class="error-message">{{ err }}</div>
+            }
+          </div>
+
+          <label class="align-top">About</label>
+          <div class="rhs">
+            <p class="note">A description of the school, shown on its public profile page.</p>
+            <app-markdown-editor
+              [initialValue]="s.publicBioMarkdown"
+              (changed)="onBioChanged($event)"
+            ></app-markdown-editor>
+          </div>
+        </div>
+      }
+
       @if (errorMessage().length > 0) {
         <div class="error-container">
           <div class="error-message">

--- a/src/app/school-edit/school-edit.scss
+++ b/src/app/school-edit/school-edit.scss
@@ -74,6 +74,36 @@
   align-items: center;
 }
 
+.image-preview {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 10px;
+  margin-bottom: 10px;
+
+  .profile-image-preview {
+    width: 120px;
+    height: 120px;
+    object-fit: cover;
+    border-radius: 50%;
+    border: 1px solid v.$border-color-light;
+  }
+
+  .cover-image-preview {
+    width: 100%;
+    max-width: 400px;
+    aspect-ratio: 800 / 600;
+    object-fit: cover;
+    border-radius: 8px;
+    border: 1px solid v.$border-color-light;
+  }
+
+  .image-actions {
+    display: flex;
+    gap: 10px;
+  }
+}
+
 .deleting-status {
   display: flex;
   align-items: center;

--- a/src/app/school-edit/school-edit.spec.ts
+++ b/src/app/school-edit/school-edit.spec.ts
@@ -15,7 +15,7 @@ import {
 import { provideZonelessChangeDetection, signal } from '@angular/core';
 import { initSchool, School, initMember, Member } from '../../../functions/src/data-model';
 import { SearchableSet } from '../searchable-set';
-import { ROUTING_CONFIG, initPathPatterns } from '../app.config';
+import { ROUTING_CONFIG, initPathPatterns, FIREBASE_APP } from '../app.config';
 import { User } from 'firebase/auth';
 import { CountryCode } from '../country-codes';
 
@@ -70,6 +70,7 @@ describe('SchoolEditComponent', () => {
         provideZonelessChangeDetection(),
         { provide: DataManagerService, useValue: dataManagerServiceMock },
         { provide: FirebaseStateService, useValue: firebaseStateServiceMock },
+        { provide: FIREBASE_APP, useValue: {} },
         {
           provide: ROUTING_CONFIG,
           useValue: {

--- a/src/app/school-edit/school-edit.ts
+++ b/src/app/school-edit/school-edit.ts
@@ -35,7 +35,10 @@ import { IconComponent } from '../icons/icon.component';
 import { DataManagerService } from '../data-manager.service';
 import { SpinnerComponent } from '../spinner/spinner.component';
 import { RoutingService } from '../routing.service';
-import { AppPathPatterns, Views } from '../app.config';
+import { AppPathPatterns, Views, FIREBASE_APP } from '../app.config';
+import { getStorage, ref, uploadBytes, getDownloadURL } from 'firebase/storage';
+import { ImageUploadPreviewComponent } from '../image-upload-preview/image-upload-preview';
+import { MarkdownEditor } from '../markdown-editor/markdown-editor';
 import { deepObjEq } from '../utils';
 import { AutocompleteComponent } from '../autocomplete/autocomplete';
 import {
@@ -54,6 +57,8 @@ import { FirebaseStateService } from '../firebase-state.service';
     SpinnerComponent,
     AutocompleteComponent,
     IdAssignmentComponent,
+    ImageUploadPreviewComponent,
+    MarkdownEditor,
   ],
   templateUrl: './school-edit.html',
   styleUrl: './school-edit.scss',
@@ -62,6 +67,7 @@ import { FirebaseStateService } from '../firebase-state.service';
 export class SchoolEditComponent {
   membersService = inject(DataManagerService);
   stateService = inject(FirebaseStateService);
+  private firebaseApp = inject(FIREBASE_APP);
   private routingService: RoutingService<AppPathPatterns> =
     inject(RoutingService);
 
@@ -285,6 +291,107 @@ export class SchoolEditComponent {
     toChipId: (i: InstructorPublicData) => i.instructorId,
     toName: (i: InstructorPublicData) => i.instructorId ? `${i.name} [${i.instructorId}]` : i.name,
   };
+
+  // --- Public profile page: images and description ---
+  readonly profileLargeDimensions = { width: 400, height: 400 };
+  readonly profileThumbDimensions = { width: 96, height: 96 };
+  readonly coverLargeDimensions = { width: 800, height: 600 };
+  readonly coverThumbDimensions = { width: 400, height: 300 };
+
+  isEditingProfileCrop = signal(false);
+  isEditingCoverCrop = signal(false);
+  isUploadingProfileImage = signal(false);
+  isUploadingCoverImage = signal(false);
+  profileImageError = signal<string | null>(null);
+  coverImageError = signal<string | null>(null);
+
+  editProfileCrop() {
+    this.isEditingProfileCrop.set(true);
+  }
+  cancelProfileCrop() {
+    this.isEditingProfileCrop.set(false);
+  }
+  editCoverCrop() {
+    this.isEditingCoverCrop.set(true);
+  }
+  cancelCoverCrop() {
+    this.isEditingCoverCrop.set(false);
+  }
+
+  async onProfileImageCropped(event: { thumbBlob: Blob; largeBlob: Blob }) {
+    const docId = this.editableSchool().docId;
+    if (!docId) {
+      this.profileImageError.set('Please save the school before uploading images.');
+      return;
+    }
+    this.isUploadingProfileImage.set(true);
+    this.profileImageError.set(null);
+    try {
+      const storage = getStorage(this.firebaseApp);
+      const largeRef = ref(storage, `schools/${docId}/images/profile_large`);
+      await uploadBytes(largeRef, event.largeBlob, { contentType: 'image/jpeg' });
+      const largeUrl = await getDownloadURL(largeRef);
+
+      const thumbRef = ref(storage, `schools/${docId}/images/profile_thumb`);
+      await uploadBytes(thumbRef, event.thumbBlob, { contentType: 'image/jpeg' });
+      const thumbUrl = await getDownloadURL(thumbRef);
+
+      this.form.publicProfileImageUrl().value.set(largeUrl);
+      this.form.publicProfileImageUrl().markAsDirty();
+      this.form.publicProfileImageThumbUrl().value.set(thumbUrl);
+      this.form.publicProfileImageThumbUrl().markAsDirty();
+      this.isEditingProfileCrop.set(false);
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : 'Unknown error';
+      console.error('Error uploading school profile image:', e);
+      this.profileImageError.set('Failed to upload image: ' + message);
+    } finally {
+      this.isUploadingProfileImage.set(false);
+    }
+  }
+
+  async onCoverImageCropped(event: { largeBlob: Blob }) {
+    const docId = this.editableSchool().docId;
+    if (!docId) {
+      this.coverImageError.set('Please save the school before uploading images.');
+      return;
+    }
+    this.isUploadingCoverImage.set(true);
+    this.coverImageError.set(null);
+    try {
+      const storage = getStorage(this.firebaseApp);
+      const coverRef = ref(storage, `schools/${docId}/images/cover_large`);
+      await uploadBytes(coverRef, event.largeBlob, { contentType: 'image/jpeg' });
+      const coverUrl = await getDownloadURL(coverRef);
+
+      this.form.publicCoverImageUrl().value.set(coverUrl);
+      this.form.publicCoverImageUrl().markAsDirty();
+      this.isEditingCoverCrop.set(false);
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : 'Unknown error';
+      console.error('Error uploading school cover image:', e);
+      this.coverImageError.set('Failed to upload image: ' + message);
+    } finally {
+      this.isUploadingCoverImage.set(false);
+    }
+  }
+
+  removeProfileImage() {
+    this.form.publicProfileImageUrl().value.set('');
+    this.form.publicProfileImageUrl().markAsDirty();
+    this.form.publicProfileImageThumbUrl().value.set('');
+    this.form.publicProfileImageThumbUrl().markAsDirty();
+  }
+
+  removeCoverImage() {
+    this.form.publicCoverImageUrl().value.set('');
+    this.form.publicCoverImageUrl().markAsDirty();
+  }
+
+  onBioChanged(markdown: string) {
+    this.form.publicBioMarkdown().value.set(markdown);
+    this.form.publicBioMarkdown().markAsDirty();
+  }
 
   // Build the back navigation URL based on context.
   backUrl = computed(() => {

--- a/src/app/school-view/school-view.html
+++ b/src/app/school-view/school-view.html
@@ -1,0 +1,109 @@
+<div class="school-view">
+  <a class="back-link" [href]="backHref()">
+    <app-icon name="arrow_back" /> Find a School
+  </a>
+
+  @if (isLoading()) {
+    <div class="center">
+      <app-spinner>Loading profile...</app-spinner>
+    </div>
+  } @else if (errorMessage(); as err) {
+    <div class="error-message">{{ err }}</div>
+  } @else if (school(); as s) {
+    <div class="profile-header">
+      <div class="cover" [class.no-cover]="!s.publicCoverImageUrl">
+        @if (s.publicCoverImageUrl) {
+          <img [src]="s.publicCoverImageUrl" alt="Cover image" class="cover-image" />
+        }
+      </div>
+      <div class="header-body">
+        @if (s.publicProfileImageUrl) {
+          <img [src]="s.publicProfileImageUrl" alt="School logo" class="profile-image" />
+        } @else {
+          <div class="profile-image placeholder">
+            <app-icon name="mountain" />
+          </div>
+        }
+        <div class="header-text">
+          <div class="name-row">
+            <h2>{{ s.schoolName }}</h2>
+            @if (s.schoolId) {
+              <span class="identifier-chip school-id">{{ s.schoolId }}</span>
+            }
+          </div>
+
+          @if (locationLine(); as location) {
+            <div class="location">
+              <app-icon name="location_on" width="16px" height="16px" />
+              <span>{{ location }}</span>
+              <a [href]="mapsUrl()" target="_blank" rel="noopener noreferrer" class="icon-link">
+                <app-icon name="map" width="16px" height="16px" />
+              </a>
+            </div>
+          }
+        </div>
+      </div>
+    </div>
+
+    <div class="contact-row">
+      @if (s.schoolWebsite) {
+        <a class="contact-link" [href]="ensureUrl(s.schoolWebsite)" target="_blank" rel="noopener noreferrer">
+          <app-icon name="link" width="16px" height="16px" /> {{ stripUrlPrefix(s.schoolWebsite) }}
+        </a>
+      }
+      @if (s.schoolClassGoogleCalendarId) {
+        <a class="contact-link" [href]="'#/calendar/school/' + s.schoolId">
+          <app-icon name="calendar_today" width="16px" height="16px" /> Class Calendar
+        </a>
+      }
+    </div>
+
+    @if (s.publicBioMarkdown) {
+      <section class="bio-section">
+        <h3>About</h3>
+        <app-markdown-viewer [markdown]="s.publicBioMarkdown" />
+      </section>
+    }
+
+    <section class="people-section">
+      <h3>Owner &amp; Managers</h3>
+      <div class="people-list">
+        @if (owner(); as o) {
+          <a class="person-card-link" [href]="instructorHref(o.instructorId)">
+            @if (o.publicProfileImageThumbUrl || o.publicProfileImageUrl) {
+              <img class="person-image" [src]="o.publicProfileImageThumbUrl || o.publicProfileImageUrl" alt="" />
+            } @else {
+              <div class="person-image placeholder"><app-icon name="salut" /></div>
+            }
+            <span class="person-text">
+              <span class="person-name">{{ o.name }}</span>
+              <span class="person-role">Owner</span>
+            </span>
+          </a>
+        } @else if (school()?.ownerInstructorId; as ownerId) {
+          <a class="person-card-link" [href]="instructorHref(ownerId)">
+            <div class="person-image placeholder"><app-icon name="salut" /></div>
+            <span class="person-text">
+              <span class="person-name">{{ ownerId }}</span>
+              <span class="person-role">Owner</span>
+            </span>
+          </a>
+        }
+
+        @for (m of managers(); track m.instructorId) {
+          <a class="person-card-link" [href]="instructorHref(m.instructorId)">
+            @if (m.instructor?.publicProfileImageThumbUrl || m.instructor?.publicProfileImageUrl) {
+              <img class="person-image" [src]="m.instructor!.publicProfileImageThumbUrl || m.instructor!.publicProfileImageUrl" alt="" />
+            } @else {
+              <div class="person-image placeholder"><app-icon name="salut" /></div>
+            }
+            <span class="person-text">
+              <span class="person-name">{{ m.instructor?.name || m.instructorId }}</span>
+              <span class="person-role">Manager</span>
+            </span>
+          </a>
+        }
+      </div>
+    </section>
+  }
+</div>

--- a/src/app/school-view/school-view.html
+++ b/src/app/school-view/school-view.html
@@ -105,5 +105,40 @@
         }
       </div>
     </section>
+
+    <section class="events-section">
+      <h3>Upcoming Events</h3>
+      @if (eventsLoading()) {
+        <app-spinner>Loading events...</app-spinner>
+      } @else if (upcomingEvents().length > 0) {
+        <div class="events-list">
+          @for (ev of upcomingEvents(); track ev.docId) {
+            <a class="event-card-link" [href]="eventHref(ev)">
+              <app-event-item [event]="ev" />
+            </a>
+          }
+        </div>
+      } @else {
+        <p class="note">No upcoming events listed.</p>
+      }
+    </section>
+
+    @if (!eventsLoading() && pastEvents().length > 0) {
+      <section class="events-section">
+        <h3>Past Events</h3>
+        <div class="events-list">
+          @for (ev of pastEvents(); track ev.docId) {
+            <a class="event-card-link" [href]="eventHref(ev)">
+              <app-event-item [event]="ev" />
+            </a>
+          }
+        </div>
+        @if (pastEventsTotal() > pastEvents().length) {
+          <a class="show-more-link" [href]="allEventsHref()">
+            Show all {{ pastEventsTotal() }} past events <app-icon name="arrow_forward" width="16px" height="16px" />
+          </a>
+        }
+      </section>
+    }
   }
 </div>

--- a/src/app/school-view/school-view.scss
+++ b/src/app/school-view/school-view.scss
@@ -1,0 +1,212 @@
+@use "../../scss_variables" as *;
+@use "../../styles.scss" as *;
+
+.school-view {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 1em;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5em;
+}
+
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3em;
+  color: $text-secondary;
+  text-decoration: none;
+  width: fit-content;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.center {
+  display: flex;
+  justify-content: center;
+  padding: 2em;
+}
+
+.profile-header {
+  border: 1px solid $border-color-light;
+  border-radius: 12px;
+  overflow: hidden;
+  background: white;
+}
+
+.cover {
+  aspect-ratio: 800 / 600;
+  max-height: 280px;
+  background: $theme-bg-color;
+  overflow: hidden;
+
+  &.no-cover {
+    aspect-ratio: auto;
+    height: 96px;
+  }
+
+  .cover-image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+}
+
+.header-body {
+  display: flex;
+  gap: 1em;
+  padding: 0 1.2em 1.2em;
+  align-items: flex-end;
+}
+
+.profile-image {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 4px solid white;
+  background: $theme-bg-color;
+  margin-top: -60px;
+  flex-shrink: 0;
+
+  &.placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: $text-muted;
+  }
+}
+
+.header-text {
+  flex: 1;
+  padding-bottom: 0.2em;
+}
+
+.name-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6em;
+  flex-wrap: wrap;
+
+  h2 {
+    margin: 0;
+  }
+}
+
+.location {
+  display: flex;
+  align-items: center;
+  gap: 0.3em;
+  margin-top: 0.6em;
+  color: $text-secondary;
+  font-size: 0.9rem;
+}
+
+.icon-link {
+  display: inline-flex;
+  color: inherit;
+  opacity: 0.7;
+
+  &:hover {
+    opacity: 1;
+  }
+}
+
+.contact-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6em 1.2em;
+  align-items: center;
+}
+
+.contact-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3em;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.bio-section,
+.people-section {
+  h3 {
+    margin-bottom: 0.6em;
+    border-bottom: 1px solid $border-color-light;
+    padding-bottom: 0.3em;
+  }
+}
+
+.people-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8em;
+}
+
+.person-card-link {
+  display: flex;
+  align-items: center;
+  gap: 0.6em;
+  text-decoration: none;
+  color: inherit;
+  border: 1px solid $border-color-light;
+  border-radius: 8px;
+  padding: 0.5em 0.8em;
+  background: white;
+
+  &:hover {
+    background: $theme-bg-color;
+  }
+
+  .person-image {
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    object-fit: cover;
+    background: $theme-bg-color;
+    flex-shrink: 0;
+
+    &.placeholder {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: $text-muted;
+    }
+  }
+
+  .person-text {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .person-name {
+    font-weight: bold;
+  }
+
+  .person-role {
+    font-size: 0.85rem;
+    color: $text-secondary;
+  }
+}
+
+.note {
+  color: $text-secondary;
+  font-style: italic;
+}
+
+@media (max-width: 600px) {
+  .header-body {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
+
+  .name-row {
+    justify-content: center;
+  }
+}

--- a/src/app/school-view/school-view.scss
+++ b/src/app/school-view/school-view.scss
@@ -134,11 +134,45 @@
 }
 
 .bio-section,
-.people-section {
+.people-section,
+.events-section {
   h3 {
     margin-bottom: 0.6em;
     border-bottom: 1px solid $border-color-light;
     padding-bottom: 0.3em;
+  }
+}
+
+.events-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8em;
+}
+
+.event-card-link {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+  border: 1px solid $border-color-light;
+  border-radius: 8px;
+  padding: 0.5em 0.8em;
+  background: white;
+
+  &:hover {
+    background: $theme-bg-color;
+  }
+}
+
+.show-more-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3em;
+  margin-top: 0.8em;
+  color: $text-secondary;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
   }
 }
 

--- a/src/app/school-view/school-view.spec.ts
+++ b/src/app/school-view/school-view.spec.ts
@@ -1,0 +1,108 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { vi } from 'vitest';
+import { SchoolViewComponent } from './school-view';
+import { DataManagerService } from '../data-manager.service';
+import { RoutingService } from '../routing.service';
+import { FIREBASE_APP, AppPathPatterns } from '../app.config';
+import { SearchableSet } from '../searchable-set';
+import {
+  School,
+  initSchool,
+  InstructorPublicData,
+  initInstructor,
+} from '../../../functions/src/data-model';
+
+// Mock firebase/firestore so the direct-fetch fallback and getFirestore are inert.
+vi.mock('firebase/firestore', () => ({
+  getFirestore: vi.fn(),
+  collection: vi.fn(),
+  query: vi.fn(),
+  where: vi.fn(),
+  limit: vi.fn(),
+  getDocs: vi.fn().mockResolvedValue({ empty: true }),
+}));
+
+describe('SchoolViewComponent', () => {
+  let component: SchoolViewComponent;
+  let fixture: ComponentFixture<SchoolViewComponent>;
+
+  const owner: InstructorPublicData = {
+    ...initInstructor(),
+    docId: 'member-doc-1',
+    instructorId: 'I-101',
+    name: 'Owner Person',
+  };
+  const manager: InstructorPublicData = {
+    ...initInstructor(),
+    docId: 'member-doc-2',
+    instructorId: 'I-202',
+    name: 'Manager Person',
+  };
+  const school: School = {
+    ...initSchool(),
+    docId: 's-1',
+    schoolId: 'SCH-1',
+    schoolName: 'Test School',
+    schoolCity: 'Kuala Lumpur',
+    schoolCountry: 'Malaysia',
+    ownerInstructorId: 'I-101',
+    managerInstructorIds: ['I-202'],
+    publicBioMarkdown: 'A great school.',
+  };
+
+  beforeEach(async () => {
+    const mockDataManagerService: Partial<DataManagerService> = {
+      schools: new SearchableSet(['schoolId'], 'schoolId', [school]),
+      instructors: new SearchableSet(['instructorId'], 'instructorId', [owner, manager]),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [SchoolViewComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        { provide: DataManagerService, useValue: mockDataManagerService },
+        { provide: FIREBASE_APP, useValue: {} },
+        {
+          provide: RoutingService,
+          useValue: {
+            hrefForView: vi.fn().mockReturnValue('#'),
+          } as unknown as RoutingService<AppPathPatterns>,
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SchoolViewComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('schoolId', 'SCH-1');
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should load the school and emit the title', async () => {
+    const titleSpy = vi.spyOn(component.titleLoaded, 'emit');
+    await (component as unknown as { loadSchool: () => Promise<void> }).loadSchool();
+    expect(component.school()?.schoolName).toBe('Test School');
+    expect(titleSpy).toHaveBeenCalledWith('Test School');
+  });
+
+  it('should build a location line from the school location fields', async () => {
+    await (component as unknown as { loadSchool: () => Promise<void> }).loadSchool();
+    expect(component.locationLine()).toBe('Kuala Lumpur, Malaysia');
+  });
+
+  it('should resolve the owner to their public instructor data', async () => {
+    await (component as unknown as { loadSchool: () => Promise<void> }).loadSchool();
+    expect(component.owner()?.name).toBe('Owner Person');
+  });
+
+  it('should resolve managers, excluding the owner', async () => {
+    await (component as unknown as { loadSchool: () => Promise<void> }).loadSchool();
+    const managers = component.managers();
+    expect(managers.length).toBe(1);
+    expect(managers[0].instructor?.name).toBe('Manager Person');
+  });
+});

--- a/src/app/school-view/school-view.spec.ts
+++ b/src/app/school-view/school-view.spec.ts
@@ -11,6 +11,9 @@ import {
   initSchool,
   InstructorPublicData,
   initInstructor,
+  IlcEvent,
+  initEvent,
+  EventStatus,
 } from '../../../functions/src/data-model';
 
 // Mock firebase/firestore so the direct-fetch fallback and getFirestore are inert.
@@ -26,6 +29,7 @@ vi.mock('firebase/firestore', () => ({
 describe('SchoolViewComponent', () => {
   let component: SchoolViewComponent;
   let fixture: ComponentFixture<SchoolViewComponent>;
+  let mockGetEventsForSchool: ReturnType<typeof vi.fn>;
 
   const owner: InstructorPublicData = {
     ...initInstructor(),
@@ -52,9 +56,11 @@ describe('SchoolViewComponent', () => {
   };
 
   beforeEach(async () => {
+    mockGetEventsForSchool = vi.fn().mockResolvedValue({ upcoming: [], past: [], pastTotal: 0 });
     const mockDataManagerService: Partial<DataManagerService> = {
       schools: new SearchableSet(['schoolId'], 'schoolId', [school]),
       instructors: new SearchableSet(['instructorId'], 'instructorId', [owner, manager]),
+      getEventsForSchool: mockGetEventsForSchool as never,
     };
 
     await TestBed.configureTestingModule({
@@ -104,5 +110,17 @@ describe('SchoolViewComponent', () => {
     const managers = component.managers();
     expect(managers.length).toBe(1);
     expect(managers[0].instructor?.name).toBe('Manager Person');
+  });
+
+  it('should surface upcoming and past events for the school', async () => {
+    const upcoming: IlcEvent = { ...initEvent(), docId: 'ev-up', title: 'Future Workshop', status: EventStatus.Listed };
+    const past: IlcEvent = { ...initEvent(), docId: 'ev-past', title: 'Old Workshop', status: EventStatus.Listed };
+    (mockGetEventsForSchool).mockResolvedValue({ upcoming: [upcoming], past: [past], pastTotal: 7 });
+    await (component as unknown as { loadSchool: () => Promise<void> }).loadSchool();
+    expect(mockGetEventsForSchool).toHaveBeenCalledWith('SCH-1');
+    expect(component.upcomingEvents().length).toBe(1);
+    expect(component.pastEvents().length).toBe(1);
+    expect(component.pastEventsTotal()).toBe(7);
+    expect(component.allEventsHref()).toBe('#/events?schoolId=SCH-1');
   });
 });

--- a/src/app/school-view/school-view.ts
+++ b/src/app/school-view/school-view.ts
@@ -20,6 +20,7 @@ import {
   signal,
 } from '@angular/core';
 import {
+  IlcEvent,
   InstructorPublicData,
   School,
   firestoreDocToSchool,
@@ -31,11 +32,12 @@ import { RoutingService } from '../routing.service';
 import { IconComponent } from '../icons/icon.component';
 import { SpinnerComponent } from '../spinner/spinner.component';
 import { MarkdownViewer } from '../markdown-editor/markdown-viewer';
+import { EventItemComponent } from '../events-calendar/event-item/event-item';
 
 @Component({
   selector: 'app-school-view',
   standalone: true,
-  imports: [IconComponent, SpinnerComponent, MarkdownViewer],
+  imports: [IconComponent, SpinnerComponent, MarkdownViewer, EventItemComponent],
   templateUrl: './school-view.html',
   styleUrl: './school-view.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -54,7 +56,23 @@ export class SchoolViewComponent implements OnInit {
   isLoading = signal(true);
   errorMessage = signal<string | null>(null);
 
+  upcomingEvents = signal<IlcEvent[]>([]);
+  pastEvents = signal<IlcEvent[]>([]);
+  pastEventsTotal = signal(0);
+  eventsLoading = signal(false);
+
   backHref = computed(() => this.routingService.hrefForView(Views.FindSchool, {}));
+
+  // Link to the events search page, pre-filtered to this school.
+  allEventsHref = computed(() => {
+    const s = this.school();
+    if (!s) return '';
+    return `#/events?schoolId=${encodeURIComponent(s.schoolId)}`;
+  });
+
+  eventHref(ev: IlcEvent): string {
+    return this.routingService.hrefForView(Views.EventView, { eventId: ev.docId });
+  }
 
   // The school's owner, resolved to their public instructor data (if available).
   owner = computed<InstructorPublicData | null>(() => {
@@ -131,6 +149,7 @@ export class SchoolViewComponent implements OnInit {
       if (school) {
         this.school.set(school);
         this.titleLoaded.emit(school.schoolName || school.schoolId || 'School');
+        this.loadEvents(school);
       } else {
         this.errorMessage.set('School not found.');
         this.titleLoaded.emit('School Not Found');
@@ -140,6 +159,21 @@ export class SchoolViewComponent implements OnInit {
       this.errorMessage.set('Failed to load school profile.');
     } finally {
       this.isLoading.set(false);
+    }
+  }
+
+  private async loadEvents(school: School) {
+    if (!school.schoolId) return;
+    this.eventsLoading.set(true);
+    try {
+      const { upcoming, past, pastTotal } = await this.dataService.getEventsForSchool(
+        school.schoolId,
+      );
+      this.upcomingEvents.set(upcoming);
+      this.pastEvents.set(past);
+      this.pastEventsTotal.set(pastTotal);
+    } finally {
+      this.eventsLoading.set(false);
     }
   }
 }

--- a/src/app/school-view/school-view.ts
+++ b/src/app/school-view/school-view.ts
@@ -1,0 +1,145 @@
+/* school-view.ts
+ *
+ * Public page showing a single school's profile: cover image, profile picture /
+ * logo, name, location, contact details, a markdown description, and the
+ * school's owner and managers (linking to their instructor profile pages).
+ *
+ * The school is identified by the human-readable `schoolId` from the route.
+ * Profile data comes from the public /schools collection (loaded by
+ * DataManagerService, with a direct Firestore fallback for deep links).
+ */
+
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+  OnInit,
+  output,
+  signal,
+} from '@angular/core';
+import {
+  InstructorPublicData,
+  School,
+  firestoreDocToSchool,
+} from '../../../functions/src/data-model';
+import { collection, getDocs, getFirestore, query, where, limit } from 'firebase/firestore';
+import { FIREBASE_APP, AppPathPatterns, Views } from '../app.config';
+import { DataManagerService } from '../data-manager.service';
+import { RoutingService } from '../routing.service';
+import { IconComponent } from '../icons/icon.component';
+import { SpinnerComponent } from '../spinner/spinner.component';
+import { MarkdownViewer } from '../markdown-editor/markdown-viewer';
+
+@Component({
+  selector: 'app-school-view',
+  standalone: true,
+  imports: [IconComponent, SpinnerComponent, MarkdownViewer],
+  templateUrl: './school-view.html',
+  styleUrl: './school-view.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SchoolViewComponent implements OnInit {
+  private dataService = inject(DataManagerService);
+  private firebaseApp = inject(FIREBASE_APP);
+  private db = getFirestore(this.firebaseApp);
+  routingService = inject(RoutingService<AppPathPatterns>);
+
+  // Human-readable school ID from the route.
+  schoolId = input.required<string>();
+  titleLoaded = output<string>();
+
+  school = signal<School | null>(null);
+  isLoading = signal(true);
+  errorMessage = signal<string | null>(null);
+
+  backHref = computed(() => this.routingService.hrefForView(Views.FindSchool, {}));
+
+  // The school's owner, resolved to their public instructor data (if available).
+  owner = computed<InstructorPublicData | null>(() => {
+    const s = this.school();
+    if (!s || !s.ownerInstructorId) return null;
+    return this.dataService.instructors.get(s.ownerInstructorId) ?? null;
+  });
+
+  // The school's managers, resolved to their public instructor data. Excludes
+  // the owner (who is implicitly also a manager).
+  managers = computed(() => {
+    const s = this.school();
+    if (!s) return [];
+    return s.managerInstructorIds
+      .filter((id) => id && id !== s.ownerInstructorId)
+      .map((id) => ({
+        instructorId: id,
+        instructor: this.dataService.instructors.get(id) ?? null,
+      }));
+  });
+
+  // A short location summary line (city, county/state, country).
+  locationLine = computed(() => {
+    const s = this.school();
+    if (!s) return '';
+    return [s.schoolCity, s.schoolCountyOrState, s.schoolCountry]
+      .filter((p) => !!p)
+      .join(', ');
+  });
+
+  mapsUrl = computed(() => {
+    const line = this.locationLine();
+    if (!line) return '';
+    return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(line)}`;
+  });
+
+  ensureUrl(url: string): string {
+    if (!url) return '';
+    return url.startsWith('http') ? url : 'https://' + url;
+  }
+
+  stripUrlPrefix(url: string): string {
+    return url.replace(/^https?:\/\//, '');
+  }
+
+  instructorHref(instructorId: string): string {
+    return this.routingService.hrefForView(Views.InstructorView, { instructorId });
+  }
+
+  ngOnInit() {
+    window.scrollTo(0, 0);
+    this.loadSchool();
+  }
+
+  private async loadSchool() {
+    this.isLoading.set(true);
+    this.errorMessage.set(null);
+    const id = this.schoolId();
+    try {
+      let school = this.dataService.schools.get(id) ?? null;
+      if (!school) {
+        // Fallback: direct query for deep links before the public set loads.
+        const q = query(
+          collection(this.db, 'schools'),
+          where('schoolId', '==', id),
+          limit(1),
+        );
+        const snap = await getDocs(q);
+        if (!snap.empty) {
+          school = firestoreDocToSchool(snap.docs[0]);
+        }
+      }
+
+      if (school) {
+        this.school.set(school);
+        this.titleLoaded.emit(school.schoolName || school.schoolId || 'School');
+      } else {
+        this.errorMessage.set('School not found.');
+        this.titleLoaded.emit('School Not Found');
+      }
+    } catch (error) {
+      console.error('Error loading school:', error);
+      this.errorMessage.set('Failed to load school profile.');
+    } finally {
+      this.isLoading.set(false);
+    }
+  }
+}

--- a/storage.rules
+++ b/storage.rules
@@ -15,6 +15,14 @@ service firebase.storage {
       return (email != null && firestore.exists(aclPath)) ? firestore.get(aclPath).data.memberDocIds : [];
     }
 
+    // Returns the list of school document IDs this user owns or manages,
+    // cached on the user's ACL document.
+    function getUserSchoolDocIds() {
+      let email = request.auth.token.email;
+      let aclPath = /databases/(default)/documents/acl/$(email);
+      return (email != null && firestore.exists(aclPath)) ? firestore.get(aclPath).data.schoolDocIds : [];
+    }
+
     match /backups/{backupFile} {
       // Only admins can read/write the backups
       allow read, write: if isAdmin();
@@ -75,6 +83,17 @@ service firebase.storage {
       allow read: if true;
       allow write: if isAdmin() || (
         request.auth != null && memberDocId in getUserMemberDocIds()
+      );
+    }
+
+    // School public profile images (logo/profile picture and cover image).
+    // Publicly readable. Writable by an admin or by an owner/manager of the
+    // school whose document matches {schoolDocId} (checked via the ACL's
+    // schoolDocIds). Stored at schools/{schoolDocId}/images/{fileId}.
+    match /schools/{schoolDocId}/images/{fileId} {
+      allow read: if true;
+      allow write: if isAdmin() || (
+        request.auth != null && schoolDocId in getUserSchoolDocIds()
       );
     }
 


### PR DESCRIPTION
## Summary

Adds a dedicated public **school profile page** (mirroring the instructor/member profiles), associates **events with schools**, surfaces a school's events on its profile, and makes the **events search page filterable on Firestore by school or instructor**.

## School profile page

- New component `src/app/school-view/` at route `school-profile/:schoolId`: cover image, logo, name + school-ID chip, location with maps link, website/calendar contact row, markdown description, and **Owner & Managers** cards linking to instructor profiles.
- **School editing** (`school-edit`): new "School Profile Page" section (admins & managers) — logo upload, cover upload, markdown description. Images stored at `schools/{docId}/images/...`.
- Data model: `publicProfileImageUrl`, `publicProfileImageThumbUrl`, `publicCoverImageUrl`, `publicBioMarkdown` on `School`.
- Links: instructor-profile school cards and the "Find a School" listing now link to the dedicated page.

## Events ↔ schools

- Data model: `schoolId` / `schoolDocId` on `IlcEvent`.
- Event editor: a **School** autocomplete selector that persists both fields.
- School profile shows **Upcoming Events** and **Past Events** (last 5, with a "show all" link to the filtered events page).
- `DataManagerService.getEventsForSchool(schoolId)` returns upcoming + last-N past.

## Events search page filtering

- `events` route gains `schoolId` & `instructorId` URL params.
- Filtered mode: single-field equality for `schoolId`; merged leading/owner/manager queries for `instructorId` (no composite index needed). Date floor dropped when filtered so past events show. Filter banner + clear link.
- Instructor profile gains a "See all events" link to the filtered page.

## Backfill

- `scripts/backfill-event-schools.ts` (`pnpm backfill:event-schools`): populates `schoolId`/`schoolDocId` on existing events from their leading instructor's primary school. Dry-run by default; `--commit` to apply; `--project=<id>` (defaults to `ilc-paris-class-tracker`).
- Verified dry-run against the default project: 76 events scanned, 2 would be updated.

## Security rules

- `firestore.rules`: school-manager update allowlist extended for the new public fields. (Events `create` stays admin-only; `update` by owner/manager already permits arbitrary field keys, so `schoolId` writes are allowed.)
- `storage.rules`: public-read / owner-manager-write rule for `schools/{schoolDocId}/images/{fileId}` (+ `getUserSchoolDocIds` helper).

## Tests / verification

- `pnpm build` ✅, functions build ✅, full suite **366 passing** (added school-view + school-events tests; updated event-edit/school-edit specs).
- Also fixed two pre-existing autocomplete-mock spec failures unrelated to this feature.
- Emulator-based `pnpm test:rules` not run — only the manager allowlist widened; worth running before deploying rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)