### PR TITLE
feat(gradings): cache student & instructor names for non-admin viewers

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -16,6 +16,7 @@
     "grant-video-library-access": "ts-node scripts/grant-video-library-access.ts",
     "normalize-members-schools": "ts-node scripts/data-migrations/normalize-members-schools.ts",
     "backfill-grading-status-actor": "ts-node scripts/data-migrations/backfill-grading-status-actor.ts",
+    "backfill-grading-names": "ts-node scripts/data-migrations/backfill-grading-names.ts",
     "test": "vitest run --no-color"
   },
   "main": "dist/index.js",

--- a/functions/scripts/data-migrations/backfill-grading-names.ts
+++ b/functions/scripts/data-migrations/backfill-grading-names.ts
@@ -1,0 +1,172 @@
+import * as admin from 'firebase-admin';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+
+/*
+ Data migration: backfill grading display-name snapshots.
+
+ Two denormalized fields cache the names referenced by a grading so non-admin
+ viewers (who cannot read the members/instructors collections) see names rather
+ than bare IDs:
+   - studentName            — the student member's display name
+   - gradingInstructorName  — the primary grading instructor's display name
+
+ Going forward these are kept in sync by the grading triggers
+ (functions/src/on-grading-update.ts) on every create/update. This script fills
+ them in for gradings written before the triggers existed.
+
+ For each grading it:
+   1. Resolves the student name from studentMemberDocId, falling back to a
+      lookup by the human-readable studentMemberId.
+   2. Resolves the primary instructor's name by finding the member whose
+      instructorId matches gradingInstructorId.
+   3. Writes the fields only when they are missing or have changed.
+
+ The script is idempotent: re-running it makes no further changes.
+
+ Usage:
+   cd functions
+   pnpm run backfill-grading-names --project ilc-paris-class-tracker --dry-run
+
+ If running against the local emulator or with GCLOUD_PROJECT set:
+   pnpm run backfill-grading-names --dry-run
+
+ Remove --dry-run to actually save changes.
+*/
+
+const argv = yargs(hideBin(process.argv))
+  .option('project', {
+    type: 'string',
+    description: 'Firebase Project ID',
+    demandOption: false,
+  })
+  .option('dry-run', {
+    type: 'boolean',
+    description: 'If true, no changes will be made to Firestore',
+    default: false,
+  })
+  .parseSync();
+
+const projectId =
+  argv.project || process.env.GCLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT;
+if (!projectId) {
+  console.error(
+    'Error: Project ID is required. Use --project or GCLOUD_PROJECT env var.',
+  );
+  process.exit(1);
+}
+
+admin.initializeApp({ projectId });
+const db = admin.firestore();
+
+// Cache member-docId → name and instructorId → name lookups so we don't re-read
+// the same member across many gradings.
+const memberNameByDocId = new Map<string, string>();
+async function memberNameFromDocId(docId: string): Promise<string> {
+  if (!docId) return '';
+  if (memberNameByDocId.has(docId)) return memberNameByDocId.get(docId)!;
+  const snap = await db.collection('members').doc(docId).get();
+  const name = snap.exists ? (snap.data()?.name as string) || '' : '';
+  memberNameByDocId.set(docId, name);
+  return name;
+}
+
+const memberNameByMemberId = new Map<string, string>();
+async function memberNameFromMemberId(memberId: string): Promise<string> {
+  if (!memberId) return '';
+  if (memberNameByMemberId.has(memberId)) return memberNameByMemberId.get(memberId)!;
+  const q = await db
+    .collection('members')
+    .where('memberId', '==', memberId)
+    .limit(1)
+    .get();
+  const name = q.empty ? '' : (q.docs[0].data()?.name as string) || '';
+  memberNameByMemberId.set(memberId, name);
+  return name;
+}
+
+const instructorNameById = new Map<string, string>();
+async function instructorName(instructorId: string): Promise<string> {
+  if (!instructorId) return '';
+  if (instructorNameById.has(instructorId)) return instructorNameById.get(instructorId)!;
+  const q = await db
+    .collection('members')
+    .where('instructorId', '==', instructorId)
+    .limit(1)
+    .get();
+  const name = q.empty ? '' : (q.docs[0].data()?.name as string) || '';
+  instructorNameById.set(instructorId, name);
+  return name;
+}
+
+async function run() {
+  const isDryRun = argv['dry-run'];
+  console.log(`Backfilling grading name snapshots for project: ${projectId}`);
+  if (isDryRun) {
+    console.log('--- DRY RUN MODE: No changes will be saved ---');
+  }
+
+  const stats = { total: 0, updated: 0, studentFilled: 0, instructorFilled: 0 };
+
+  const snap = await db.collection('gradings').get();
+  stats.total = snap.size;
+  console.log(`Found ${stats.total} gradings.`);
+
+  let batch = db.batch();
+  let batchCount = 0;
+
+  for (const doc of snap.docs) {
+    const data = doc.data() as Record<string, unknown>;
+    const update: Record<string, unknown> = {};
+
+    const studentMemberDocId = (data.studentMemberDocId as string) || '';
+    const studentMemberId = (data.studentMemberId as string) || '';
+    const gradingInstructorId = (data.gradingInstructorId as string) || '';
+
+    const resolvedStudentName =
+      (await memberNameFromDocId(studentMemberDocId)) ||
+      (await memberNameFromMemberId(studentMemberId));
+    const resolvedInstructorName = await instructorName(gradingInstructorId);
+
+    if ((data.studentName ?? '') !== resolvedStudentName) {
+      update.studentName = resolvedStudentName;
+      if (resolvedStudentName) stats.studentFilled++;
+    }
+    if ((data.gradingInstructorName ?? '') !== resolvedInstructorName) {
+      update.gradingInstructorName = resolvedInstructorName;
+      if (resolvedInstructorName) stats.instructorFilled++;
+    }
+
+    if (Object.keys(update).length === 0) continue;
+
+    stats.updated++;
+    console.log(`  Grading ${doc.id}: ${Object.keys(update).join(', ')}`);
+    if (!isDryRun) {
+      batch.update(doc.ref, update);
+      batchCount++;
+      if (batchCount >= 100) {
+        await batch.commit();
+        batch = db.batch();
+        batchCount = 0;
+      }
+    }
+  }
+
+  if (!isDryRun && batchCount > 0) {
+    await batch.commit();
+  }
+
+  console.log('\n--- Summary ---');
+  console.log(`Total gradings:           ${stats.total}`);
+  console.log(`Updated:                  ${stats.updated}`);
+  console.log(`studentName filled:       ${stats.studentFilled}`);
+  console.log(`gradingInstructorName filled: ${stats.instructorFilled}`);
+  if (isDryRun) console.log('(dry run — nothing was saved)');
+}
+
+run()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/functions/src/data-model.ts
+++ b/functions/src/data-model.ts
@@ -984,6 +984,14 @@ export type Grading = {
   schoolDocId: string; // The Firestore doc ID of the school where the grading was conducted.
   studentMemberId: string; // The human-readable memberId of the student being graded.
   studentMemberDocId: string; // The Firestore doc ID of the student member document.
+  // Denormalized display-name snapshots, kept in sync by the grading triggers
+  // (see on-grading-update.ts) on every create/update. They let non-admin
+  // viewers — who cannot read the members/instructors collections — see the
+  // student and primary instructor names instead of bare IDs. Plain `name`
+  // values; the UI still formats them with the IDs it already has on the
+  // grading. '' until first resolved (e.g. the member doc isn't found).
+  studentName: string; // Display name of the student at the last create/update.
+  gradingInstructorName: string; // Display name of the primary grading instructor.
   status: GradingStatus; // See GradingStatus enum for details.
   gradingEventDate: string; // YYYY-MM-DD, set when grading is conducted.
   gradingEvent: string; // Text string for event/location/date of the grading.
@@ -1040,6 +1048,8 @@ export function initGrading(): Grading {
     schoolDocId: '',
     studentMemberId: '',
     studentMemberDocId: '',
+    studentName: '',
+    gradingInstructorName: '',
     status: GradingStatus.AwaitingRequest,
     gradingEventDate: '',
     gradingEvent: '',

--- a/functions/src/on-grading-update.ts
+++ b/functions/src/on-grading-update.ts
@@ -190,6 +190,53 @@ async function getMemberName(
   return snap.exists ? snap.data()?.name || fallback : fallback;
 }
 
+/**
+ * Resolve a member's display name from a Firestore doc ID, falling back to the
+ * human-readable memberId when the doc ID is missing or doesn't resolve. Some
+ * gradings carry only a studentMemberId, so we look up by that too.
+ */
+async function getMemberNameByDocIdOrMemberId(
+  memberDocId: string | undefined,
+  memberId: string | undefined,
+): Promise<string> {
+  if (memberDocId) {
+    const snap = await db.collection('members').doc(memberDocId).get();
+    if (snap.exists && snap.data()?.name) return snap.data()!.name;
+  }
+  if (memberId) {
+    const q = await db
+      .collection('members')
+      .where('memberId', '==', memberId)
+      .limit(1)
+      .get();
+    if (!q.empty && q.docs[0].data()?.name) return q.docs[0].data().name;
+  }
+  return '';
+}
+
+/**
+ * Resolve the denormalized display-name snapshots cached on a grading: the
+ * student's name and the primary grading instructor's name. Returns '' for
+ * either when the referenced member can't be found. See the Grading.studentName
+ * / gradingInstructorName fields for why these are cached.
+ */
+async function resolveGradingNames(
+  grading: Grading,
+): Promise<{ studentName: string; gradingInstructorName: string }> {
+  const studentName = await getMemberNameByDocIdOrMemberId(
+    grading.studentMemberDocId,
+    grading.studentMemberId,
+  );
+  let gradingInstructorName = '';
+  if (grading.gradingInstructorId) {
+    const instructorMemberDocId = await findInstructorMemberDocId(
+      grading.gradingInstructorId,
+    );
+    gradingInstructorName = await getMemberName(instructorMemberDocId, '');
+  }
+  return { studentName, gradingInstructorName };
+}
+
 async function getPrimaryInstructorId(memberDocId: string | undefined): Promise<string | undefined> {
   if (!memberDocId) return undefined;
   const snap = await db.collection('members').doc(memberDocId).get();
@@ -316,6 +363,15 @@ export const onGradingCreated = onDocumentCreated(
     grading.docId = snap.id;
     const gradingDocId = snap.id;
 
+    // Cache the student/instructor display names so non-admin viewers (who can't
+    // read members/instructors) see names instead of IDs. Set on the in-memory
+    // grading first so the mirrored copies below carry the names too, then write
+    // them back to the source doc if they were missing/stale. The write-back
+    // re-fires onGradingUpdated, which re-resolves and finds them unchanged.
+    const resolvedNames = await resolveGradingNames(grading);
+    grading.studentName = resolvedNames.studentName;
+    grading.gradingInstructorName = resolvedNames.gradingInstructorName;
+
     // Mirror to all instructors (primary + assistants)
     await mirrorGradingToAllInstructors(gradingDocId, grading);
 
@@ -402,6 +458,20 @@ export const onGradingCreated = onDocumentCreated(
       }
     }
 
+    // Persist the cached names to the source grading if they weren't already
+    // stored (e.g. the client created the doc without them).
+    const storedStudentName = (snap.data() as Grading).studentName || '';
+    const storedInstructorName = (snap.data() as Grading).gradingInstructorName || '';
+    if (
+      storedStudentName !== grading.studentName ||
+      storedInstructorName !== grading.gradingInstructorName
+    ) {
+      await snap.ref.update({
+        studentName: grading.studentName,
+        gradingInstructorName: grading.gradingInstructorName,
+      });
+    }
+
     logger.info(`Grading ${gradingDocId} created and mirrored.`);
   },
 );
@@ -417,6 +487,17 @@ export const onGradingUpdated = onDocumentUpdated(
     const previous = snap.before.data() as Grading;
     previous.docId = snap.before.id;
     const gradingDocId = snap.after.id;
+
+    // Re-resolve the cached display names from the current student/instructor so
+    // they stay in sync on every update. Set on the in-memory grading first so
+    // the sub-collection mirrors below carry the fresh names. Captured stored
+    // values are compared at the end to decide whether a write-back is needed
+    // (the write-back re-fires this trigger, which then finds them unchanged).
+    const storedStudentName = grading.studentName || '';
+    const storedInstructorName = grading.gradingInstructorName || '';
+    const resolvedNames = await resolveGradingNames(grading);
+    grading.studentName = resolvedNames.studentName;
+    grading.gradingInstructorName = resolvedNames.gradingInstructorName;
 
     // Determine which instructor IDs changed
     const previousPrimaryInstructor = await getPrimaryInstructorId(previous.studentMemberDocId);
@@ -820,6 +901,19 @@ export const onGradingUpdated = onDocumentUpdated(
       previous.status === GradingStatus.AwaitingAcceptance
     ) {
       await annotateManagerNotificationsWithAcceptor(grading, gradingDocId);
+    }
+
+    // Write the refreshed cached names back to the source grading if they
+    // changed. Skipping the write when unchanged stops the trigger re-firing in
+    // a loop.
+    if (
+      storedStudentName !== grading.studentName ||
+      storedInstructorName !== grading.gradingInstructorName
+    ) {
+      await snap.after.ref.update({
+        studentName: grading.studentName,
+        gradingInstructorName: grading.gradingInstructorName,
+      });
     }
 
     logger.info(`Grading ${gradingDocId} updated and re-mirrored.`);

--- a/src/app/data-manager.service.ts
+++ b/src/app/data-manager.service.ts
@@ -253,25 +253,32 @@ export class DataManagerService {
 
   // Standard "(memberId) Name" display form for a member referenced by a
   // grading. Resolves the member by docId first, then by human-readable
-  // memberId (some gradings have a stale/empty studentMemberDocId). Falls back
-  // to whatever identifier we have when the member document isn't loaded.
-  memberDisplayName(memberDocId: string, memberId: string): string {
+  // memberId (some gradings have a stale/empty studentMemberDocId). When the
+  // member document isn't loaded — e.g. non-admin viewers can't read the members
+  // collection — falls back to the denormalized `cachedName` snapshot stored on
+  // the grading (Grading.studentName), then to whatever identifier we have.
+  memberDisplayName(memberDocId: string, memberId: string, cachedName?: string): string {
     const member =
       (memberDocId ? this.getMemberByDocId(memberDocId) : undefined) ??
       (memberId ? this.getMemberByMemberId(memberId) : undefined);
     if (member) {
       return member.memberId ? `(${member.memberId}) ${member.name}` : member.name;
     }
+    if (cachedName) {
+      return memberId ? `(${memberId}) ${cachedName}` : cachedName;
+    }
     return memberId || memberDocId || '';
   }
 
   // Standard "Name [instructorId]" display form for an instructor referenced by
   // a grading. Resolves the instructor by their human-readable instructorId.
-  // Falls back to the raw id when the instructor document isn't loaded.
-  instructorDisplayName(instructorId: string): string {
+  // Falls back to the denormalized `cachedName` snapshot (Grading.gradingInstructorName)
+  // and then the raw id when the instructor document isn't loaded.
+  instructorDisplayName(instructorId: string, cachedName?: string): string {
     if (!instructorId) return '';
     const instructor = this.instructors.get(instructorId);
-    return instructor ? `${instructor.name} [${instructor.instructorId}]` : instructorId;
+    if (instructor) return `${instructor.name} [${instructor.instructorId}]`;
+    return cachedName ? `${cachedName} [${instructorId}]` : instructorId;
   }
 
   // Reactive map from memberId to docId for the logged-in instructor's students.

--- a/src/app/grading-list/grading-list.ts
+++ b/src/app/grading-list/grading-list.ts
@@ -112,11 +112,18 @@ export class GradingListComponent {
         studentName: this.dataService.memberDisplayName(
           g.studentMemberDocId,
           g.studentMemberId,
+          g.studentName,
         ),
         // Include the senior grading instructor plus any assistant instructors
-        // so searching for any examiner's name surfaces the grading.
+        // so searching for any examiner's name surfaces the grading. The primary
+        // instructor's cached name is supplied as a fallback for non-admin views.
         instructorName: [g.gradingInstructorId, ...g.assistantInstructorIds]
-          .map((id) => this.dataService.instructorDisplayName(id))
+          .map((id) =>
+            this.dataService.instructorDisplayName(
+              id,
+              id === g.gradingInstructorId ? g.gradingInstructorName : undefined,
+            ),
+          )
           .filter((name) => !!name)
           .join(' '),
       })),

--- a/src/app/grading-progress/grading-progress.html
+++ b/src/app/grading-progress/grading-progress.html
@@ -136,7 +136,7 @@
                 {{ inst.name }} [{{ inst.instructorId }}]
               </a>
             } @else {
-              <strong>{{ g.gradingInstructorId }}</strong>
+              <strong>{{ gradingInstructorLabel() }}</strong>
             }
             declined this grading request.
             @if (userIsStudent()) {
@@ -181,7 +181,7 @@
                   {{ inst.name }} [{{ inst.instructorId }}]
                 </a>
               } @else {
-                <strong>{{ g.gradingInstructorId }}</strong>
+                <strong>{{ gradingInstructorLabel() }}</strong>
               }
               to accept your grading request.
             </span>
@@ -410,7 +410,7 @@
                   {{ inst.name }} [{{ inst.instructorId }}]
                 </a>
               } @else {
-                <strong>{{ g.gradingInstructorId }}</strong>
+                <strong>{{ gradingInstructorLabel() }}</strong>
               }
               .
             } @else if (g.status === GradingStatus.AwaitingRequest) {
@@ -486,7 +486,7 @@
                 ><app-icon name="person" class="person-icon"></app-icon>{{ inst.name }} [{{ inst.instructorId }}]</a
               >
             } @else {
-              <strong>{{ g.gradingInstructorId }}</strong>
+              <strong>{{ gradingInstructorLabel() }}</strong>
             }
             .
             @let assistants = gradingManagers();
