### PR TITLE
feat(gradings): payment gating, level snapshot at acceptance, sifu-on-request (PR 2/6)

### DIFF
--- a/functions/scripts/data-migrations/backfill-grading-managers-paid-level.ts
+++ b/functions/scripts/data-migrations/backfill-grading-managers-paid-level.ts
@@ -141,13 +141,18 @@ async function run() {
     }
 
     // Pass 3: level snapshot for accepted-or-beyond gradings, when empty.
+    // Gate on the *source* (a previous level exists) rather than only on the
+    // snapshot being empty: gradings for the first progression entry ('Student
+    // Entry') legitimately derive an empty snapshot, so a plain !hasSnapshot
+    // check would re-write them every run. Skipping when `held` is empty keeps
+    // the script idempotent (those gradings keep the default '' snapshot).
     const status = (data.status as string) || '';
     const level = (data.level as string) || '';
     const hasSnapshot =
       !!(data.studentLevelAtAcceptance as string) ||
       !!(data.applicationLevelAtAcceptance as string);
-    if (ACCEPTED_STATUSES.has(status) && level && !hasSnapshot) {
-      const held = previousGradingLevel(level);
+    const held = level ? previousGradingLevel(level) : '';
+    if (ACCEPTED_STATUSES.has(status) && held && !hasSnapshot) {
       const { studentLevel, applicationLevel } = deriveLevels(held);
       update.studentLevelAtAcceptance = studentLevel;
       update.applicationLevelAtAcceptance = applicationLevel;

--- a/functions/src/on-grading-update.ts
+++ b/functions/src/on-grading-update.ts
@@ -9,7 +9,7 @@ import * as admin from 'firebase-admin';
 // which crashes trigger writes that use serverTimestamp()/arrayUnion(). The
 // named import works in both the emulator and production.
 import { FieldValue } from 'firebase-admin/firestore';
-import { Grading, GradingStatus, StudentLevel, NotificationKind, MemberNotification, gradingManagerIdsOf } from './data-model';
+import { Grading, GradingStatus, StudentLevel, NotificationKind, MemberNotification, gradingManagerIdsOf, isGradingPaid } from './data-model';
 import { canonicalizeGradingLevel, extractLevelValue } from './level-utils';
 import { createMemberNotification } from './notifications';
 import * as logger from 'firebase-functions/logger';
@@ -438,6 +438,36 @@ export const onGradingCreated = onDocumentCreated(
           }
         );
       }
+
+      // Also notify the student's primary instructor (sifu), unless they are the
+      // selected grading instructor (already notified above).
+      const primaryInstructorId = await getPrimaryInstructorId(grading.studentMemberDocId);
+      if (primaryInstructorId && primaryInstructorId !== grading.gradingInstructorId) {
+        const sifu = await resolvePrimaryInstructorToNotify(
+          grading,
+          grading.statusChangedByMemberDocId,
+        );
+        if (sifu) {
+          const gradingHref = `#/gradings/${gradingDocId}`;
+          const instructorName = await getMemberName(
+            await findInstructorMemberDocId(grading.gradingInstructorId),
+            'another instructor',
+          );
+          await createNotification(sifu.sifuMemberDocId, {
+            markdown:
+              `Your student **${sifu.studentName}** has requested a grading for **${grading.level}** ` +
+              `from **${instructorName}**. [Open the grading](${gradingHref}).`,
+            createdAt: new Date().toISOString(),
+            dismissed: false,
+            kind: NotificationKind.GradingRequestsYouAsInstructor,
+            data: {
+              gradingDocId,
+              studentName: sifu.studentName,
+              level: grading.level,
+            },
+          });
+        }
+      }
     }
 
     // If the grading is created already linked to an event, notify the event's
