### PR TITLE
fix(notifications): add events (status, createdAt) index for pending-event query

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -94,6 +94,25 @@
         }
       ],
       "density": "SPARSE_ALL"
+    },
+    {
+      "collectionGroup": "events",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "DESCENDING"
+        }
+      ],
+      "density": "SPARSE_ALL"
     }
   ],
   "fieldOverrides": []

--- a/src/app/notification.service.ts
+++ b/src/app/notification.service.ts
@@ -523,6 +523,9 @@ export class NotificationService implements OnDestroy {
     });
 
     // The events currently waiting for approval, newest proposals first.
+    // Requires a (status, createdAt) composite index on the events collection.
+    // Note: orderBy('createdAt') excludes any proposed event missing a
+    // createdAt field — submitProposedEvent always sets it.
     const eventsSnap = await getDocs(
       query(
         collection(this.db, 'events'),


### PR DESCRIPTION
## Why

Follow-up to #16. The admin pending-event-approval sync queries proposed events with `where('status','==','proposed')` + `orderBy('createdAt','desc')`, which requires a `(status, createdAt)` composite index. That index was missing, so the query failed with `failed-precondition`, the error was caught/logged, and **no pending-event notifications were created** for admins.

This commit landed after #16 was squash-merged, so it wasn't included — hence this small follow-up PR.

## What

- **`firestore.indexes.json`**: add the `(status, createdAt, __name__)` composite index for the `events` collection (mirrors the existing `(status, start)` / `(status, lastUpdated)` indexes).
- **`notification.service.ts`**: document the index requirement at the query.

## Deployment

The index has already been deployed to Firestore (`firebase deploy --only firestore:indexes` on `ilc-paris-class-tracker`); this PR just brings source control in line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)