@@ -713,7 +713,7 @@
                 ><app-icon name="person" class="person-icon"></app-icon>{{ inst.name }} [{{ inst.instructorId }}]</a
               >
             } @else {
-              <strong>{{ g.gradingInstructorId }}</strong>
+              <strong>{{ gradingInstructorLabel() }}</strong>
             }
             .
             @let assistants = gradingManagers();
@@ -914,7 +914,7 @@
               <a class="instructor-link" [href]="'#/instructors/' + inst.instructorId"
                 ><app-icon name="person" class="person-icon"></app-icon>{{ inst.name }} [{{ inst.instructorId }}]</a>
             } @else {
-              <strong>{{ g.gradingInstructorId }}</strong>
+              <strong>{{ gradingInstructorLabel() }}</strong>
             }
             @if (canEditGradingDetails()) {
               <button class="icon-only-button detail-edit-btn" (click)="isEditingInstructor.set(true)" title="Edit grading instructor"><app-icon name="edit"></app-icon></button>

--- a/src/app/grading-progress/grading-progress.spec.ts
+++ b/src/app/grading-progress/grading-progress.spec.ts
@@ -39,6 +39,7 @@ describe('GradingProgressComponent', () => {
       getMemberByDocId: () => undefined,
       getMemberByMemberId: () => undefined,
       memberDisplayName: (docId: string, memberId: string) => memberId || docId || '',
+      instructorDisplayName: (instructorId: string) => instructorId,
     };
 
     mockFirebaseState = createFirebaseStateServiceMock();

--- a/src/app/grading-progress/grading-progress.ts
+++ b/src/app/grading-progress/grading-progress.ts
@@ -150,6 +150,7 @@ export class GradingProgressComponent implements OnDestroy {
     return this.dataService.memberDisplayName(
       g.studentMemberDocId,
       g.studentMemberId,
+      g.studentName,
     );
   });
 
@@ -158,6 +159,16 @@ export class GradingProgressComponent implements OnDestroy {
     if (!id) return null;
     return this.dataService.instructors.get(id) ?? null;
   });
