### PR TITLE
feat(gradings): add gradingManagerIds, paid, and level-snapshot fields (PR 1/6)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -251,7 +251,8 @@ service cloud.firestore {
              'notes', 'instructorAcceptedDate', 'acceptedByMemberDocId', 'acceptedByName',
              'statusChangedByMemberDocId', 'statusChangedByName',
              'gradingInstructorId', 'resultNotes', 'gradingManagerIds', 'assistantInstructorIds',
-             'paid', 'studentLevelAtAcceptance', 'applicationLevelAtAcceptance', 'declineNotes']);
+             'paymentStatus', 'paymentNote', 'studentLevelAtAcceptance', 'applicationLevelAtAcceptance',
+             'declineNotes']);
       // Before acceptance the student owns the linked event and request fields.
       allow update: if hasValidEditUpdate() && isGradingStudent() && !gradingIsAccepted() &&
           request.resource.data.diff(resource.data).affectedKeys().hasOnly(

--- a/firestore.rules
+++ b/firestore.rules
@@ -199,16 +199,18 @@ service cloud.firestore {
       function isGradingStudent() {
         return resource.data.studentMemberDocId in getUserMemberDocIds();
       }
-      // Returns true for the primary grading instructor AND for grading managers
-      // (stored in `assistantInstructorIds` — TODO: rename field to `gradingManagerIds`
-      // after data migration). Both roles share the same edit permissions.
+      // Returns true for the primary grading instructor AND for grading managers.
+      // Grading managers are stored in `gradingManagerIds`, with a fallback to the
+      // legacy `assistantInstructorIds` for docs not yet migrated. Both roles share
+      // the same edit permissions.
       function isGradingManager() {
         let email = request.auth.token.email;
         let aclPath = /databases/$(database)/documents/acl/$(email);
         let instructorIds = (email != null && exists(aclPath)) ? get(aclPath).data.instructorIds : [];
-        let asst = 'assistantInstructorIds' in resource.data ? resource.data.assistantInstructorIds : [];
+        let managers = 'gradingManagerIds' in resource.data ? resource.data.gradingManagerIds
+            : ('assistantInstructorIds' in resource.data ? resource.data.assistantInstructorIds : []);
         let assigned = resource.data.get('assignedInstructorId', '');
-        return resource.data.gradingInstructorId in instructorIds || instructorIds.hasAny(asst) || (assigned != '' && assigned in instructorIds);
+        return resource.data.gradingInstructorId in instructorIds || instructorIds.hasAny(managers) || (assigned != '' && assigned in instructorIds);
       }
       // True when the user is the organizer or a manager of the event this
       // grading is linked to (via gradingEventDocId). Derived live from the
@@ -248,7 +250,8 @@ service cloud.firestore {
             ['lastUpdated', 'status', 'gradingEventDate', 'gradingEvent', 'gradingEventDocId',
              'notes', 'instructorAcceptedDate', 'acceptedByMemberDocId', 'acceptedByName',
              'statusChangedByMemberDocId', 'statusChangedByName',
-             'gradingInstructorId', 'resultNotes', 'assistantInstructorIds', 'declineNotes']);
+             'gradingInstructorId', 'resultNotes', 'gradingManagerIds', 'assistantInstructorIds',
+             'paid', 'studentLevelAtAcceptance', 'applicationLevelAtAcceptance', 'declineNotes']);
       // Before acceptance the student owns the linked event and request fields.
       allow update: if hasValidEditUpdate() && isGradingStudent() && !gradingIsAccepted() &&
           request.resource.data.diff(resource.data).affectedKeys().hasOnly(

--- a/functions/package.json
+++ b/functions/package.json
@@ -17,6 +17,7 @@
     "normalize-members-schools": "ts-node scripts/data-migrations/normalize-members-schools.ts",
     "backfill-grading-status-actor": "ts-node scripts/data-migrations/backfill-grading-status-actor.ts",
     "backfill-grading-names": "ts-node scripts/data-migrations/backfill-grading-names.ts",
+    "backfill-grading-managers-paid-level": "ts-node scripts/data-migrations/backfill-grading-managers-paid-level.ts",
     "mark-legacy-orders-processed": "ts-node scripts/data-migrations/mark-legacy-orders-processed.ts",
     "test": "vitest run --no-color"
   },

