### PR TITLE
feat(notifications): notify admins of orders needing manual processing

### DIFF
--- a/functions/src/data-model.ts
+++ b/functions/src/data-model.ts
@@ -443,7 +443,7 @@ export interface NotificationPurchaseData {
 export interface NotificationOrderIssueData {
   // Firestore doc ID of the order; used both to deep-link to the order view and
   // to de-duplicate so the same order is only announced once per admin.
-  orderId: string;
+  orderDocId: string;
   // Human-readable order reference (Squarespace orderNumber or Sheets
   // referenceNumber) for display.
   orderRef: string;

--- a/functions/src/data-model.ts
+++ b/functions/src/data-model.ts
@@ -382,6 +382,9 @@ export enum NotificationKind {
   // Admin-only: a member-proposed event is waiting for approval (status='proposed').
   // Surfaced to admins so they can review and approve/reject it from Manage Events.
   PendingEventApproval = 'PendingEventApproval',
+  // Admin-only: an order failed automatic processing (ilcAppOrderStatus 'error' or
+  // 'needs-manual-processing') and needs an admin to resolve it from the order view.
+  OrderNeedsAttention = 'OrderNeedsAttention',
 }
 
 export interface MemberNotificationCommon {
@@ -437,6 +440,20 @@ export interface NotificationPurchaseData {
   summary: string;
 }
 
+export interface NotificationOrderIssueData {
+  // Firestore doc ID of the order; used both to deep-link to the order view and
+  // to de-duplicate so the same order is only announced once per admin.
+  orderId: string;
+  // Human-readable order reference (Squarespace orderNumber or Sheets
+  // referenceNumber) for display.
+  orderRef: string;
+  // The processing status that flagged this order ('error' or
+  // 'needs-manual-processing').
+  status: OrderStatus;
+  // The recorded processing issues (ilcAppOrderIssues), if any.
+  issues: string[];
+}
+
 export type MemberNotification = MemberNotificationCommon & (
   | {
     kind: NotificationKind.GradingRequestAccepted;
@@ -481,6 +498,10 @@ export type MemberNotification = MemberNotificationCommon & (
   | {
     kind: NotificationKind.PendingEventApproval;
     data: NotificationEventData;
+  }
+  | {
+    kind: NotificationKind.OrderNeedsAttention;
+    data: NotificationOrderIssueData;
   }
   | {
     kind: NotificationKind.PurchaseFulfilled;

--- a/src/app/notification.service.ts
+++ b/src/app/notification.service.ts
@@ -27,8 +27,11 @@ import {
   MembershipType,
   MemberNotification,
   NotificationKind,
+  Order,
+  OrderStatus,
   PushSubscriptionDoc,
   firestoreDocToMemberNotification,
+  firestoreDocToOrder,
   initCachedBlogPost,
   initEvent,
 } from '../../functions/src/data-model';
@@ -82,6 +85,9 @@ export class NotificationService implements OnDestroy {
   // The admin member doc ID we have already run pending-event catch-up for this
   // session, so the auth effect re-firing doesn't re-run it.
   private pendingEventsSyncedForMemberDocId: string | null = null;
+  // The admin member doc ID we have already run order-issue catch-up for this
+  // session, so the auth effect re-firing doesn't re-run it.
+  private orderIssuesSyncedForMemberDocId: string | null = null;
   // The member doc ID we have already registered a web-push subscription for
   // this session, to avoid redundant re-subscriptions on effect re-fires.
   private pushSubscribedForMemberDocId: string | null = null;
@@ -92,6 +98,16 @@ export class NotificationService implements OnDestroy {
   // Maximum number of pending-event approval notifications to create at once,
   // newest proposals first, so a large backlog can't flood an admin's feed.
   private static readonly MAX_PENDING_EVENT_NOTIFICATIONS = 20;
+
+  // Maximum number of order-issue notifications to create at once, most recent
+  // orders first, so a large backlog can't flood an admin's feed.
+  private static readonly MAX_ORDER_ISSUE_NOTIFICATIONS = 20;
+
+  // The order processing statuses that require admin attention.
+  private static readonly ORDER_ATTENTION_STATUSES: OrderStatus[] = [
+    'error',
+    'needs-manual-processing',
+  ];
 
   // The blog feeds we surface notifications for. `route` is the hash-router
   // path prefix used to deep-link to an individual post by its urlId.
@@ -132,6 +148,11 @@ export class NotificationService implements OnDestroy {
           this.syncPendingEventNotifications(user.member).catch((e) =>
             console.error('Failed to sync pending event notifications:', e),
           );
+          // Also surface any orders that failed automatic processing and need a
+          // human to resolve them.
+          this.syncOrderIssueNotifications(user.member).catch((e) =>
+            console.error('Failed to sync order issue notifications:', e),
+          );
         }
         // If the member has already granted notification permission, (re)register
         // this device's web-push subscription so background pushes can reach them.
@@ -143,6 +164,7 @@ export class NotificationService implements OnDestroy {
         this.notifications.set([]);
         this.blogSyncedForMemberDocId = null;
         this.pendingEventsSyncedForMemberDocId = null;
+        this.orderIssuesSyncedForMemberDocId = null;
         this.pushSubscribedForMemberDocId = null;
       }
     });
@@ -557,6 +579,89 @@ export class NotificationService implements OnDestroy {
         data: {
           eventId: event.docId,
           title: event.title || 'Untitled event',
+        },
+      };
+      batch.set(ref, notification);
+    }
+    await batch.commit();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Admin order-issue notifications
+  // ---------------------------------------------------------------------------
+
+  // Human-readable reference for an order: the Squarespace order number, or the
+  // Sheets-import reference number, falling back to the doc ID.
+  private orderRef(order: Order): string {
+    if (order.ilcAppOrderKind === 'https://api.squarespace.com/1.0/commerce/orders') {
+      return order.orderNumber || order.docId;
+    }
+    return order.referenceNumber || order.docId;
+  }
+
+  // Surfaces orders that failed automatic processing (ilcAppOrderStatus 'error'
+  // or 'needs-manual-processing') as notifications in this admin's feed, most
+  // recent first. Idempotent and modelled on the pending-event catch-up: it
+  // reads the admin's own OrderNeedsAttention notifications to find which orders
+  // have already been surfaced and only adds notifications for ones it hasn't
+  // announced yet. Runs once per session.
+  private async syncOrderIssueNotifications(member: Member): Promise<void> {
+    if (this.orderIssuesSyncedForMemberDocId === member.docId) return;
+    this.orderIssuesSyncedForMemberDocId = member.docId;
+
+    const notifCollection = collection(this.db, 'members', member.docId, 'notifications');
+
+    // Which order-issue notifications have we already created for this admin?
+    // Single-field filter (no composite index needed).
+    const existingSnap = await getDocs(
+      query(notifCollection, where('kind', '==', NotificationKind.OrderNeedsAttention)),
+    );
+    const notifiedOrderIds = new Set<string>();
+    existingSnap.forEach((d) => {
+      const data = (d.data() as MemberNotification).data as { orderId?: string };
+      if (data?.orderId) notifiedOrderIds.add(data.orderId);
+    });
+
+    // Orders flagged for attention. We filter by status only (an `in` filter on
+    // a single field, so no composite index needed) and sort/cap client-side.
+    const ordersSnap = await getDocs(
+      query(
+        collection(this.db, 'orders'),
+        where('ilcAppOrderStatus', 'in', NotificationService.ORDER_ATTENTION_STATUSES),
+      ),
+    );
+    if (ordersSnap.empty) return;
+
+    const orders = ordersSnap.docs
+      .map((d) => firestoreDocToOrder(d))
+      .filter((o) => !notifiedOrderIds.has(o.docId))
+      // Most recently updated first, then cap to avoid flooding the feed.
+      .sort((a, b) => (b.lastUpdated || '').localeCompare(a.lastUpdated || ''))
+      .slice(0, NotificationService.MAX_ORDER_ISSUE_NOTIFICATIONS);
+    if (orders.length === 0) return;
+
+    const batch = writeBatch(this.db);
+    for (const order of orders) {
+      const ref = doc(notifCollection); // auto-generated ID
+      const link = `#/order-view/${order.docId}`;
+      const orderRef = this.orderRef(order);
+      const status = order.ilcAppOrderStatus as OrderStatus;
+      const verb = status === 'error' ? 'failed with an error' : 'needs manual processing';
+      const issues = order.ilcAppOrderIssues || [];
+      const issuesSuffix = issues.length > 0 ? ` — ${issues.join('; ')}` : '';
+      const notification: MemberNotification = {
+        docId: ref.id,
+        markdown: `Order [#${orderRef}](${link}) ${verb}${issuesSuffix}`,
+        // Stamp with the order's last-updated time so the card date reflects the
+        // order rather than "now".
+        createdAt: order.lastUpdated || new Date().toISOString(),
+        dismissed: false,
+        kind: NotificationKind.OrderNeedsAttention,
+        data: {
+          orderId: order.docId,
+          orderRef,
+          status,
+          issues,
         },
       };
       batch.set(ref, notification);

--- a/src/app/notification.service.ts
+++ b/src/app/notification.service.ts
@@ -618,8 +618,8 @@ export class NotificationService implements OnDestroy {
     );
     const notifiedOrderIds = new Set<string>();
     existingSnap.forEach((d) => {
-      const data = (d.data() as MemberNotification).data as { orderId?: string };
-      if (data?.orderId) notifiedOrderIds.add(data.orderId);
+      const data = (d.data() as MemberNotification).data as { orderDocId?: string };
+      if (data?.orderDocId) notifiedOrderIds.add(data.orderDocId);
     });
 
     // Orders flagged for attention. We filter by status only (an `in` filter on
@@ -658,7 +658,7 @@ export class NotificationService implements OnDestroy {
         dismissed: false,
         kind: NotificationKind.OrderNeedsAttention,
         data: {
-          orderId: order.docId,
+          orderDocId: order.docId,
           orderRef,
           status,
           issues,

--- a/src/app/notifications-list/notifications-list.scss
+++ b/src/app/notifications-list/notifications-list.scss
@@ -113,6 +113,15 @@
     @include v.row-highlight-base;
     @include v.row-highlight-active; // Active highlights unread by default
 
+    // Admin-only notification kinds get a distinct light-orange background so
+    // they stand out from a member's own notifications. Higher specificity than
+    // the row-highlight mixin above, so it wins for these kinds.
+    &.PendingEventApproval,
+    &.OrderNeedsAttention {
+      background-color: #fff4e5; // Light orange
+      border-left-color: #f5a623; // Orange accent
+    }
+
     .notification-icon {
       display: flex;
       align-items: center;
@@ -140,6 +149,11 @@
       }
       &.NewEventPosted {
         background-color: #e8f0fe; // Soft blue
+      }
+      // Admin-only kinds — soft orange tint matching the card background.
+      &.PendingEventApproval,
+      &.OrderNeedsAttention {
+        background-color: #fee9cc; // Soft orange
       }
     }
 

--- a/src/app/notifications-view/notifications-view.scss
+++ b/src/app/notifications-view/notifications-view.scss
@@ -37,6 +37,15 @@
   @include v.row-highlight-active; // Highlight unread by default
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 
+  // Admin-only notification kinds get a distinct light-orange background so they
+  // stand out from a member's own notifications. The later `.read` rule still
+  // de-emphasises them to white once read, matching the other kinds.
+  &.PendingEventApproval,
+  &.OrderNeedsAttention {
+    background-color: #fff4e5; // Light orange
+    border-left-color: #f5a623; // Orange accent
+  }
+
   // Read notifications are visually de-emphasised.
   &.read {
     background: white;
@@ -83,6 +92,11 @@
     }
     &.NewEventPosted {
       background-color: #e8f0fe; // Soft blue
+    }
+    // Admin-only kinds — soft orange tint matching the card background.
+    &.PendingEventApproval,
+    &.OrderNeedsAttention {
+      background-color: #fee9cc; // Soft orange
     }
   }
 

--- a/src/app/settings/notification-settings/notification-settings.component.ts
+++ b/src/app/settings/notification-settings/notification-settings.component.ts
@@ -165,6 +165,8 @@ export class NotificationSettingsComponent implements OnInit {
         return 'New Event Posted';
       case NotificationKind.PendingEventApproval:
         return 'Event Awaiting Approval (Admins)';
+      case NotificationKind.OrderNeedsAttention:
+        return 'Order Needs Manual Processing (Admins)';
       case NotificationKind.PurchaseFulfilled:
         return 'Purchase Processed';
       default:


### PR DESCRIPTION
## What

Adds an admin notification class for **orders that failed automatic processing** and need a human to resolve them — the same pattern as the pending-event-approval notifications (#16).

## Review of orders (context)

Order processing (`functions/src/squarespace-orders/api.ts`) aggregates per-line-item failures into the **order-level** `ilcAppOrderStatus` (`'error'` or `'needs-manual-processing'`) and collects human-readable reasons in `ilcAppOrderIssues[]`. The order list already keys its status badges off `ilcAppOrderStatus`, and orders are admin-read-only in `firestore.rules`. So filtering on order-level status is the right, complete signal for "needs manual processing".

## How

- **`data-model.ts`**: new `NotificationKind.OrderNeedsAttention` + `NotificationOrderIssueData` (`orderId`, `orderRef`, `status`, `issues`) and the union member.
- **`notification.service.ts`**: `syncOrderIssueNotifications()`, modelled on `syncPendingEventNotifications`:
  - Runs from the auth effect, **gated on `user.isAdmin`**, once per admin per session (guard reset on logout).
  - De-duped against the admin's existing `OrderNeedsAttention` notifications by order `docId`.
  - Queries `orders where ilcAppOrderStatus in ['error','needs-manual-processing']` — a single-field `in` filter, **no composite index needed** (lesson from #18) — then sorts by `lastUpdated` desc and caps at 20 client-side.
  - Links each to `#/order-view/{docId}`; text includes the order ref and the recorded issues. Stamped with the order's `lastUpdated`.
- **`notification-settings.component.ts`**: friendly label for the new kind.

## Notes

- Create-only, matching the existing patterns: a notification isn't auto-cleared when an order is later resolved — the admin dismisses it.

## Verification

- `pnpm --prefix functions run build` (tsc): clean
- `pnpm run build` (ng build): succeeds
- `pnpm exec vitest run src/app/notification.service.spec.ts`: 3/3 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)