+
+  // Display label for the primary grading instructor when their public profile
+  // isn't loaded (e.g. non-admin viewers). Falls back to the cached name
+  // snapshot on the grading, then the raw instructorId.
+  gradingInstructorLabel = computed(() =>
+    this.dataService.instructorDisplayName(
+      this.grading().gradingInstructorId,
+      this.grading().gradingInstructorName,
+    ),
+  );
 
   // Grading managers — displayed as "Grading Managers" in the UI.
   // Backed by the legacy Firestore field `assistantInstructorIds`.

--- a/src/app/grading-row-header/grading-row-header.ts
+++ b/src/app/grading-row-header/grading-row-header.ts
@@ -33,6 +33,7 @@ export class GradingRowHeaderComponent {
     return this.dataService.memberDisplayName(
       g.studentMemberDocId,
       g.studentMemberId,
+      g.studentName,
     );
   });
 
@@ -50,7 +51,10 @@ export class GradingRowHeaderComponent {
   });
 
   instructorName = computed(() =>
-    this.dataService.instructorDisplayName(this.grading().gradingInstructorId),
+    this.dataService.instructorDisplayName(
+      this.grading().gradingInstructorId,
+      this.grading().gradingInstructorName,
+    ),
   );
 
   formatLevel(lvl: string): string {

--- a/src/app/grading-view/grading-view.ts
+++ b/src/app/grading-view/grading-view.ts
@@ -84,6 +84,7 @@ export class GradingViewComponent {
         this.dataService.memberDisplayName(
           g.studentMemberDocId,
           g.studentMemberId,
+          g.studentName,
         ) || 'Unknown Student';
       this.titleLoaded.emit(`Grading: ${studentLabel}`);
     } else if (!this.loading()) {

--- a/tests/e2e/grading-event-managers.spec.ts
+++ b/tests/e2e/grading-event-managers.spec.ts
@@ -78,6 +78,8 @@ function makeGrading(studentMemberDocId: string, studentMemberId: string): Gradi
     schoolDocId: '',
     studentMemberId,
     studentMemberDocId,
+    studentName: '',
+    gradingInstructorName: '',
     status: GradingStatus.AwaitingAcceptance,
     gradingEventDate: '',
     gradingEvent: '',
@@ -130,6 +132,21 @@ describe('story: grading-event-managers', () => {
 
   afterAll(async () => {
     await db.terminate();
+  });
+
+  it('caches the student name on the grading so non-admins see it', async () => {
+    // The onGradingCreated trigger should denormalize the student's display name
+    // onto the grading (studentName) so viewers who cannot read the members
+    // collection still see a name instead of a bare ID.
+    const deadline = Date.now() + 15000;
+    let studentName = '';
+    while (Date.now() < deadline) {
+      const snap = await db.collection('gradings').doc(gradingDocId).get();
+      studentName = (snap.data() as Grading | undefined)?.studentName || '';
+      if (studentName) break;
+      await new Promise((r) => setTimeout(r, 400));
+    }
+    expect(studentName).toBe('Test Student');
   });
 
   it('links the grading to the event, notifying organizer and manager', async () => {


### PR DESCRIPTION
## Problem
When a non-admin views a grading or a grading list, they only see the student's (and instructor's) **ID**, not their name — non-admins can't read the `members`/`instructors` collections, so the live name lookup falls back to the raw ID.

## Approach
Denormalize the names onto the grading document (same pattern as the existing `acceptedByName` / `statusChangedByName` snapshots) and keep them fresh via the grading triggers.

- **Data model** ([data-model.ts](functions/src/data-model.ts)): add `Grading.studentName` and `Grading.gradingInstructorName`.
- **Triggers** ([on-grading-update.ts](functions/src/on-grading-update.ts)): `onGradingCreated` / `onGradingUpdated` re-resolve both names on every create/update, set them on the in-memory grading (so the instructor/school sub-collection mirrors carry them too), and write them back to the source doc **only when changed** (guard prevents the write-back from re-firing the trigger in a loop).
- **UI fallbacks** ([data-manager.service.ts](src/app/data-manager.service.ts)): `memberDisplayName` / `instructorDisplayName` take an optional cached-name argument, used only when the live doc isn't loaded. Wired into the grading row header, grading view title, grading-progress (incl. a new `gradingInstructorLabel` replacing bare-ID template fallbacks), and grading-list search.
- **Backfill** ([backfill-grading-names.ts](functions/scripts/data-migrations/backfill-grading-names.ts)): idempotent migration to populate existing gradings — `pnpm run backfill-grading-names` (supports `--dry-run` / `--project`).

## Verification
- Functions build + 185 unit tests: pass
- Frontend typecheck + grading component tests (17): pass
- e2e against emulator (3): pass, including a new test asserting the trigger caches `studentName` on creation

## After merge/deploy
```
cd functions
pnpm run backfill-grading-names --project ilc-paris-class-tracker --dry-run
```
Remove `--dry-run` to apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)