### PR TITLE
feat(markdown-editor): add clear-formatting button

### DIFF
--- a/src/app/markdown-editor/markdown-editor.html
+++ b/src/app/markdown-editor/markdown-editor.html
@@ -61,6 +61,10 @@
             <span class="menu-icon"><app-icon name="link" width="1.2em" height="1.2em"></app-icon></span>
             @if (showDescriptions()) { <span>Link</span> }
           </div>
+          <div class="menu-item" (click)="clearFormatting()">
+            <span class="menu-icon clear-format-icon">T&#x2715;</span>
+            @if (showDescriptions()) { <span>Clear Formatting</span> }
+          </div>
         </div>
       }
     </div>

--- a/src/app/markdown-editor/markdown-editor.scss
+++ b/src/app/markdown-editor/markdown-editor.scss
@@ -196,6 +196,11 @@
     &.redo-icon {
       transform: scaleX(-1);
     }
+
+    &.clear-format-icon {
+      font-size: 0.85em;
+      letter-spacing: 1px;
+    }
   }
 
   span {

--- a/src/app/markdown-editor/markdown-editor.ts
+++ b/src/app/markdown-editor/markdown-editor.ts
@@ -280,6 +280,46 @@ export class MarkdownEditor implements AfterViewInit, OnDestroy {
     });
   }
 
+  // Remove all inline marks (bold, italic, link, etc.) and reset block
+  // types to paragraph. Operates on the current selection, or on the
+  // whole block at the cursor when the selection is collapsed.
+  clearFormatting() {
+    this.editor?.action((ctx) => {
+      const view = ctx.get(editorViewCtx);
+      const { state } = view;
+      const { schema } = state;
+      const { paragraph } = schema.nodes;
+      const { $from, $to, empty } = state.selection;
+
+      // Determine the range to clear: the selection itself, or the
+      // entire block containing the cursor when nothing is selected.
+      let from: number;
+      let to: number;
+      if (empty) {
+        const depth = $from.depth;
+        if (depth === 0) return;
+        from = $from.before(depth);
+        to = $from.after(depth);
+      } else {
+        from = $from.pos;
+        to = $to.pos;
+      }
+
+      const tr = state.tr;
+
+      // Strip every mark type from the range.
+      for (const markType of Object.values(schema.marks)) {
+        tr.removeMark(from, to, markType);
+      }
+
+      // Reset any block (headings, etc.) within the range to paragraph.
+      tr.setBlockType(from, to, paragraph);
+
+      view.dispatch(tr);
+      view.focus();
+    });
+  }
+
   indent() {
     this.editor?.action((ctx) => {
       const view = ctx.get(editorViewCtx);


### PR DESCRIPTION
## Summary

Adds a **Clear Formatting** button to the WYSIWYG markdown editor toolbar.

- If there's a selection, clears formatting across that range.
- If the cursor is collapsed (no selection), clears the whole block at the cursor position.
- Strips every inline mark type (bold, italic, link, etc.) and resets block types (headings, etc.) back to paragraph in a single transaction, then restores editor focus.

## Changes
- `markdown-editor.ts` — new `clearFormatting()` method.
- `markdown-editor.html` — toolbar menu item with a `T✕` icon.
- `markdown-editor.scss` — sizing tweak for the icon glyph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)