### PR TITLE
fix(notifications): keep per-device push toggle in sync with real subscription

### DIFF
--- a/src/app/notification.service.ts
+++ b/src/app/notification.service.ts
@@ -169,6 +169,24 @@ export class NotificationService implements OnDestroy {
     return !!this.swPush?.isEnabled && !!environment.vapidPublicKey;
   }
 
+  // Re-reads the browser's live push subscription and updates pushDeviceEnabled
+  // to match. The constructor's swPush.subscription stream only emits once at
+  // startup, so the settings UI calls this when shown to make sure the per-device
+  // toggle reflects the actual on-device subscription state rather than a stale
+  // signal value.
+  public async refreshPushDeviceState(): Promise<void> {
+    if (!this.swPush?.isEnabled) {
+      this.pushDeviceEnabled.set(false);
+      return;
+    }
+    try {
+      const sub = await firstValueFrom(this.swPush.subscription);
+      this.pushDeviceEnabled.set(!!sub);
+    } catch (e) {
+      console.error('Failed to read push subscription state:', e);
+    }
+  }
+
   // Turns on push for THIS device: requests notification permission if needed,
   // then registers the subscription. Returns true if the device ends up enabled.
   public async enablePushOnThisDevice(): Promise<boolean> {
@@ -181,6 +199,9 @@ export class NotificationService implements OnDestroy {
     } else {
       await this.registerPushSubscription(memberDocId);
     }
+    // registerPushSubscription may short-circuit on its per-session guard without
+    // touching the signal, so reconcile against the real subscription here.
+    await this.refreshPushDeviceState();
     return permission === 'granted' && this.pushDeviceEnabled();
   }
 
@@ -197,6 +218,7 @@ export class NotificationService implements OnDestroy {
         await deleteDoc(doc(this.db, 'members', memberDocId, 'pushSubscriptions', subId));
       }
       await this.swPush.unsubscribe();
+      this.pushDeviceEnabled.set(false);
     } catch (e) {
       console.error('Failed to disable push on this device:', e);
     } finally {

--- a/src/app/settings/notification-settings/notification-settings.component.ts
+++ b/src/app/settings/notification-settings/notification-settings.component.ts
@@ -4,7 +4,14 @@
   It also exposes standard push permission prompts and triggers manual test alerts.
 */
 
-import { Component, ChangeDetectionStrategy, computed, inject, signal } from '@angular/core';
+import {
+  Component,
+  ChangeDetectionStrategy,
+  OnInit,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { getFirestore, collection, addDoc } from 'firebase/firestore';
 import { NotificationService } from '../../notification.service';
@@ -21,10 +28,17 @@ import { IconComponent } from '../../icons/icon.component';
   styleUrl: './notification-settings.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class NotificationSettingsComponent {
+export class NotificationSettingsComponent implements OnInit {
   protected notificationService = inject(NotificationService);
   private firebaseService = inject(FirebaseStateService);
   private dataManager = inject(DataManagerService);
+
+  ngOnInit() {
+    // The service's push subscription stream only emits once at app startup, so
+    // re-read the device's live subscription each time the panel is shown to keep
+    // the per-device toggle in sync (e.g. after navigating away and back).
+    this.notificationService.refreshPushDeviceState?.();
+  }
 
   protected localSettings = this.notificationService.localSettings;
   protected permissionStatus = this.notificationService.permissionStatus;


### PR DESCRIPTION
## Problem

In notification settings, clicking **"Enable push on this device"**, navigating away, and returning shows the toggle unchecked again.

## Root cause

The checkbox is bound to `pushDeviceEnabled()`, a signal in the singleton `NotificationService`. That signal was only seeded once at app startup from `SwPush.subscription` (which emits a single value — `null` when there's no subscription yet) and otherwise only flipped `true` by a manual `set(true)` inside `registerPushSubscription`. When enabling silently failed to set it (the per-session `pushSubscribedForMemberDocId` guard short-circuits, or a swallowed `requestSubscription` error), the signal stayed `false`.

The native checkbox *looked* checked because clicking toggles its own DOM state, but with zoneless/OnPush the `[checked]` binding wasn't re-evaluated — until navigating back triggered a fresh render that exposed the real `false` state.

## Fix

- Add `refreshPushDeviceState()` to read the browser's live push subscription and set `pushDeviceEnabled` to match.
- Reconcile against the real subscription at the end of `enablePushOnThisDevice` (handles the registration guard short-circuit).
- Set `pushDeviceEnabled` to `false` in `disablePushOnThisDevice` (it was never cleared — the inverse bug).
- Re-sync on the settings component's `ngOnInit` so the toggle is correct each time the panel is shown.

## Testing

- `pnpm test` for notification service + settings component: 9 passing.
- `tsc` typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)