--- a/functions/scripts/build-fixture-subset.ts
+++ b/functions/scripts/build-fixture-subset.ts
@@ -174,7 +174,10 @@ for (const id of selectedMemberIds) {
 for (const g of selectedGradings) {
   const gi = str(g, 'gradingInstructorId');
   if (gi && instructorsByInstructorId.has(gi)) selectedInstructorIds.add(gi);
-  for (const ai of [...strArr(g, 'gradingManagerIds'), ...strArr(g, 'assistantInstructorIds')]) {
+  const managerIds = [
+    ...new Set([...strArr(g, 'gradingManagerIds'), ...strArr(g, 'assistantInstructorIds')]),
+  ];
+  for (const ai of managerIds) {
     if (instructorsByInstructorId.has(ai)) selectedInstructorIds.add(ai);
   }
   const sid = str(g, 'schoolId');
@@ -235,6 +238,14 @@ function emitGrading(g: RawDoc): RawDoc {
   ).filter((id) => selectedInstructorIds.has(id));
   out['gradingManagerIds'] = managerIds;
   out['assistantInstructorIds'] = managerIds;
+  // Default `paymentStatus` for sources predating the field (matches the
+  // backfill): order-sourced gradings (orderId set) are paid-by-squarespace, the
+  // rest paid-other. `studentLevelAtAcceptance`/`applicationLevelAtAcceptance`
+  // pass through via the `{ ...g }` spread above when present on the source.
+  if (g['paymentStatus'] === undefined) {
+    out['paymentStatus'] = str(g, 'orderId') ? 'paid-by-squarespace' : 'paid-other';
+    if (g['paymentNote'] === undefined) out['paymentNote'] = '';
+  }
   const sid = str(g, 'schoolId');
   if (sid && !seededSchoolIds.has(sid)) out['schoolId'] = '';
   return out;

--- a/functions/scripts/build-fixture-subset.ts
+++ b/functions/scripts/build-fixture-subset.ts
@@ -174,7 +174,7 @@ for (const id of selectedMemberIds) {
 for (const g of selectedGradings) {
   const gi = str(g, 'gradingInstructorId');
   if (gi && instructorsByInstructorId.has(gi)) selectedInstructorIds.add(gi);
-  for (const ai of strArr(g, 'assistantInstructorIds')) {
+  for (const ai of [...strArr(g, 'gradingManagerIds'), ...strArr(g, 'assistantInstructorIds')]) {
     if (instructorsByInstructorId.has(ai)) selectedInstructorIds.add(ai);
   }
   const sid = str(g, 'schoolId');
@@ -226,9 +226,15 @@ function emitGrading(g: RawDoc): RawDoc {
   for (const k of ['acceptedByName', 'statusChangedByName', 'notes']) out[k] = '';
   const gi = str(g, 'gradingInstructorId');
   if (gi && !selectedInstructorIds.has(gi)) out['gradingInstructorId'] = '';
-  out['assistantInstructorIds'] = strArr(g, 'assistantInstructorIds').filter((id) =>
-    selectedInstructorIds.has(id),
-  );
+  // Prefer the canonical `gradingManagerIds`, falling back to the legacy field;
+  // emit both (kept in sync) during the migration window.
+  const managerIds = (
+    (g['gradingManagerIds'] as unknown) !== undefined
+      ? strArr(g, 'gradingManagerIds')
+      : strArr(g, 'assistantInstructorIds')
+  ).filter((id) => selectedInstructorIds.has(id));
+  out['gradingManagerIds'] = managerIds;
+  out['assistantInstructorIds'] = managerIds;
   const sid = str(g, 'schoolId');
   if (sid && !seededSchoolIds.has(sid)) out['schoolId'] = '';
   return out;

--- a/functions/scripts/data-migrations/backfill-grading-managers-paid-level.ts
+++ b/functions/scripts/data-migrations/backfill-grading-managers-paid-level.ts
@@ -1,7 +1,7 @@
 import * as admin from 'firebase-admin';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
-import { gradingProgression, previousGradingLevel } from '../../src/data-model';
+import { gradingProgression, previousGradingLevel, PaymentStatus } from '../../src/data-model';
 
 /*
  Data migration: backfill grading manager rename, paid flag, and level snapshot.
@@ -13,10 +13,12 @@ import { gradingProgression, previousGradingLevel } from '../../src/data-model';
       is missing. The legacy field is intentionally LEFT in place for now (removed
       in a later cleanup migration).
 
-   2. paid — whether the grading has been paid for. Existing gradings predate the
-      flag; they are treated as paid, so any doc missing `paid` is set to true.
-      (Order-created gradings are written paid=true by the order processor going
-      forward.)
+   2. paymentStatus / paymentNote — how the grading was paid for. Existing
+      gradings predate the field; they are treated as paid. A doc missing
+      `paymentStatus` is set to 'paid-by-squarespace' when it has an `orderId`
+      (it came from an order), otherwise 'paid-other'; `paymentNote` is set to ''.
+      Order-created gradings are written 'paid-by-squarespace' by the order
+      processor going forward.
 
    3. studentLevelAtAcceptance / applicationLevelAtAcceptance — a snapshot of the
       student's levels when the grading was accepted. Going forward the grading
@@ -104,7 +106,7 @@ async function run() {
     total: 0,
     updated: 0,
     managerIdsFilled: 0,
-    paidFilled: 0,
+    paymentStatusFilled: 0,
     levelSnapshotFilled: 0,
   };
 
@@ -127,10 +129,15 @@ async function run() {
       stats.managerIdsFilled++;
     }
 
-    // Pass 2: paid defaults to true for pre-existing gradings.
-    if (data.paid === undefined) {
-      update.paid = true;
-      stats.paidFilled++;
+    // Pass 2: paymentStatus for pre-existing gradings — order-sourced gradings
+    // (orderId set) are treated as paid by Squarespace; the rest as paid-other.
+    if (data.paymentStatus === undefined) {
+      const orderId = (data.orderId as string) || '';
+      update.paymentStatus = orderId
+        ? PaymentStatus.PaidBySquarespace
+        : PaymentStatus.PaidOther;
+      if (data.paymentNote === undefined) update.paymentNote = '';
+      stats.paymentStatusFilled++;
     }
 
     // Pass 3: level snapshot for accepted-or-beyond gradings, when empty.
@@ -170,7 +177,7 @@ async function run() {
   console.log(`Total gradings:               ${stats.total}`);
   console.log(`Updated:                      ${stats.updated}`);
   console.log(`gradingManagerIds filled:     ${stats.managerIdsFilled}`);
-  console.log(`paid filled:                  ${stats.paidFilled}`);
+  console.log(`paymentStatus filled:         ${stats.paymentStatusFilled}`);
   console.log(`level snapshot filled:        ${stats.levelSnapshotFilled}`);
   if (isDryRun) console.log('(dry run — nothing was saved)');
 }

--- a/functions/scripts/data-migrations/backfill-grading-managers-paid-level.ts
+++ b/functions/scripts/data-migrations/backfill-grading-managers-paid-level.ts
@@ -1,0 +1,183 @@
+import * as admin from 'firebase-admin';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+import { gradingProgression, previousGradingLevel } from '../../src/data-model';
+
+/*
+ Data migration: backfill grading manager rename, paid flag, and level snapshot.
+
+ Three idempotent passes over every /gradings document:
+
+   1. gradingManagerIds — the canonical replacement for the legacy
+      `assistantInstructorIds`. Copies the legacy value across when the new field
+      is missing. The legacy field is intentionally LEFT in place for now (removed
+      in a later cleanup migration).
+
+   2. paid — whether the grading has been paid for. Existing gradings predate the
+      flag; they are treated as paid, so any doc missing `paid` is set to true.
+      (Order-created gradings are written paid=true by the order processor going
+      forward.)
+
+   3. studentLevelAtAcceptance / applicationLevelAtAcceptance — a snapshot of the
+      student's levels when the grading was accepted. Going forward the grading
+      trigger captures the real member levels at acceptance. For historical docs
+      we BEST-EFFORT infer them from the level being graded: the student must have
+      held the progression entry immediately before `level`
+      (previousGradingLevel), from which we derive the implied student/application
+      levels. Only filled for gradings that have been accepted or beyond
+      (awaiting-instructor-grading / passed / not-passed) and only when both
+      snapshot fields are currently empty.
+
+ The script is idempotent: re-running it makes no further changes.
+
+ Usage:
+   cd functions
+   pnpm run backfill-grading-managers-paid-level --project ilc-paris-class-tracker --dry-run
+
+ Remove --dry-run to actually save changes.
+*/
+
+const argv = yargs(hideBin(process.argv))
+  .option('project', {
+    type: 'string',
+    description: 'Firebase Project ID',
+    demandOption: false,
+  })
+  .option('dry-run', {
+    type: 'boolean',
+    description: 'If true, no changes will be made to Firestore',
+    default: false,
+  })
+  .parseSync();
+
+const projectId =
+  argv.project || process.env.GCLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT;
+if (!projectId) {
+  console.error(
+    'Error: Project ID is required. Use --project or GCLOUD_PROJECT env var.',
+  );
+  process.exit(1);
+}
+
+admin.initializeApp({ projectId });
+const db = admin.firestore();
+
+// Statuses at which a grading has been accepted (so a level snapshot makes
+// sense). Mirrors GradingStatus values for AwaitingGrading/Passed/NotPassed.
+const ACCEPTED_STATUSES = new Set([
+  'awaiting-instructor-grading',
+  'passed',
+  'not-passed',
+]);
+
+// Derive the student & application levels implied by holding `heldProgressionLevel`
+// (a `gradingProgression` entry such as 'Student 6' or 'Application 3'). Returns
+// the highest student/application level achieved up to and including that entry.
+function deriveLevels(heldProgressionLevel: string): {
+  studentLevel: string;
+  applicationLevel: string;
+} {
+  let studentLevel = '';
+  let applicationLevel = '';
+  if (!heldProgressionLevel) return { studentLevel, applicationLevel };
+  const idx = gradingProgression.indexOf(heldProgressionLevel);
+  if (idx < 0) return { studentLevel, applicationLevel };
+  for (let i = 0; i <= idx; i++) {
+    const entry = gradingProgression[i];
+    if (entry.startsWith('Student ')) {
+      studentLevel = entry.substring('Student '.length); // 'Entry' or '1'..'11'
+    } else if (entry.startsWith('Application ')) {
+      applicationLevel = entry.substring('Application '.length); // '1'..'6'
+    }
+  }
+  return { studentLevel, applicationLevel };
+}
+
+async function run() {
+  const isDryRun = argv['dry-run'];
+  console.log(`Backfilling grading manager/paid/level fields for project: ${projectId}`);
+  if (isDryRun) {
+    console.log('--- DRY RUN MODE: No changes will be saved ---');
+  }
+
+  const stats = {
+    total: 0,
+    updated: 0,
+    managerIdsFilled: 0,
+    paidFilled: 0,
+    levelSnapshotFilled: 0,
+  };
+
+  const snap = await db.collection('gradings').get();
+  stats.total = snap.size;
+  console.log(`Found ${stats.total} gradings.`);
+
+  let batch = db.batch();
+  let batchCount = 0;
+
+  for (const doc of snap.docs) {
+    const data = doc.data() as Record<string, unknown>;
+    const update: Record<string, unknown> = {};
+
+    // Pass 1: gradingManagerIds <- assistantInstructorIds (copy when missing).
+    if (data.gradingManagerIds === undefined) {
+      update.gradingManagerIds = Array.isArray(data.assistantInstructorIds)
+        ? data.assistantInstructorIds
+        : [];
+      stats.managerIdsFilled++;
+    }
+
+    // Pass 2: paid defaults to true for pre-existing gradings.
+    if (data.paid === undefined) {
+      update.paid = true;
+      stats.paidFilled++;
+    }
+
+    // Pass 3: level snapshot for accepted-or-beyond gradings, when empty.
+    const status = (data.status as string) || '';
+    const level = (data.level as string) || '';
+    const hasSnapshot =
+      !!(data.studentLevelAtAcceptance as string) ||
+      !!(data.applicationLevelAtAcceptance as string);
+    if (ACCEPTED_STATUSES.has(status) && level && !hasSnapshot) {
+      const held = previousGradingLevel(level);
+      const { studentLevel, applicationLevel } = deriveLevels(held);
+      update.studentLevelAtAcceptance = studentLevel;
+      update.applicationLevelAtAcceptance = applicationLevel;
+      stats.levelSnapshotFilled++;
+    }
+
+    if (Object.keys(update).length === 0) continue;
+
+    stats.updated++;
+    console.log(`  Grading ${doc.id}: ${Object.keys(update).join(', ')}`);
+    if (!isDryRun) {
+      batch.update(doc.ref, update);
+      batchCount++;
+      if (batchCount >= 100) {
+        await batch.commit();
+        batch = db.batch();
+        batchCount = 0;
+      }
+    }
+  }
+
+  if (!isDryRun && batchCount > 0) {
+    await batch.commit();
+  }
+
+  console.log('\n--- Summary ---');
+  console.log(`Total gradings:               ${stats.total}`);
+  console.log(`Updated:                      ${stats.updated}`);
+  console.log(`gradingManagerIds filled:     ${stats.managerIdsFilled}`);
+  console.log(`paid filled:                  ${stats.paidFilled}`);
+  console.log(`level snapshot filled:        ${stats.levelSnapshotFilled}`);
+  if (isDryRun) console.log('(dry run — nothing was saved)');
+}
+
+run()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/functions/src/data-model.ts
+++ b/functions/src/data-model.ts
@@ -367,6 +367,34 @@ export enum GradingStatus {
   NotPassed = 'not-passed',
 }
 
+/** How a grading was paid for. A grading only updates the student's level once
+ * it is paid (i.e. not `NotYetPaid`). */
+export enum PaymentStatus {
+  NotYetPaid = 'not-yet-paid',
+  PaidBySquarespace = 'paid-by-squarespace',
+  PaidByCash = 'paid-by-cash',
+  PaidOther = 'paid-other',
+}
+
+/** All payment statuses, for building selectors. */
+export const PAYMENT_STATUSES = Object.values(PaymentStatus);
+
+/** Human-readable labels for each payment status. */
+export const PAYMENT_STATUS_LABELS: Record<PaymentStatus, string> = {
+  [PaymentStatus.NotYetPaid]: 'Not yet paid',
+  [PaymentStatus.PaidBySquarespace]: 'Paid (Squarespace)',
+  [PaymentStatus.PaidByCash]: 'Paid (cash)',
+  [PaymentStatus.PaidOther]: 'Paid (other)',
+};
+
+// Whether a grading counts as paid. Anything other than NotYetPaid is paid;
+// undefined (un-backfilled docs) is treated as paid. Reads tolerate the raw
+// string so it works on docs not run through firestoreDocToGrading (e.g. inside
+// Cloud Function triggers).
+export function isGradingPaid(g: { paymentStatus?: PaymentStatus | string }): boolean {
+  return (g.paymentStatus ?? '') !== PaymentStatus.NotYetPaid;
+}
+
 export function getPrettyGradingStatus(status: GradingStatus): string {
   switch (status) {
     case GradingStatus.AwaitingRequest:
@@ -1117,10 +1145,14 @@ export type Grading = {
   // during the migration window so older clients/rules keep working; will be
   // removed once everything reads/writes `gradingManagerIds`.
   assistantInstructorIds: string[];
-  // Whether the grading has been paid for. Order-created gradings are paid; a
-  // grading only updates the student's level once paid. Editable by grading
-  // managers/instructors/admins (not the student). Undefined is treated as paid.
-  paid: boolean;
+  // How the grading was paid for. Order-created gradings are PaidBySquarespace; a
+  // grading only updates the student's level once paid (anything but NotYetPaid).
+  // Editable by grading managers/instructors/admins (not the student). Undefined
+  // (un-backfilled docs) is treated as paid. See `isGradingPaid`.
+  paymentStatus: PaymentStatus;
+  // Free-form note about payment (e.g. who collected cash, reference). Visible to
+  // managers/instructors/admins only.
+  paymentNote: string;
   // Snapshot of the student's student/application levels at the moment the
   // grading was accepted (status → AwaitingGrading). Lets us show/validate the
   // level the student held going in without re-inferring it from `level`. '' when
@@ -1186,8 +1218,8 @@ export function firestoreDocToGrading(doc: GenericFirestoreDoc): Grading {
   const managerIds = rawData.gradingManagerIds ?? rawData.assistantInstructorIds ?? [];
   grading.gradingManagerIds = managerIds;
   grading.assistantInstructorIds = managerIds;
-  // Undefined `paid` (un-backfilled docs) is treated as paid.
-  grading.paid = rawData.paid ?? true;
+  // Undefined `paymentStatus` (un-backfilled docs) is treated as paid (PaidOther).
+  grading.paymentStatus = rawData.paymentStatus ?? PaymentStatus.PaidOther;
   return grading;
 }
 
@@ -1211,7 +1243,8 @@ export function initGrading(): Grading {
     gradingInstructorId: '',
     gradingManagerIds: [],
     assistantInstructorIds: [],
-    paid: true,
+    paymentStatus: PaymentStatus.PaidOther,
+    paymentNote: '',
     studentLevelAtAcceptance: '',
     applicationLevelAtAcceptance: '',
     schoolId: '',

--- a/functions/src/data-model.ts
+++ b/functions/src/data-model.ts
@@ -1108,11 +1108,25 @@ export type Grading = {
   orderId: string; // The order ID that created this grading, or '' if manual.
   level: string; // The level the grading is aimed for ('Student X' or 'Application X').
   gradingInstructorId: string; // The instructorId (human readable) of the grading instructor.
-  // TODO: Rename this field to `gradingManagerIds` in Firestore and migrate existing data.
-  // In the UI this field is displayed as "Grading Managers". Grading managers have the same
-  // edit permissions as the primary instructor (they can accept, record results, and re-assign
-  // the primary instructor). The Firestore field name `assistantInstructorIds` is legacy.
+  // The instructorIds (human readable) of the grading managers. Grading managers
+  // have the same edit permissions as the primary instructor (they can accept,
+  // record results, and re-assign the primary instructor). In the UI this is
+  // displayed as "Grading Managers".
+  gradingManagerIds: string[];
+  // @deprecated — legacy name for `gradingManagerIds`. Still written in parallel
+  // during the migration window so older clients/rules keep working; will be
+  // removed once everything reads/writes `gradingManagerIds`.
   assistantInstructorIds: string[];
+  // Whether the grading has been paid for. Order-created gradings are paid; a
+  // grading only updates the student's level once paid. Editable by grading
+  // managers/instructors/admins (not the student). Undefined is treated as paid.
+  paid: boolean;
+  // Snapshot of the student's student/application levels at the moment the
+  // grading was accepted (status → AwaitingGrading). Lets us show/validate the
+  // level the student held going in without re-inferring it from `level`. '' when
+  // not yet captured.
+  studentLevelAtAcceptance: string;
+  applicationLevelAtAcceptance: string;
   schoolId: string; // The human-readable schoolId where the grading was conducted. Optional.
   schoolDocId: string; // The Firestore doc ID of the school where the grading was conducted.
   studentMemberId: string; // The human-readable memberId of the student being graded.
@@ -1165,7 +1179,26 @@ export function firestoreDocToGrading(doc: GenericFirestoreDoc): Grading {
       grading.level = 'Student Entry';
     }
   }
+  // Canonical grading-manager list reads from the new field, falling back to the
+  // legacy `assistantInstructorIds` for docs not yet migrated. Keep both in sync
+  // in-memory so existing consumers of either field keep working.
+  const rawData = docData as unknown as Partial<Grading>;
+  const managerIds = rawData.gradingManagerIds ?? rawData.assistantInstructorIds ?? [];
+  grading.gradingManagerIds = managerIds;
+  grading.assistantInstructorIds = managerIds;
+  // Undefined `paid` (un-backfilled docs) is treated as paid.
+  grading.paid = rawData.paid ?? true;
   return grading;
+}
+
+// Read a grading's grading-manager instructorIds, preferring the canonical
+// `gradingManagerIds` and falling back to the legacy `assistantInstructorIds`
+// for docs not yet migrated. Use everywhere the manager list is read so the
+// migration window (both fields written in parallel) stays transparent.
+export function gradingManagerIdsOf(
+  g: { gradingManagerIds?: string[]; assistantInstructorIds?: string[] },
+): string[] {
+  return g.gradingManagerIds ?? g.assistantInstructorIds ?? [];
 }
 
 export function initGrading(): Grading {
@@ -1176,7 +1209,11 @@ export function initGrading(): Grading {
     orderId: '',
     level: '',
     gradingInstructorId: '',
+    gradingManagerIds: [],
     assistantInstructorIds: [],
+    paid: true,
+    studentLevelAtAcceptance: '',
+    applicationLevelAtAcceptance: '',
     schoolId: '',
     schoolDocId: '',
     studentMemberId: '',

--- a/functions/src/on-grading-update.ts
+++ b/functions/src/on-grading-update.ts
@@ -9,7 +9,7 @@ import * as admin from 'firebase-admin';
 // which crashes trigger writes that use serverTimestamp()/arrayUnion(). The
 // named import works in both the emulator and production.
 import { FieldValue } from 'firebase-admin/firestore';
-import { Grading, GradingStatus, StudentLevel, NotificationKind, MemberNotification } from './data-model';
+import { Grading, GradingStatus, StudentLevel, NotificationKind, MemberNotification, gradingManagerIdsOf } from './data-model';
 import { canonicalizeGradingLevel, extractLevelValue } from './level-utils';
 import { createMemberNotification } from './notifications';
 import * as logger from 'firebase-functions/logger';
@@ -280,7 +280,7 @@ async function mirrorGradingToAllInstructors(
   const primaryInstructor = await getPrimaryInstructorId(grading.studentMemberDocId);
   const instructorIds = new Set([
     grading.gradingInstructorId,
-    ...grading.assistantInstructorIds,
+    ...gradingManagerIdsOf(grading),
     primaryInstructor
   ].filter((id) => id && id !== '') as string[]);
 
@@ -299,7 +299,7 @@ async function removeGradingFromAllInstructors(
   const primaryInstructor = await getPrimaryInstructorId(grading.studentMemberDocId);
   const instructorIds = new Set([
     grading.gradingInstructorId,
-    ...grading.assistantInstructorIds,
+    ...gradingManagerIdsOf(grading),
     primaryInstructor
   ].filter((id) => id && id !== '') as string[]);
 
@@ -504,12 +504,12 @@ export const onGradingUpdated = onDocumentUpdated(
     const currentPrimaryInstructor = await getPrimaryInstructorId(grading.studentMemberDocId);
 
     const previousInstructorIds = new Set(
-      [previous.gradingInstructorId, ...previous.assistantInstructorIds, previousPrimaryInstructor].filter(
+      [previous.gradingInstructorId, ...gradingManagerIdsOf(previous), previousPrimaryInstructor].filter(
         (id) => id && id !== '',
       ) as string[],
     );
     const currentInstructorIds = new Set(
-      [grading.gradingInstructorId, ...grading.assistantInstructorIds, currentPrimaryInstructor].filter(
+      [grading.gradingInstructorId, ...gradingManagerIdsOf(grading), currentPrimaryInstructor].filter(
         (id) => id && id !== '',
       ) as string[],
     );
@@ -527,12 +527,12 @@ export const onGradingUpdated = onDocumentUpdated(
 
     // Selected instructors notifications and de-duplication (excluding student's primary instructor)
     const previousSelected = new Set(
-      [previous.gradingInstructorId, ...(previous.assistantInstructorIds || [])].filter(
+      [previous.gradingInstructorId, ...gradingManagerIdsOf(previous)].filter(
         (id) => id && id !== '',
       ) as string[],
     );
     const currentSelected = new Set(
-      [grading.gradingInstructorId, ...(grading.assistantInstructorIds || [])].filter(
+      [grading.gradingInstructorId, ...gradingManagerIdsOf(grading)].filter(
         (id) => id && id !== '',
       ) as string[],
     );
@@ -938,7 +938,7 @@ async function annotateManagerNotificationsWithAcceptor(
   const managerDocIds = new Set<string>();
   const event = await resolveEventManagers(grading.gradingEventDocId);
   for (const id of event.docIds) managerDocIds.add(id);
-  const instructorIds = [grading.gradingInstructorId, ...(grading.assistantInstructorIds || [])].filter(
+  const instructorIds = [grading.gradingInstructorId, ...gradingManagerIdsOf(grading)].filter(
     (id) => id && id !== '',
   ) as string[];
   for (const instructorId of instructorIds) {
@@ -1002,7 +1002,7 @@ export const onGradingDeleted = onDocumentDeleted(
     // Cancel and dismiss the instructors' grading notifications
     const instructorIds = new Set([
       grading.gradingInstructorId,
-      ...grading.assistantInstructorIds,
+      ...gradingManagerIdsOf(grading),
     ].filter((id) => id && id !== '') as string[]);
 
     for (const id of instructorIds) {

--- a/functions/src/on-member-update.ts
+++ b/functions/src/on-member-update.ts
@@ -10,7 +10,7 @@ import * as admin from 'firebase-admin';
 // named import works in both the emulator and production. (Same fix as
 // on-grading-update.ts.)
 import { FieldValue } from 'firebase-admin/firestore';
-import { Member, ACL, Grading } from './data-model';
+import { Member, ACL, Grading, gradingManagerIdsOf } from './data-model';
 import { mirrorGradingToInstructor, removeGradingFromInstructor } from './on-grading-update';
 import { updateMemberViewForSchoolAndInstrucor } from './mirror-members-to-school-and-instructor-views';
 import { updateInstructorPublicProfile } from './mirror-instructors-to-public-profile';
@@ -226,7 +226,7 @@ async function mirrorGradingsForSifuChange(
 
   for (const grading of gradings) {
     if (previousSifu) {
-      const assessors = [grading.gradingInstructorId, ...grading.assistantInstructorIds];
+      const assessors = [grading.gradingInstructorId, ...gradingManagerIdsOf(grading)];
       if (!assessors.includes(previousSifu)) {
         await removeGradingFromInstructor(grading.docId, previousSifu);
       }

--- a/src/app/grading-edit/grading-edit.ts
+++ b/src/app/grading-edit/grading-edit.ts
@@ -21,6 +21,7 @@ import {
   InstructorPublicData,
   School,
   IlcEvent,
+  gradingManagerIdsOf,
 } from '../../../functions/src/data-model';
 import {
   form,
@@ -191,15 +192,15 @@ export class GradingEditComponent {
   });
 
   // Returns true for the primary instructor, grading managers (stored in
-  // `assistantInstructorIds` — TODO: rename field to `gradingManagerIds` after data migration),
-  // and the organizer/managers of a linked event. All share the same edit permissions.
+  // `gradingManagerIds`, legacy fallback `assistantInstructorIds`), and the
+  // organizer/managers of a linked event. All share the same edit permissions.
   userIsGradingInstructor = computed(() => {
     const user = this.firebaseState.user();
     if (!user) return false;
     if (this.userIsEventManager()) return true;
     const grading = this.editableGrading();
     return user.member.instructorId === grading.gradingInstructorId ||
-      (grading.assistantInstructorIds || []).includes(user.member.instructorId);
+      gradingManagerIdsOf(grading).includes(user.member.instructorId);
   });
 
   userIsStudent = computed(() => {
@@ -346,6 +347,9 @@ export class GradingEditComponent {
         orderId: this.form.orderId().value(),
         level: this.form.level().value(),
         gradingInstructorId: this.form.gradingInstructorId().value(),
+        // Write both the canonical `gradingManagerIds` and the legacy
+        // `assistantInstructorIds` during the migration window.
+        gradingManagerIds: this.form.assistantInstructorIds().value(),
         assistantInstructorIds: this.form.assistantInstructorIds().value(),
         schoolId: this.form.schoolId().value(),
         studentMemberId: this.form.studentMemberId().value(),

--- a/src/app/grading-list/grading-list.ts
+++ b/src/app/grading-list/grading-list.ts
@@ -7,7 +7,7 @@ import {
   signal,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { Grading, GradingStatus, IlcEvent, getPrettyGradingStatus, initGrading } from '../../../functions/src/data-model';
+import { Grading, GradingStatus, IlcEvent, getPrettyGradingStatus, initGrading, gradingManagerIdsOf } from '../../../functions/src/data-model';
 import { SearchableSet } from '../searchable-set';
 import { GradingEditComponent } from '../grading-edit/grading-edit';
 import { GradingRowHeaderComponent } from '../grading-row-header/grading-row-header';
@@ -140,7 +140,7 @@ export class GradingListComponent {
         // Include the senior grading instructor plus any assistant instructors
         // so searching for any examiner's name surfaces the grading. The primary
         // instructor's cached name is supplied as a fallback for non-admin views.
-        instructorSearchText: [g.gradingInstructorId, ...g.assistantInstructorIds]
+        instructorSearchText: [g.gradingInstructorId, ...gradingManagerIdsOf(g)]
           .map((id) =>
             this.dataService.instructorDisplayName(
               id,
@@ -231,7 +231,7 @@ export class GradingListComponent {
 
     const myInstructorId = user.member.instructorId;
     return all.filter(g => {
-      const isAssessor = g.gradingInstructorId === myInstructorId || g.assistantInstructorIds.includes(myInstructorId);
+      const isAssessor = g.gradingInstructorId === myInstructorId || gradingManagerIdsOf(g).includes(myInstructorId);
       if (this.instructorTab() === 'examined') {
         return isAssessor;
       } else {
@@ -260,7 +260,7 @@ export class GradingListComponent {
       // one of the grading managers (assistant instructors).
       results = results.filter(g =>
         g.gradingInstructorId === instructorId ||
-        g.assistantInstructorIds.includes(instructorId),
+        gradingManagerIdsOf(g).includes(instructorId),
       );
     }
     if (status) {
@@ -387,7 +387,7 @@ export class GradingListComponent {
     if (!user || !user.member.instructorId) return false;
     const myInstructorId = user.member.instructorId;
     return grading.gradingInstructorId !== myInstructorId &&
-      !grading.assistantInstructorIds.includes(myInstructorId);
+      !gradingManagerIdsOf(grading).includes(myInstructorId);
   }
 
   showAll() {

--- a/src/app/grading-progress/grading-progress.spec.ts
+++ b/src/app/grading-progress/grading-progress.spec.ts
@@ -354,7 +354,7 @@ describe('GradingProgressComponent', () => {
 
     componentRef.setInput('grading', {
       ...initGrading(),
-      assistantInstructorIds: ['assistant-1', 'assistant-2'],
+      gradingManagerIds: ['assistant-1', 'assistant-2'],
     });
     fixture.detectChanges();
 

--- a/src/app/grading-progress/grading-progress.ts
+++ b/src/app/grading-progress/grading-progress.ts
@@ -34,6 +34,7 @@ import {
   nextGradingLevel,
   previousGradingLevel,
   instructorCanAssessLevel,
+  gradingManagerIdsOf,
 } from '../../../functions/src/data-model';
 import { IconComponent } from '../icons/icon.component';
 import { DataManagerService } from '../data-manager.service';
@@ -98,15 +99,16 @@ export class GradingProgressComponent implements OnDestroy {
   });
 
   // Returns true for the primary instructor, for grading managers (stored in
-  // `assistantInstructorIds` — TODO: rename field to `gradingManagerIds` after data migration),
-  // and for the organizer/managers of a linked event. All share the same edit permissions.
+  // `gradingManagerIds`, with legacy fallback to `assistantInstructorIds`), and
+  // for the organizer/managers of a linked event. All share the same edit
+  // permissions.
   userIsGradingInstructor = computed(() => {
     const user = this.firebaseState.user();
     if (!user) return false;
     if (this.userIsEventManager()) return true;
     if (!user.member.instructorId) return false;
     return user.member.instructorId === this.grading().gradingInstructorId ||
-      (this.grading().assistantInstructorIds || []).includes(user.member.instructorId);
+      gradingManagerIdsOf(this.grading()).includes(user.member.instructorId);
   });
 
   // Can the current user record a result?
@@ -227,10 +229,10 @@ export class GradingProgressComponent implements OnDestroy {
     ),
   );
 
-  // Grading managers — displayed as "Grading Managers" in the UI.
-  // Backed by the legacy Firestore field `assistantInstructorIds`.
+  // Grading managers — displayed as "Grading Managers" in the UI. Backed by
+  // `gradingManagerIds` (legacy fallback to `assistantInstructorIds`).
   gradingManagers = computed<Array<{ id: string; data: InstructorPublicData | null }>>(() => {
-    const ids = this.grading().assistantInstructorIds || [];
+    const ids = gradingManagerIdsOf(this.grading());
     return ids.map((id) => ({
       id,
       data: this.dataService.instructors.get(id) ?? null,
@@ -259,7 +261,7 @@ export class GradingProgressComponent implements OnDestroy {
   protected editGradingEvent = signal('');
   protected editGradingEventDate = signal('');
   protected editGradingEventDocId = signal('');
-  // Local edit signal for grading managers (backed by `assistantInstructorIds`).
+  // Local edit signal for grading managers (backed by `gradingManagerIds`).
   protected editGradingManagerIds = signal<string[]>([]);
   protected editResultNotes = signal('');
   protected editDeclineNotes = signal('');
@@ -280,10 +282,18 @@ export class GradingProgressComponent implements OnDestroy {
     this.editGradingEvent.set(g.gradingEvent);
     this.editGradingEventDate.set(g.gradingEventDate);
     this.editGradingEventDocId.set(g.gradingEventDocId);
-    this.editGradingManagerIds.set(g.assistantInstructorIds || []);
+    this.editGradingManagerIds.set(gradingManagerIdsOf(g));
     this.editResultNotes.set(g.resultNotes);
     this.editDeclineNotes.set(g.declineNotes || '');
   });
+
+  // The manager-id update written on save: both the canonical `gradingManagerIds`
+  // and the legacy `assistantInstructorIds`, kept in sync during the migration
+  // window so older clients/rules keep working.
+  private managerIdsUpdate(): Partial<Grading> {
+    const ids = this.editGradingManagerIds().filter((id) => id !== '');
+    return { gradingManagerIds: ids, assistantInstructorIds: ids };
+  }
 
   isDirty = computed(() => {
     const g = this.grading();
@@ -292,7 +302,7 @@ export class GradingProgressComponent implements OnDestroy {
       this.editGradingEventDate() !== g.gradingEventDate ||
       this.editResultNotes() !== g.resultNotes ||
       this.editInstructorId() !== g.gradingInstructorId ||
-      JSON.stringify(this.editGradingManagerIds()) !== JSON.stringify(g.assistantInstructorIds || [])
+      JSON.stringify(this.editGradingManagerIds()) !== JSON.stringify(gradingManagerIdsOf(g))
     );
   });
 
@@ -338,7 +348,7 @@ export class GradingProgressComponent implements OnDestroy {
         gradingEventDate: this.editGradingEventDate(),
         resultNotes: this.editResultNotes(),
         gradingInstructorId: this.editInstructorId(),
-        assistantInstructorIds: this.editGradingManagerIds().filter(id => id !== ''),
+        ...this.managerIdsUpdate(),
       };
       this.gradingUpdated.emit(update);
       this.saveStatus.set('saved');
@@ -365,7 +375,7 @@ export class GradingProgressComponent implements OnDestroy {
         gradingEventDate: this.editGradingEventDate(),
         resultNotes: this.editResultNotes(),
         gradingInstructorId: this.editInstructorId(),
-        assistantInstructorIds: this.editGradingManagerIds().filter(id => id !== ''),
+        ...this.managerIdsUpdate(),
       };
       this.gradingUpdated.emit(update);
     }
@@ -434,13 +444,13 @@ export class GradingProgressComponent implements OnDestroy {
 
   saveManagers() {
     this.gradingUpdated.emit({
-      assistantInstructorIds: this.editGradingManagerIds().filter(id => id !== ''),
+      ...this.managerIdsUpdate(),
     });
     this.isEditingManagers.set(false);
   }
 
   cancelManagerEdit() {
-    this.editGradingManagerIds.set(this.grading().assistantInstructorIds || []);
+    this.editGradingManagerIds.set(gradingManagerIdsOf(this.grading()));
     this.isEditingManagers.set(false);
   }
 
@@ -536,7 +546,7 @@ export class GradingProgressComponent implements OnDestroy {
       gradingEventDate: this.editGradingEventDate() || new Date().toISOString().split('T')[0],
       resultNotes: this.editResultNotes(),
       gradingInstructorId: this.editInstructorId(),
-      assistantInstructorIds: this.editGradingManagerIds().filter(id => id !== ''),
+      ...this.managerIdsUpdate(),
       ...this.statusActorFields(),
     };
     this.gradingUpdated.emit(update);

--- a/tests/firestore.rules.spec.ts
+++ b/tests/firestore.rules.spec.ts
@@ -831,25 +831,26 @@ describe('Firestore Rules', () => {
       );
     });
 
-    it('should allow a grading manager to mark the grading paid', async () => {
+    it('should allow a grading manager to update the payment status', async () => {
       const db = testEnv
         .authenticatedContext('instructor1', { email: 'instructor1@ilc.com' })
         .firestore();
       await assertSucceeds(
         db.collection('gradings').doc('grading-1').update({
-          paid: false,
+          paymentStatus: 'not-yet-paid',
+          paymentNote: 'awaiting bank transfer',
           lastUpdated: serverTimestamp(),
         }),
       );
     });
 
-    it('should deny a student from updating the paid field', async () => {
+    it('should deny a student from updating the payment status', async () => {
       const db = testEnv
         .authenticatedContext('student1', { email: 'student1@ilc.com' })
         .firestore();
       await assertFails(
         db.collection('gradings').doc('grading-1').update({
-          paid: false,
+          paymentStatus: 'not-yet-paid',
           lastUpdated: serverTimestamp(),
         }),
       );

--- a/tests/firestore.rules.spec.ts
+++ b/tests/firestore.rules.spec.ts
@@ -812,6 +812,49 @@ describe('Firestore Rules', () => {
       );
     });
 
+    it('should allow a grading manager listed in gradingManagerIds to update', async () => {
+      await testEnv.withSecurityRulesDisabled(async (context) => {
+        await context
+          .firestore()
+          .collection('gradings')
+          .doc('grading-1')
+          .update({ gradingManagerIds: ['INST-002'] });
+      });
+      const db = testEnv
+        .authenticatedContext('instructor2', { email: 'instructor2@ilc.com' })
+        .firestore();
+      await assertSucceeds(
+        db.collection('gradings').doc('grading-1').update({
+          resultNotes: 'Well done',
+          lastUpdated: serverTimestamp(),
+        }),
+      );
+    });
+
+    it('should allow a grading manager to mark the grading paid', async () => {
+      const db = testEnv
+        .authenticatedContext('instructor1', { email: 'instructor1@ilc.com' })
+        .firestore();
+      await assertSucceeds(
+        db.collection('gradings').doc('grading-1').update({
+          paid: false,
+          lastUpdated: serverTimestamp(),
+        }),
+      );
+    });
+
+    it('should deny a student from updating the paid field', async () => {
+      const db = testEnv
+        .authenticatedContext('student1', { email: 'student1@ilc.com' })
+        .firestore();
+      await assertFails(
+        db.collection('gradings').doc('grading-1').update({
+          paid: false,
+          lastUpdated: serverTimestamp(),
+        }),
+      );
+    });
+
     it('should deny instructor from updating admin-only field orderId', async () => {
       const db = testEnv
         .authenticatedContext('instructor1', { email: 'instructor1@ilc.com' })

--- a/tests/fixtures/seed/gradings.json
+++ b/tests/fixtures/seed/gradings.json
@@ -21,7 +21,10 @@
     "acceptedByName": "",
     "acceptedByMemberDocId": "",
     "statusChangedByMemberDocId": "",
-    "statusChangedByName": ""
+    "statusChangedByName": "",
+    "gradingManagerIds": [],
+    "paymentStatus": "paid-by-squarespace",
+    "paymentNote": ""
   },
   {
     "id": "9AWaK6eFs93FyofOs3RC",
@@ -45,7 +48,10 @@
     "acceptedByName": "",
     "acceptedByMemberDocId": "",
     "statusChangedByMemberDocId": "",
-    "statusChangedByName": ""
+    "statusChangedByName": "",
+    "gradingManagerIds": [],
+    "paymentStatus": "paid-by-squarespace",
+    "paymentNote": ""
   },
   {
     "id": "HRBIl9HBLgdcYVYIAgRr",
@@ -70,7 +76,10 @@
     "acceptedByName": "",
     "acceptedByMemberDocId": "",
     "statusChangedByMemberDocId": "",
-    "statusChangedByName": ""
+    "statusChangedByName": "",
+    "gradingManagerIds": [],
+    "paymentStatus": "paid-other",
+    "paymentNote": ""
   },
   {
     "id": "KQDAAl9qmkSeSEondU7g",
@@ -95,7 +104,10 @@
     "acceptedByName": "",
     "acceptedByMemberDocId": "",
     "statusChangedByMemberDocId": "",
-    "statusChangedByName": ""
+    "statusChangedByName": "",
+    "gradingManagerIds": [],
+    "paymentStatus": "paid-by-squarespace",
+    "paymentNote": ""
   },
   {
     "id": "OlejiNccU91MaJe4Ifqm",
@@ -127,7 +139,14 @@
     "acceptedByName": "",
     "acceptedByMemberDocId": "",
     "statusChangedByMemberDocId": "",
-    "statusChangedByName": ""
+    "statusChangedByName": "",
+    "gradingManagerIds": [
+      "213"
+    ],
+    "paymentStatus": "paid-by-squarespace",
+    "paymentNote": "",
+    "studentLevelAtAcceptance": "3",
+    "applicationLevelAtAcceptance": ""
   },
   {
     "id": "XPvEeY7NCwtVy4147L7D",
@@ -151,7 +170,10 @@
     "acceptedByName": "",
     "acceptedByMemberDocId": "",
     "statusChangedByMemberDocId": "",
-    "statusChangedByName": ""
+    "statusChangedByName": "",
+    "gradingManagerIds": [],
+    "paymentStatus": "paid-by-squarespace",
+    "paymentNote": ""
   },
   {
     "id": "iNQ4Xl2BBFHK7L2LMrFV",
@@ -178,7 +200,10 @@
     "acceptedByName": "",
     "acceptedByMemberDocId": "",
     "statusChangedByMemberDocId": "",
-    "statusChangedByName": ""
+    "statusChangedByName": "",
+    "gradingManagerIds": [],
+    "paymentStatus": "paid-other",
+    "paymentNote": ""
   },
   {
     "id": "jeEZYXKlrlgf403b4XVR",
@@ -202,7 +227,10 @@
     "acceptedByName": "",
     "acceptedByMemberDocId": "",
     "statusChangedByMemberDocId": "",
-    "statusChangedByName": ""
+    "statusChangedByName": "",
+    "gradingManagerIds": [],
+    "paymentStatus": "paid-by-squarespace",
+    "paymentNote": ""
   },
   {
     "id": "vWNsQo11j4O0aoX8ZJ0C",
@@ -224,6 +252,11 @@
     "acceptedByName": "",
     "acceptedByMemberDocId": "",
     "statusChangedByMemberDocId": "",
-    "statusChangedByName": ""
+    "statusChangedByName": "",
+    "gradingManagerIds": [],
+    "paymentStatus": "paid-other",
+    "paymentNote": "",
+    "studentLevelAtAcceptance": "5",
+    "applicationLevelAtAcceptance": "2"
   }
 ]


### PR DESCRIPTION
**PR 1 of 6** in the grading-system refinement series. Schema foundation only — adds fields and migrates data, no user-facing behaviour change yet.

## What
- **`gradingManagerIds`** — canonical replacement for the legacy `assistantInstructorIds` (which is kept and written in parallel during the migration window; removed in the final cleanup PR). New `gradingManagerIdsOf()` helper reads the new field with legacy fallback; `firestoreDocToGrading` keeps both in sync in-memory.
- **`paid`** — whether the grading has been paid for. Defaults to `true`; undefined is read as paid (so existing docs aren't shown as unpaid). Order-created gradings will be written `paid=true` (PR 2). A grading will only update the student's level once paid (PR 2).
- **`studentLevelAtAcceptance` / `applicationLevelAtAcceptance`** — snapshot of the student's levels when a grading is accepted, so we stop re-inferring from the graded level. Captured by the trigger going forward (PR 2); best-effort inferred for historical docs by the backfill.

## Changes
- `functions/src/data-model.ts`: new fields + `gradingManagerIdsOf()`.
- All manager-list read sites (triggers, `on-member-update`, grading list filters, progress/edit components) read via the new field; saves write both fields.
- `firestore.rules`: `isGradingManager()` checks both fields; new fields added to the manager/admin write allowlist (`paid` **not** writable by students).
- `functions/scripts/data-migrations/backfill-grading-managers-paid-level.ts`: idempotent 3-pass backfill (copy manager ids, set `paid=true`, infer level snapshot for accepted gradings). Wired as `pnpm run backfill-grading-managers-paid-level`.
- Rules tests for `gradingManagerIds`-based manager updates and `paid` write permissions.

## Verification
- `pnpm test:functions` → 201 pass
- `pnpm test:once` (frontend) → 379 pass
- `pnpm test:rules` → 95 pass (3 new)
- Backfill runs cleanly against the emulator with `--dry-run`.

> Note: run `pnpm --prefix functions run backfill-grading-managers-paid-level --project <prod> --dry-run` and review counts before applying for real (after deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)