@@ -548,7 +578,7 @@ export const onGradingUpdated = onDocumentUpdated(
         const instructorMemberDocId = await findInstructorMemberDocId(id);
         if (instructorMemberDocId) {
           const isMain = grading.gradingInstructorId === id;
-          const role = isMain ? 'main instructor' : 'assistant instructor';
+          const role = isMain ? 'grading instructor' : 'grading manager';
           const msg = `You have been assigned as the **${role}** to grade **${studentName}** for **${grading.level}**.`;
           await createNotification(
             instructorMemberDocId,
@@ -570,7 +600,7 @@ export const onGradingUpdated = onDocumentUpdated(
       for (const id of removedSelected) {
         const instructorMemberDocId = await findInstructorMemberDocId(id);
         if (instructorMemberDocId) {
-          const msg = `You have been removed as an instructor for **${studentName}**'s grading for **${grading.level}**.`;
+          const msg = `You have been removed as a grading manager for **${studentName}**'s grading for **${grading.level}**.`;
           await createNotification(
             instructorMemberDocId,
             {
@@ -597,10 +627,19 @@ export const onGradingUpdated = onDocumentUpdated(
       await mirrorGradingToSchool(gradingDocId, grading, grading.schoolId);
     }
 
-    // If status changed to 'passed', update the student's studentLevel
+    // Update the student's level once a grading is BOTH passed and paid. This
+    // fires when the grading just became passed (and is already paid) or when an
+    // already-passed grading is later marked paid — so an unpaid pass does not
+    // promote the student until payment is recorded.
+    const isPaid = isGradingPaid(grading);
+    const becamePassed =
+      grading.status === GradingStatus.Passed && previous.status !== GradingStatus.Passed;
+    const becamePaidWhilePassed =
+      grading.status === GradingStatus.Passed && isPaid && !isGradingPaid(previous);
     if (
       grading.status === GradingStatus.Passed &&
-      previous.status !== GradingStatus.Passed &&
+      isPaid &&
+      (becamePassed || becamePaidWhilePassed) &&
       grading.studentMemberId &&
       grading.level !== StudentLevel.None
     ) {
@@ -635,6 +674,11 @@ export const onGradingUpdated = onDocumentUpdated(
           `Could not find student with memberId ${grading.studentMemberId} to update level.`,
         );
       }
+    } else if (becamePassed && !isPaid) {
+      logger.info(
+        `Grading ${gradingDocId} passed but not paid (status ${grading.paymentStatus}); ` +
+          `student ${grading.studentMemberId} level NOT updated until payment is recorded.`,
+      );
     }
 
     // Notify the student when their grading result is recorded.
@@ -875,6 +919,44 @@ export const onGradingUpdated = onDocumentUpdated(
       }
     }
 
+    // Notify the student's primary instructor (sifu) when their student makes a
+    // grading request — only on a fresh request (not reassignment), and not when
+    // the sifu is the selected grading instructor (they already get the request
+    // notification above). story: docs/user-stories/grading-sifu-notifications.md
+    if (
+      grading.status === GradingStatus.AwaitingAcceptance &&
+      previous.status !== GradingStatus.AwaitingAcceptance &&
+      grading.gradingInstructorId
+    ) {
+      const primaryInstructorId = await getPrimaryInstructorId(grading.studentMemberDocId);
+      if (primaryInstructorId && primaryInstructorId !== grading.gradingInstructorId) {
+        const sifu = await resolvePrimaryInstructorToNotify(
+          grading,
+          grading.statusChangedByMemberDocId,
+        );
+        if (sifu) {
+          const gradingHref = `#/gradings/${gradingDocId}`;
+          const instructorName = await getMemberName(
+            await findInstructorMemberDocId(grading.gradingInstructorId),
+            'another instructor',
+          );
+          await createNotification(sifu.sifuMemberDocId, {
+            markdown:
+              `Your student **${sifu.studentName}** has requested a grading for **${grading.level}** ` +
+              `from **${instructorName}**. [Open the grading](${gradingHref}).`,
+            createdAt: new Date().toISOString(),
+            dismissed: false,
+            kind: NotificationKind.GradingRequestsYouAsInstructor,
+            data: {
+              gradingDocId,
+              studentName: sifu.studentName,
+              level: grading.level,
+            },
+          });
+        }
+      }
+    }
+
     // Handle event-link change: notify event organizers/managers that they have
     // gained or lost grading-manager status. Status is derived live from the
     // link (no cached field), so we only need to notify on the transition.
@@ -903,17 +985,48 @@ export const onGradingUpdated = onDocumentUpdated(
       await annotateManagerNotificationsWithAcceptor(grading, gradingDocId);
     }
 
-    // Write the refreshed cached names back to the source grading if they
-    // changed. Skipping the write when unchanged stops the trigger re-firing in
-    // a loop.
-    if (
-      storedStudentName !== grading.studentName ||
-      storedInstructorName !== grading.gradingInstructorName
-    ) {
-      await snap.after.ref.update({
-        studentName: grading.studentName,
-        gradingInstructorName: grading.gradingInstructorName,
-      });
+    // Capture the student's level snapshot when the grading is accepted (moves
+    // to AwaitingGrading), if not already captured. This is the authoritative
+    // record of the level the student held going in, so we no longer infer it
+    // from `grading.level`.
+    const acceptedNow =
+      grading.status === GradingStatus.AwaitingGrading &&
+      previous.status !== GradingStatus.AwaitingGrading;
+    const snapshotMissing =
+      !grading.studentLevelAtAcceptance && !grading.applicationLevelAtAcceptance;
+    let snapshotUpdate:
+      | { studentLevelAtAcceptance: string; applicationLevelAtAcceptance: string }
+      | undefined;
+    if (acceptedNow && snapshotMissing && grading.studentMemberDocId) {
+      const studentSnap = await db
+        .collection('members')
+        .doc(grading.studentMemberDocId)
+        .get();
+      if (studentSnap.exists) {
+        const d = studentSnap.data() || {};
+        snapshotUpdate = {
+          studentLevelAtAcceptance: (d.studentLevel as string) || '',
+          applicationLevelAtAcceptance: (d.applicationLevel as string) || '',
+        };
+      }
+    }
+
+    // Write the refreshed cached names (and any acceptance level snapshot) back
+    // to the source grading. Skipping the write when nothing changed stops the
+    // trigger re-firing in a loop.
+    const writeBack: Record<string, unknown> = {};
+    if (storedStudentName !== grading.studentName) {
+      writeBack.studentName = grading.studentName;
+    }
+    if (storedInstructorName !== grading.gradingInstructorName) {
+      writeBack.gradingInstructorName = grading.gradingInstructorName;
+    }
+    if (snapshotUpdate) {
+      writeBack.studentLevelAtAcceptance = snapshotUpdate.studentLevelAtAcceptance;
+      writeBack.applicationLevelAtAcceptance = snapshotUpdate.applicationLevelAtAcceptance;
+    }
+    if (Object.keys(writeBack).length > 0) {
+      await snap.after.ref.update(writeBack);
     }
 
     logger.info(`Grading ${gradingDocId} updated and re-mirrored.`);

--- a/functions/src/squarespace-orders/grading.spec.ts
+++ b/functions/src/squarespace-orders/grading.spec.ts
@@ -74,6 +74,8 @@ describe('parseGradingOrderInfo', () => {
         level: 'Student 7',
         gradingInstructorId: '1',
         assistantInstructorIds: [],
+        gradingManagerIds: [],
+        paymentStatus: 'paid-by-squarespace',
         schoolId: '',
         schoolDocId: '',
         studentMemberId: 'US402',

--- a/functions/src/squarespace-orders/grading.ts
+++ b/functions/src/squarespace-orders/grading.ts
@@ -7,7 +7,7 @@ through Squarespace.
 
 import * as admin from 'firebase-admin';
 import * as logger from 'firebase-functions/logger';
-import { Member, Grading, GradingStatus, initGrading, SquareSpaceOrder, SquareSpaceLineItem, SquareSpaceCustomization } from '../data-model';
+import { Member, Grading, GradingStatus, PaymentStatus, initGrading, SquareSpaceOrder, SquareSpaceLineItem, SquareSpaceCustomization } from '../data-model';
 import { canonicalizeGradingLevel, canonicalizeStudentLevel, canonicalizeApplicationLevel } from '../level-utils';
 import { GradingResult } from './common';
 import { inferMemberIdFromOrder } from './infer-member';
@@ -73,6 +73,10 @@ export function parseGradingOrderInfo(
     currentApplicationLevel: canonicalizeApplicationLevel(currentApplicationLevel),
     gradingInfo: {
       ...initGrading(),
+      // Purchased through Squarespace, so it is paid. The student's level
+      // snapshot is captured authoritatively by the grading trigger at
+      // acceptance (from the member record), not seeded from the order form.
+      paymentStatus: PaymentStatus.PaidBySquarespace,
       status: providedMemberId ? GradingStatus.AwaitingRequest : GradingStatus.RequiresReview,
       reviewIssue: providedMemberId ? '' : 'Missing member ID in order customizations.',
       gradingPurchaseDate: purchaseDate,

--- a/tests/e2e/grading-paid-and-snapshot.spec.ts
+++ b/tests/e2e/grading-paid-and-snapshot.spec.ts
@@ -1,0 +1,217 @@
+/*
+ * Emulator-driven e2e tests for the PR2 grading-trigger behaviours:
+ *   - the student's level is only updated once a grading is BOTH passed and paid
+ *     (an unpaid pass does not promote them; later marking it paid does);
+ *   - the student's level snapshot is captured from the member record when the
+ *     grading is accepted (status -> AwaitingGrading);
+ *   - the student's primary instructor (sifu) is notified when their student
+ *     makes a grading request.
+ *
+ * Exercises the real `onGradingCreated` / `onGradingUpdated` Cloud Functions
+ * against the Firebase emulator. Run via `pnpm test:e2e`.
+ */
+
+process.env['FIRESTORE_EMULATOR_HOST'] ||= '127.0.0.1:8080';
+process.env['FIREBASE_AUTH_EMULATOR_HOST'] ||= '127.0.0.1:9099';
+
+import * as admin from 'firebase-admin';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  GradingStatus,
+  NotificationKind,
+  PaymentStatus,
+  initGrading,
+  type Grading,
+  type MemberNotification,
+} from '../../functions/src/data-model';
+
+const PROJECT_ID = 'demo-ilc-test';
+
+if (admin.apps.length === 0) {
+  admin.initializeApp({ projectId: PROJECT_ID });
+}
+const db = admin.firestore();
+const ts = () => admin.firestore.FieldValue.serverTimestamp();
+
+// Poll until `read()` returns a value satisfying `predicate`, or time out.
+async function waitFor<T>(
+  read: () => Promise<T>,
+  predicate: (v: T) => boolean,
+  timeoutMs = 15000,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  let last: T;
+  do {
+    last = await read();
+    if (predicate(last)) return last;
+    await new Promise((r) => setTimeout(r, 400));
+  } while (Date.now() < deadline);
+  throw new Error(`Timed out waiting. Last value: ${JSON.stringify(last!)}`);
+}
+
+const memberLevel = (docId: string) => async () => {
+  const snap = await db.collection('members').doc(docId).get();
+  const d = (snap.data() as Record<string, unknown> | undefined) || {};
+  return {
+    studentLevel: (d.studentLevel as string) || '',
+    applicationLevel: (d.applicationLevel as string) || '',
+  };
+};
+
+const gradingDoc = (docId: string) => async () =>
+  (await db.collection('gradings').doc(docId).get()).data() as Grading | undefined;
+
+afterAll(async () => {
+  await db.terminate();
+});
+
+describe('story: grading level updates only once paid', () => {
+  const suffix = Date.now().toString(36);
+  const studentDocId = `pg-student-${suffix}`;
+  const memberId = `PG-${suffix}`;
+  let gradingDocId = '';
+
+  beforeAll(async () => {
+    await db.collection('members').doc(studentDocId).set({
+      name: 'Paid Gating Student',
+      memberId,
+      studentLevel: '',
+      applicationLevel: '',
+      primaryInstructorId: '',
+      gradingDocIds: [],
+    });
+    const ref = db.collection('gradings').doc();
+    gradingDocId = ref.id;
+    await ref.set({
+      ...initGrading(),
+      level: 'Student 1',
+      studentMemberId: memberId,
+      studentMemberDocId: studentDocId,
+      status: GradingStatus.AwaitingGrading,
+      paymentStatus: PaymentStatus.NotYetPaid,
+    });
+  });
+
+  it('does not promote the student while the passed grading is unpaid', async () => {
+    await db.collection('gradings').doc(gradingDocId).update({
+      status: GradingStatus.Passed,
+      lastUpdated: ts(),
+    });
+    // Give the trigger time to run, then assert the level is still unset.
+    await new Promise((r) => setTimeout(r, 3000));
+    const { studentLevel } = await memberLevel(studentDocId)();
+    expect(studentLevel).toBe('');
+  });
+
+  it('promotes the student once the grading is marked paid', async () => {
+    await db.collection('gradings').doc(gradingDocId).update({
+      paymentStatus: PaymentStatus.PaidByCash,
+      lastUpdated: ts(),
+    });
+    const { studentLevel } = await waitFor(
+      memberLevel(studentDocId),
+      (v) => v.studentLevel === '1',
+    );
+    expect(studentLevel).toBe('1');
+  });
+});
+
+describe('story: grading captures the level snapshot at acceptance', () => {
+  const suffix = Date.now().toString(36);
+  const studentDocId = `sn-student-${suffix}`;
+  let gradingDocId = '';
+
+  beforeAll(async () => {
+    await db.collection('members').doc(studentDocId).set({
+      name: 'Snapshot Student',
+      memberId: `SN-${suffix}`,
+      studentLevel: '3',
+      applicationLevel: '1',
+      primaryInstructorId: '',
+      gradingDocIds: [],
+    });
+    const ref = db.collection('gradings').doc();
+    gradingDocId = ref.id;
+    await ref.set({
+      ...initGrading(),
+      level: 'Student 4',
+      studentMemberId: `SN-${suffix}`,
+      studentMemberDocId: studentDocId,
+      gradingInstructorId: 'INST-SN',
+      status: GradingStatus.AwaitingAcceptance,
+    });
+  });
+
+  it('snapshots the student levels when the grading is accepted', async () => {
+    await db.collection('gradings').doc(gradingDocId).update({
+      status: GradingStatus.AwaitingGrading,
+      acceptedByMemberDocId: studentDocId,
+      statusChangedByMemberDocId: studentDocId,
+      lastUpdated: ts(),
+    });
+    const g = await waitFor(
+      gradingDoc(gradingDocId),
+      (v) => !!v && v.studentLevelAtAcceptance === '3',
+    );
+    expect(g!.studentLevelAtAcceptance).toBe('3');
+    expect(g!.applicationLevelAtAcceptance).toBe('1');
+  });
+});
+
+describe('story: sifu notified when their student requests a grading', () => {
+  const suffix = Date.now().toString(36);
+  const sifuDocId = `rq-sifu-${suffix}`;
+  const sifuInstructorId = `SIFU-${suffix}`;
+  const studentDocId = `rq-student-${suffix}`;
+  let gradingDocId = '';
+
+  beforeAll(async () => {
+    await db.collection('members').doc(sifuDocId).set({
+      name: 'Sifu R',
+      instructorId: sifuInstructorId,
+    });
+    await db.collection('members').doc(studentDocId).set({
+      name: 'Requesting Student',
+      memberId: `RQ-${suffix}`,
+      primaryInstructorId: sifuInstructorId,
+      gradingDocIds: [],
+    });
+    const ref = db.collection('gradings').doc();
+    gradingDocId = ref.id;
+    await ref.set({
+      ...initGrading(),
+      level: 'Student 1',
+      studentMemberId: `RQ-${suffix}`,
+      studentMemberDocId: studentDocId,
+      status: GradingStatus.AwaitingRequest,
+    });
+  });
+
+  it('notifies the sifu when the student selects a different instructor', async () => {
+    await db.collection('gradings').doc(gradingDocId).update({
+      status: GradingStatus.AwaitingAcceptance,
+      gradingInstructorId: 'INST-OTHER',
+      statusChangedByMemberDocId: studentDocId,
+      statusChangedByName: 'Requesting Student',
+      lastUpdated: ts(),
+    });
+    const note = await waitFor(
+      async () => {
+        const snap = await db
+          .collection('members')
+          .doc(sifuDocId)
+          .collection('notifications')
+          .where('data.gradingDocId', '==', gradingDocId)
+          .get();
+        return snap.docs.map((d) => d.data() as MemberNotification);
+      },
+      (notes) =>
+        notes.some(
+          (n) =>
+            n.kind === NotificationKind.GradingRequestsYouAsInstructor &&
+            n.markdown.includes('has requested a grading'),
+        ),
+    );
+    expect(note.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
**PR 2 of 6** in the grading-system refinement series. Cloud Function trigger behaviour (builds on the PR 1 schema).

## What
- **Payment gating of level updates** — `onGradingUpdated` now only promotes the student when a grading is **both passed and paid** (`isGradingPaid`, i.e. anything but `not-yet-paid`). It fires when the grading becomes passed-while-paid, *and* when an already-passed grading is later marked paid. An unpaid pass logs and leaves the level unchanged.
- **Level snapshot at acceptance** — when a grading is accepted (status → `AwaitingGrading`), the trigger captures `studentLevelAtAcceptance` / `applicationLevelAtAcceptance` from the **member record** (authoritative), if not already set. Folded into the existing cached-name write-back so it doesn't add a trigger fire.
- **Sifu-on-request notification** — the student's primary instructor is notified when their student makes a grading request (both the create and update paths), unless the sifu is the selected grading instructor (already notified).
- **Wording fix** — "assistant instructor" / "removed as an instructor" → "grading manager".
- **Squarespace** — order-created gradings are written `paid-by-squarespace`.
- **Backfill idempotency** — the level-snapshot pass now skips when there's no previous level (e.g. `Student Entry`), so re-runs make no further writes (per the convention that backfills must be idempotent).

## Verification
- `pnpm test:functions` → 201 pass
- `pnpm test:once` (frontend) → 379 pass
- `pnpm test:rules` → 95 pass
- `pnpm test:e2e` → 10 pass, incl. a **new spec** (`grading-paid-and-snapshot.spec.ts`) covering paid-gating, snapshot-at-acceptance, and sifu-on-request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)