### PR TITLE
feat(gradings): explicit save UX + event-input redesign (PR 4/6)

### DIFF
--- a/src/app/grading-edit/grading-edit.html
+++ b/src/app/grading-edit/grading-edit.html
@@ -250,6 +250,25 @@
           placeholder="Feedback or comments visible to the student..."
         ></textarea>
       </div>
+
+      <label for="paymentStatus">Payment status</label>
+      <div class="rhs">
+        <select id="paymentStatus" [formField]="form.paymentStatus">
+          @for (s of paymentStatuses; track s) {
+            <option [value]="s">{{ paymentStatusLabel(s) }}</option>
+          }
+        </select>
+      </div>
+
+      <label for="paymentNote">Payment note (optional)</label>
+      <div class="rhs">
+        <input
+          type="text"
+          id="paymentNote"
+          [formField]="form.paymentNote"
+          placeholder="e.g. who collected payment, reference"
+        />
+      </div>
     </div>
 
     @if (errorMessage().length > 0) {

--- a/src/app/grading-edit/grading-edit.html
+++ b/src/app/grading-edit/grading-edit.html
@@ -291,7 +291,7 @@
           <app-spinner></app-spinner>
         } @else {
           @if (isDirty() && canEdit()) {
-            <button type="submit" [disabled]="form().invalid()">Save</button>
+            <button type="submit" [disabled]="form().invalid() || eventInputInvalid()">Save</button>
           }
           @if (!grading().docId || isDirty()) {
             <button type="button" (click)="cancel($event)">

--- a/src/app/grading-edit/grading-edit.ts
+++ b/src/app/grading-edit/grading-edit.ts
@@ -174,6 +174,15 @@ export class GradingEditComponent {
   asyncError = signal<Error | null>(null);
   protected showStatusGuide = signal(false);
 
+  // Free-text event info that isn't linked to a listed event — the grading must
+  // either link an event or be marked "not at a listed event" (date only). The
+  // event input shows the warning; the form's Save is disabled while invalid.
+  eventInputInvalid = computed(
+    () =>
+      this.form.gradingEvent().value().trim() !== '' &&
+      !this.form.gradingEventDocId().value(),
+  );
+
   // User permissions
   userIsAdmin = computed(() => {
     const user = this.firebaseState.user();
@@ -345,6 +354,15 @@ export class GradingEditComponent {
 
   async saveGrading(event: Event) {
     event.preventDefault();
+    if (this.eventInputInvalid()) {
+      this.asyncError.set(
+        new Error(
+          'The event isn\'t linked to a listed ILC event. Search and select it, ' +
+            'or tick "Grading was not at a listed workshop/event".',
+        ),
+      );
+      return;
+    }
     this.isSaving.set(true);
     this.asyncError.set(null);
     try {

--- a/src/app/grading-edit/grading-edit.ts
+++ b/src/app/grading-edit/grading-edit.ts
@@ -22,6 +22,9 @@ import {
   School,
   IlcEvent,
   gradingManagerIdsOf,
+  PaymentStatus,
+  PAYMENT_STATUSES,
+  PAYMENT_STATUS_LABELS,
 } from '../../../functions/src/data-model';
 import {
   form,
@@ -57,6 +60,8 @@ export class GradingEditComponent {
   getPrettyGradingStatus = getPrettyGradingStatus;
   studentLevels = Object.values(StudentLevel);
   applicationLevels = Object.values(ApplicationLevel);
+  paymentStatuses = PAYMENT_STATUSES;
+  paymentStatusLabel = (s: string) => PAYMENT_STATUS_LABELS[s as PaymentStatus] ?? s;
 
   // The core object of interest.
   grading = input.required<Grading>();
@@ -76,6 +81,9 @@ export class GradingEditComponent {
     disabled(schema.gradingInstructorId, () => !this.userIsAdmin() && !this.userIsStudent() && !this.userIsGradingInstructor());
     // `assistantInstructorIds` maps to "Grading Managers" in the UI.
     disabled(schema.assistantInstructorIds, () => !this.userIsAdmin() && !this.userIsGradingInstructor());
+    // Payment is editable by admins and grading managers/instructors (not students).
+    disabled(schema.paymentStatus, () => !this.userIsAdmin() && !this.userIsGradingInstructor());
+    disabled(schema.paymentNote, () => !this.userIsAdmin() && !this.userIsGradingInstructor());
     disabled(schema.schoolId, () => !this.userIsAdmin());
     disabled(schema.studentMemberId, () => !this.userIsAdmin());
     disabled(schema.studentMemberDocId, () => !this.userIsAdmin());
@@ -157,6 +165,8 @@ export class GradingEditComponent {
       this.form.studentNotes().value() !== original.studentNotes ||
       this.form.instructorAcceptedDate().value() !== original.instructorAcceptedDate ||
       this.form.resultNotes().value() !== original.resultNotes ||
+      this.form.paymentStatus().value() !== original.paymentStatus ||
+      this.form.paymentNote().value() !== original.paymentNote ||
       this.form.reviewIssue().value() !== original.reviewIssue
     );
   });
@@ -362,6 +372,8 @@ export class GradingEditComponent {
         studentNotes: this.form.studentNotes().value(),
         instructorAcceptedDate: this.form.instructorAcceptedDate().value(),
         resultNotes: this.form.resultNotes().value(),
+        paymentStatus: this.form.paymentStatus().value(),
+        paymentNote: this.form.paymentNote().value(),
         reviewIssue: this.form.reviewIssue().value(),
       };
       if (grading.docId) {

--- a/src/app/grading-event-input/grading-event-input.html
+++ b/src/app/grading-event-input/grading-event-input.html
@@ -62,6 +62,16 @@
           }
         </div>
       }
+      @if (isUnlinkedText()) {
+        <p class="event-unlinked-warning">
+          <app-icon name="error" width="16" height="16" fill="#b06000"></app-icon>
+          <span>
+            “<strong>{{ editEvent() }}</strong>” isn't a linked ILC event. Search
+            and select the event above, or tick
+            <strong>“Grading was not at a listed workshop/event”</strong>.
+          </span>
+        </p>
+      }
     </div>
   }
 

--- a/src/app/grading-event-input/grading-event-input.html
+++ b/src/app/grading-event-input/grading-event-input.html
@@ -1,30 +1,31 @@
 <div class="event-input-wrapper">
 
-  <!-- Mode toggle: link a listed ILC event, or enter a custom event/location -->
-  <div class="pill-tabs">
-    <button
-      type="button"
-      class="pill-tab"
-      data-label="Linked ILC event"
-      [class.active]="mode() === 'ilc'"
-      (click)="setMode('ilc')"
-    >
-      Linked ILC event
-    </button>
-    <button
-      type="button"
-      class="pill-tab"
-      data-label="Other event / location"
-      [class.active]="mode() === 'manual'"
-      (click)="setMode('manual')"
-    >
-      Other event / location
-    </button>
+  <!-- Date first, always shown (even when an event is linked). -->
+  <div class="event-manual-row">
+    <label class="small-label">Date of grading</label>
+    <input
+      type="date"
+      [value]="editDate()"
+      (input)="onDateInput($event)"
+    />
   </div>
 
-  @if (mode() === 'ilc') {
+  <!-- Single checkbox: was the grading at a listed workshop/event, or not? -->
+  <div class="event-not-listed-row">
+    <label class="checkbox-label">
+      <input
+        type="checkbox"
+        [checked]="notListed()"
+        (change)="setNotListed($any($event.target).checked)"
+      />
+      Grading was not at a listed workshop/event
+    </label>
+  </div>
+
+  @if (!notListed()) {
     <!-- ILC event search -->
     <div class="event-search-section">
+      <label class="small-label">Grading happened at event:</label>
       <app-autocomplete
         class="event-autocomplete"
         name="Event"
@@ -61,26 +62,6 @@
           }
         </div>
       }
-    </div>
-  } @else {
-    <!-- Manual text / date inputs -->
-    <div class="event-manual-row">
-      <label class="small-label">Event / location</label>
-      <input
-        type="text"
-        class="event-text-input"
-        [value]="editEvent()"
-        (input)="onTextInput($event)"
-        placeholder="e.g. Summer Workshop 2026"
-      />
-    </div>
-    <div class="event-manual-row">
-      <label class="small-label">Date</label>
-      <input
-        type="date"
-        [value]="editDate()"
-        (input)="onDateInput($event)"
-      />
     </div>
   }
 

--- a/src/app/grading-event-input/grading-event-input.scss
+++ b/src/app/grading-event-input/grading-event-input.scss
@@ -10,11 +10,16 @@
   gap: 0.5em;
 }
 
-// ── Mode toggle ──
-// Uses the global `.pill-tabs` / `.pill-tab` system from styles.scss.
-.pill-tabs {
-  align-self: flex-start;
-  margin-bottom: 0;
+// ── "Not at a listed event" checkbox ──
+.event-not-listed-row {
+  .checkbox-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4em;
+    font-size: 0.85em;
+    color: v.$text-secondary;
+    cursor: pointer;
+  }
 }
 
 // ── ILC event search ──
@@ -105,14 +110,13 @@
   color: #e65100;
 }
 
-// ── Manual entry ──
+// ── Date row ──
 .event-manual-row {
   display: flex;
   align-items: center;
   gap: 0.6em;
   flex-wrap: wrap;
 
-  input[type='text'],
   input[type='date'] {
     flex: 1;
     min-width: 10em;
@@ -123,8 +127,4 @@
     font-size: 0.9em;
     background: #fff;
   }
-}
-
-.event-text-input {
-  min-width: 14em;
 }

--- a/src/app/grading-event-input/grading-event-input.scss
+++ b/src/app/grading-event-input/grading-event-input.scss
@@ -110,6 +110,26 @@
   color: #e65100;
 }
 
+.event-unlinked-warning {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.4em;
+  margin: 0.2em 0 0;
+  padding: 0.5em 0.7em;
+  background-color: #fff4e5;
+  border: 1px solid #f5a623;
+  border-left-width: 4px;
+  border-radius: 6px;
+  font-size: 0.85em;
+  color: #8a5200;
+  line-height: 1.4;
+
+  app-icon {
+    flex-shrink: 0;
+    margin-top: 0.1em;
+  }
+}
+
 // ── Date row ──
 .event-manual-row {
   display: flex;

--- a/src/app/grading-event-input/grading-event-input.ts
+++ b/src/app/grading-event-input/grading-event-input.ts
@@ -26,8 +26,6 @@ export interface GradingEventDetails {
   gradingEventDocId: string;
 }
 
-export type EventInputMode = 'ilc' | 'manual';
-
 @Component({
   selector: 'app-grading-event-input',
   standalone: true,
@@ -50,35 +48,30 @@ export class GradingEventInputComponent {
   editDate = linkedSignal(() => this.gradingEventDate());
   editDocId = linkedSignal(() => this.gradingEventDocId());
 
-  // Whether the user is linking a listed ILC event or entering a custom
-  // event/location. The initial mode is derived from the incoming data
-  // (linked ILC event → 'ilc'; free-form text/date only → 'manual'); after
-  // that it is purely user-controlled via the tabs and preserved across
-  // re-renders so switching tabs never loses the entered information.
-  mode = linkedSignal<{ docId: string; hasManual: boolean }, EventInputMode>({
-    source: () => ({
-      docId: this.gradingEventDocId(),
-      hasManual: !!(this.gradingEvent() || this.gradingEventDate()),
-    }),
+  // Whether the grading was NOT at a listed workshop/event. When checked, only
+  // the date is recorded (no event name/link). Seeded from the incoming data —
+  // a linked event means it WAS at a listed event — then user-controlled via the
+  // checkbox and preserved across re-renders.
+  notListed = linkedSignal<{ docId: string }, boolean>({
+    source: () => ({ docId: this.gradingEventDocId() }),
     computation: (src, prev) => {
       if (prev) return prev.value;
-      if (src.docId) return 'ilc';
-      return src.hasManual ? 'manual' : 'ilc';
+      return false;
     },
   });
 
-  // Event search. When the grading already has a date, default the search to the
-  // week either side of it so the matching event is easy to find; otherwise fall
-  // back to the last month onwards. These stay user-editable via the date inputs
-  // (re-seeded only if the grading date itself changes).
+  // Event search. When the grading already has a date, default the search to a
+  // fortnight either side of it so the matching event is easy to find; otherwise
+  // fall back to the last month onwards. These stay user-editable via the date
+  // inputs (re-seeded only if the grading date itself changes).
   eventsSet = new SearchableSet<'docId', IlcEvent>(['title', 'location', 'start'], 'docId');
   eventRangeFrom = linkedSignal(() => {
     const date = this.gradingEventDate();
-    return date ? shiftDays(date, -7) : oneMonthAgo();
+    return date ? shiftDays(date, -15) : oneMonthAgo();
   });
   eventRangeTo = linkedSignal(() => {
     const date = this.gradingEventDate();
-    return date ? shiftDays(date, 7) : '';
+    return date ? shiftDays(date, 15) : '';
   });
 
   _loadEvents = effect(() => {
@@ -119,12 +112,16 @@ export class GradingEventInputComponent {
     return this.routingService.hrefForView(Views.EventView, { eventId: docId });
   });
 
-  // Switching tabs only changes the view — all entered data (event text, date,
-  // and any linked ILC event) is preserved. A linked ILC event is only
-  // detached when the user actually edits a manual field (see onTextInput /
-  // onDateInput).
-  setMode(mode: EventInputMode) {
-    this.mode.set(mode);
+  // Toggle "not at a listed event". When checked, the grading is date-only:
+  // clear any event name/link and keep just the date. When unchecked, the event
+  // search reappears (the date is preserved either way).
+  setNotListed(checked: boolean) {
+    this.notListed.set(checked);
+    if (checked) {
+      this.editEvent.set('');
+      this.editDocId.set('');
+      this.emit();
+    }
   }
 
   onEventSelected(event: IlcEvent) {
@@ -135,15 +132,10 @@ export class GradingEventInputComponent {
     this.emit();
   }
 
-  onTextInput(e: Event) {
-    this.editEvent.set((e.target as HTMLInputElement).value);
-    this.editDocId.set('');
-    this.emit();
-  }
-
+  // The date is always shown, even when an event is linked. Editing it just
+  // updates the grading date; it does not detach a linked event.
   onDateInput(e: Event) {
     this.editDate.set((e.target as HTMLInputElement).value);
-    this.editDocId.set('');
     this.emit();
   }
 

--- a/src/app/grading-event-input/grading-event-input.ts
+++ b/src/app/grading-event-input/grading-event-input.ts
@@ -106,6 +106,14 @@ export class GradingEventInputComponent {
     return !this.eventsSet.get(docId);
   });
 
+  // True when there is free-text event info that isn't linked to a listed event
+  // and the user hasn't ticked "not at a listed workshop/event". This is an
+  // invalid, ambiguous state: the grading must either link a real event or be
+  // marked as not-at-a-listed-event (date only). Parents disable saving while so.
+  isUnlinkedText = computed(
+    () => !this.notListed() && !this.editDocId() && this.editEvent().trim() !== '',
+  );
+
   linkedEventHref = computed(() => {
     const docId = this.editDocId();
     if (!docId) return '';

--- a/src/app/grading-progress/grading-progress.html
+++ b/src/app/grading-progress/grading-progress.html
@@ -541,46 +541,47 @@
             height="18"
             fill="#155724"
           ></app-icon>
-          <span>
-            Your grading has been accepted by
-            @if (gradingInstructor(); as inst) {
-              <a
-                class="instructor-link"
-                [href]="'#/instructors/' + inst.instructorId"
-                ><app-icon name="person" class="person-icon"></app-icon>{{ inst.name }} [{{ inst.instructorId }}]</a
-              >
-            } @else {
-              <strong>{{ gradingInstructorLabel() }}</strong>
-            }
-            .
+          <span class="accepted-summary">
+            <span class="accepted-line">
+              <strong>Your grading instructor:</strong>
+              @if (gradingInstructor(); as inst) {
+                <a
+                  class="instructor-link"
+                  [href]="'#/instructors/' + inst.instructorId"
+                  ><app-icon name="person" class="person-icon"></app-icon>{{ inst.name }} [{{ inst.instructorId }}]</a
+                >
+              } @else {
+                <strong>{{ gradingInstructorLabel() }}</strong>
+              }
+            </span>
             @let assistants = gradingManagers();
             @if (assistants.length > 0) {
-              Supporting instructors include:
-              @for (
-                assistant of assistants;
-                track assistant.id;
-                let last = $last
-              ) {
-                @if (assistant.data) {
-                  <a
-                    class="instructor-link"
-                    [href]="'#/instructors/' + assistant.data.instructorId"
-                    ><app-icon name="person" class="person-icon"></app-icon>{{ assistant.data.name }} [{{ assistant.data.instructorId }}]</a
-                  >
-                } @else {
-                  <strong>{{ assistant.id }}</strong>
+              <span class="accepted-line">
+                <strong>Grading managers:</strong>
+                @for (
+                  assistant of assistants;
+                  track assistant.id;
+                  let last = $last
+                ) {
+                  @if (assistant.data) {
+                    <a
+                      class="instructor-link"
+                      [href]="'#/instructors/' + assistant.data.instructorId"
+                      ><app-icon name="person" class="person-icon"></app-icon>{{ assistant.data.name }} [{{ assistant.data.instructorId }}]</a
+                    >
+                  } @else {
+                    <strong>{{ assistant.id }}</strong>
+                  }
+                  @if (!last) {
+                    ,
+                  }
                 }
-                @if (!last) {
-                  ,
-                } @else {
-                  .
-                }
-              }
+              </span>
             }
-            <span
-              >Waiting for the grading to be completed and for notes and result
-              to be uploaded by the instructor(s).</span
-            >
+            <span class="accepted-line accepted-waiting">
+              Your grading has been accepted — waiting for it to be completed and
+              for the result and notes to be recorded.
+            </span>
           </span>
         </p>
         @if (isEditingEvent()) {
@@ -792,44 +793,47 @@
         <!-- No edit role: read-only summary -->
         <p class="action-message">
           <app-icon name="schedule" width="18" height="18"></app-icon>
-          <span>
-            Grading has been accepted by
-            @if (gradingInstructor(); as inst) {
-              <a
-                class="instructor-link"
-                [href]="'#/instructors/' + inst.instructorId"
-                ><app-icon name="person" class="person-icon"></app-icon>{{ inst.name }} [{{ inst.instructorId }}]</a
-              >
-            } @else {
-              <strong>{{ gradingInstructorLabel() }}</strong>
-            }
-            .
+          <span class="accepted-summary">
+            <span class="accepted-line">
+              <strong>Accepted by:</strong>
+              @if (gradingInstructor(); as inst) {
+                <a
+                  class="instructor-link"
+                  [href]="'#/instructors/' + inst.instructorId"
+                  ><app-icon name="person" class="person-icon"></app-icon>{{ inst.name }} [{{ inst.instructorId }}]</a
+                >
+              } @else {
+                <strong>{{ gradingInstructorLabel() }}</strong>
+              }
+            </span>
             @let assistants = gradingManagers();
             @if (assistants.length > 0) {
-              Supporting instructors include:
-              @for (
-                assistant of assistants;
-                track assistant.id;
-                let last = $last
-              ) {
-                @if (assistant.data) {
-                  <a
-                    class="instructor-link"
-                    [href]="'#/instructors/' + assistant.data.instructorId"
-                    ><app-icon name="person" class="person-icon"></app-icon>{{ assistant.data.name }} [{{ assistant.data.instructorId }}]</a
-                  >
-                } @else {
-                  <strong>{{ assistant.id }}</strong>
+              <span class="accepted-line">
+                <strong>Grading managers:</strong>
+                @for (
+                  assistant of assistants;
+                  track assistant.id;
+                  let last = $last
+                ) {
+                  @if (assistant.data) {
+                    <a
+                      class="instructor-link"
+                      [href]="'#/instructors/' + assistant.data.instructorId"
+                      ><app-icon name="person" class="person-icon"></app-icon>{{ assistant.data.name }} [{{ assistant.data.instructorId }}]</a
+                    >
+                  } @else {
+                    <strong>{{ assistant.id }}</strong>
+                  }
+                  @if (!last) {
+                    ,
+                  }
                 }
-                @if (!last) {
-                  ,
-                } @else {
-                  .
-                }
-              }
+              </span>
             }
-            Waiting for the grading to be completed and for notes and result to
-            be uploaded by the instructor(s).
+            <span class="accepted-line accepted-waiting">
+              Waiting for the grading to be completed and for the result and notes
+              to be recorded.
+            </span>
           </span>
         </p>
         @if (isEditingEvent()) {

--- a/src/app/grading-progress/grading-progress.html
+++ b/src/app/grading-progress/grading-progress.html
@@ -925,9 +925,30 @@
           }
         }
       </p>
-      @if (g.resultNotes) {
+      @if (isEditingResultNotes()) {
+        <div class="detail-inline-edit result-notes-edit">
+          <label>Notes for the student</label>
+          <textarea
+            [value]="editResultNotes()"
+            (input)="editResultNotes.set($any($event.target).value)"
+            rows="3"
+            placeholder="Feedback or comments for the student..."
+          ></textarea>
+          <div class="detail-edit-actions">
+            <button class="subtle-button" (click)="saveResultNotes()">Save</button>
+            <button class="subtle-button" (click)="cancelResultNotesEdit()">Cancel</button>
+          </div>
+        </div>
+      } @else if (g.resultNotes) {
         <p class="detail-note result-detail">
           <strong>Grading Instructor's notes:</strong> {{ g.resultNotes }}
+          @if (canEditGradingDetails()) {
+            <button class="icon-only-button detail-edit-btn" (click)="isEditingResultNotes.set(true)" title="Edit notes for the student"><app-icon name="edit"></app-icon></button>
+          }
+        </p>
+      } @else if (canEditGradingDetails()) {
+        <p class="detail-note">
+          <button class="subtle-button detail-edit-btn" (click)="isEditingResultNotes.set(true)"><app-icon name="edit"></app-icon> Add notes for the student</button>
         </p>
       }
 
@@ -1062,6 +1083,54 @@
               </button>
             </span>
           }
+        }
+
+        <!-- Payment status -->
+        @if (isEditingPayment()) {
+          <div class="detail-edit-span">
+            <div class="detail-inline-edit">
+              <div class="detail-inline-edit-row">
+                <label>Payment</label>
+                <select
+                  [value]="editPaymentStatus()"
+                  (change)="editPaymentStatus.set($any($event.target).value)"
+                >
+                  @for (s of paymentStatuses; track s) {
+                    <option [value]="s">{{ paymentStatusLabel(s) }}</option>
+                  }
+                </select>
+              </div>
+              <div class="detail-inline-edit-row">
+                <label>Payment note</label>
+                <input
+                  type="text"
+                  [value]="editPaymentNote()"
+                  (input)="editPaymentNote.set($any($event.target).value)"
+                  placeholder="e.g. who collected payment, reference"
+                />
+              </div>
+              <div class="detail-edit-actions">
+                <button class="subtle-button" (click)="savePaymentDetails()">Save</button>
+                <button class="subtle-button" (click)="cancelPaymentEdit()">Cancel</button>
+              </div>
+            </div>
+          </div>
+        } @else {
+          <span class="detail-label">Payment</span>
+          <span class="detail-value">
+            <span [class.unpaid-flag]="isUnpaid()">
+              @if (isUnpaid()) {
+                <app-icon name="error" width="14" height="14"></app-icon>
+              }
+              {{ currentPaymentLabel() }}
+            </span>
+            @if (grading().paymentNote) {
+              <span class="detail-sub">— {{ grading().paymentNote }}</span>
+            }
+            @if (canEditGradingDetails()) {
+              <button class="icon-only-button detail-edit-btn" (click)="isEditingPayment.set(true)" title="Edit payment status"><app-icon name="edit"></app-icon></button>
+            }
+          </span>
         }
 
       </div>

--- a/src/app/grading-progress/grading-progress.html
+++ b/src/app/grading-progress/grading-progress.html
@@ -167,7 +167,7 @@
             }
             declined this grading request.
             @if (userIsStudent()) {
-              Please select a different instructor below.
+              Please select a different grading instructor below.
             }
           </span>
         </p>
@@ -293,14 +293,14 @@
               @if (selectedInstructorUnqualified()) {
                 <p class="field-warning">
                   <app-icon name="info" width="16" height="16"></app-icon>
-                  This instructor may not be qualified to assess
+                  This grading instructor may not be qualified to assess
                   <strong>{{ g.level }}</strong>. You can still send the request,
                   but they may need to assign a more senior grading manager.
                 </p>
               }
             </div>
 
-            <label>Note for the instructor (optional)</label>
+            <label>Note for the grading instructor (optional)</label>
             <div class="field">
               <textarea
                 [value]="editStudentNotes()"
@@ -386,10 +386,32 @@
             </div>
           </div>
 
+          @if (isDirty()) {
+            <div class="unsaved-bar">
+              <app-icon name="error" width="18" height="18"></app-icon>
+              <span class="unsaved-note">You have unsaved changes.</span>
+              <button
+                class="subtle-button"
+                (click)="saveEdits()"
+                [disabled]="isSaving()"
+              >
+                Save changes
+              </button>
+              <button
+                class="subtle-button"
+                (click)="discardEdits()"
+                [disabled]="isSaving()"
+              >
+                Discard
+              </button>
+            </div>
+          }
+
           <div class="action-buttons">
             <button
               (click)="acceptAndGradeMyself()"
-              [disabled]="isSaving() || !isNextGrading()"
+              [disabled]="isSaving() || isDirty() || !isNextGrading()"
+              [title]="isDirty() ? 'Save or discard your changes first' : ''"
             >
               Accept
             </button>
@@ -397,7 +419,8 @@
             <button
               class="not-pass-button"
               (click)="showDeclineForm.set(!showDeclineForm())"
-              [disabled]="isSaving()"
+              [disabled]="isSaving() || isDirty()"
+              [title]="isDirty() ? 'Save or discard your changes first' : ''"
             >
               Decline
             </button>
@@ -693,25 +716,49 @@
           </div>
         </div>
 
+        @if (isDirty()) {
+          <div class="unsaved-bar">
+            <app-icon name="error" width="18" height="18"></app-icon>
+            <span class="unsaved-note">You have unsaved changes.</span>
+            <button
+              class="subtle-button"
+              (click)="saveEdits()"
+              [disabled]="isSaving()"
+            >
+              Save changes
+            </button>
+            <button
+              class="subtle-button"
+              (click)="discardEdits()"
+              [disabled]="isSaving()"
+            >
+              Discard
+            </button>
+          </div>
+        }
+
         <div class="action-buttons">
           <button
             class="pass-button"
             (click)="markResult(GradingStatus.Passed)"
-            [disabled]="isSaving()"
+            [disabled]="isSaving() || isDirty()"
+            [title]="isDirty() ? 'Save or discard your changes first' : ''"
           >
             Mark as Passed
           </button>
           <button
             class="not-pass-button"
             (click)="markResult(GradingStatus.NotPassed)"
-            [disabled]="isSaving()"
+            [disabled]="isSaving() || isDirty()"
+            [title]="isDirty() ? 'Save or discard your changes first' : ''"
           >
             Mark as Not Passed
           </button>
           <button
             class="not-pass-button"
             (click)="showDeclineForm.set(!showDeclineForm())"
-            [disabled]="isSaving()"
+            [disabled]="isSaving() || isDirty()"
+            [title]="isDirty() ? 'Save or discard your changes first' : ''"
           >
             Decline Request
           </button>
@@ -876,7 +923,7 @@
       </p>
       @if (g.resultNotes) {
         <p class="detail-note result-detail">
-          <strong>Instructor's notes:</strong> {{ g.resultNotes }}
+          <strong>Grading Instructor's notes:</strong> {{ g.resultNotes }}
         </p>
       }
 
@@ -936,7 +983,7 @@
           <div class="detail-edit-span">
             <div class="detail-inline-edit">
               <div class="detail-inline-edit-row">
-                <label>Instructor</label>
+                <label>Grading Instructor</label>
                 <app-instructor-selector
                   [value]="editInstructorId()"
                   (valueChange)="editInstructorId.set($event)"
@@ -949,7 +996,7 @@
             </div>
           </div>
         } @else if (g.gradingInstructorId) {
-          <span class="detail-label">Instructor</span>
+          <span class="detail-label">Grading Instructor</span>
           <span class="detail-value">
             @if (gradingInstructor(); as inst) {
               <a class="instructor-link" [href]="'#/instructors/' + inst.instructorId"

--- a/src/app/grading-progress/grading-progress.html
+++ b/src/app/grading-progress/grading-progress.html
@@ -629,17 +629,15 @@
         @if (g.studentNotes) {
           <p class="detail-note">Your note: {{ g.studentNotes }}</p>
         }
-      } @else if (canRecordResult()) {
-        <!-- Instructor / assigned instructor / admin: record result -->
+      } @else if (canEditGradingDetails()) {
+        <!-- Grading instructor / manager / admin: edit details + record result.
+             Admins always get the full edit form here, matching the final state. -->
         <p class="action-message">
           <app-icon name="info" width="18" height="18"></app-icon>
           <span>
             Grading accepted. Fill in the result below after the grading event.
           </span>
         </p>
-        @if (g.studentNotes) {
-          <p class="detail-note">Student's note: {{ g.studentNotes }}</p>
-        }
 
         <div class="inline-form">
           <label class="align-top">Event</label>
@@ -716,7 +714,32 @@
               </button>
             }
           </div>
+
+          <label>Payment</label>
+          <div class="field">
+            <select
+              [value]="editPaymentStatus()"
+              (change)="editPaymentStatus.set($any($event.target).value)"
+            >
+              @for (s of paymentStatuses; track s) {
+                <option [value]="s">{{ paymentStatusLabel(s) }}</option>
+              }
+            </select>
+            <input
+              type="text"
+              class="payment-note-input"
+              [value]="editPaymentNote()"
+              (input)="editPaymentNote.set($any($event.target).value)"
+              placeholder="Payment note (optional)"
+            />
+          </div>
         </div>
+
+        @if (g.studentNotes) {
+          <p class="detail-note student-note-row">
+            <strong>Note from student:</strong> {{ g.studentNotes }}
+          </p>
+        }
 
         @if (isDirty()) {
           <div class="unsaved-bar">

--- a/src/app/grading-progress/grading-progress.html
+++ b/src/app/grading-progress/grading-progress.html
@@ -125,7 +125,7 @@
       <span>
         <strong>Out of order.</strong> This grading is for
         <strong>{{ g.level }}</strong>, but
-        <strong>{{ studentName() }}</strong>'s next grading should be
+        <ng-container *ngTemplateOutlet="studentNameTpl"></ng-container>'s next grading should be
         <strong>{{ studentNextGradingLevel() }}</strong>. Earlier levels should be
         completed first.
       </span>
@@ -365,7 +365,7 @@
           <p class="action-message">
             <app-icon name="info" width="18" height="18"></app-icon>
             <span>
-              <strong>{{ studentName() }}</strong> has requested you grade them
+              <ng-container *ngTemplateOutlet="studentNameTpl"></ng-container> has requested you grade them
               for <strong>{{ g.level }}</strong
               >.
             </span>
@@ -903,16 +903,15 @@
             Congratulations! You passed <strong>{{ g.level }}</strong
             >.
           } @else {
-            <strong>{{ studentName() }} passed
-            <span style="white-space: nowrap;">{{ g.level }}.</span></strong
-            >
+            <ng-container *ngTemplateOutlet="studentNameTpl"></ng-container> passed
+            <strong style="white-space: nowrap;">{{ g.level }}.</strong>
           }
         } @else if (g.status === GradingStatus.RequiresReview) {
           <app-icon name="info" width="18" height="18"></app-icon>
           @if (userIsStudent()) {
             Your grading is being reviewed by HQ admin.
           } @else {
-            The grading for <strong>{{ studentName() }}</strong> is being
+            The grading for <ng-container *ngTemplateOutlet="studentNameTpl"></ng-container> is being
             reviewed by HQ admin.
           }
         } @else {
@@ -920,7 +919,7 @@
           @if (userIsStudent()) {
             You did not pass <strong>{{ g.level }}</strong> this time.
           } @else {
-            <strong>{{ studentName() }}</strong> did not pass
+            <ng-container *ngTemplateOutlet="studentNameTpl"></ng-container> did not pass
             <strong>{{ g.level }}</strong
             >.
           }
@@ -1134,7 +1133,25 @@
           </span>
         }
 
+        <!-- Note from the student (their request note), under the other info.
+             Skipped entirely when empty. -->
+        @if (g.studentNotes) {
+          <p class="detail-note student-note-row">
+            <strong>Note from student:</strong> {{ g.studentNotes }}
+          </p>
+        }
+
       </div>
     </div>
   }
 </div>
+
+<!-- Student name, rendered as a profile link when the viewer is permitted to
+     open it (admin / primary instructor / school manager), else plain text. -->
+<ng-template #studentNameTpl>
+  @if (studentProfileLink(); as link) {
+    <a class="student-profile-link" [href]="link"><strong>{{ studentName() }}</strong></a>
+  } @else {
+    <strong>{{ studentName() }}</strong>
+  }
+</ng-template>

--- a/src/app/grading-progress/grading-progress.html
+++ b/src/app/grading-progress/grading-progress.html
@@ -120,15 +120,16 @@
   <!-- Warn when this grading isn't the student's next grading in the
        progression (only shown when their level is known). -->
   @if (!isNextGrading()) {
-    <p class="action-message result-message not-passed grading-level-warning">
-      <app-icon name="info" width="18" height="18"></app-icon>
+    <div class="warning-box grading-level-warning">
+      <app-icon name="error" width="18" height="18" fill="#b06000"></app-icon>
       <span>
-        This grading is for <strong>{{ g.level }}</strong>, but
-        <strong>{{ studentName() }}</strong>'s next grading is
-        <strong>{{ studentNextGradingLevel() }}</strong>. Earlier gradings should
-        be completed first.
+        <strong>Out of order.</strong> This grading is for
+        <strong>{{ g.level }}</strong>, but
+        <strong>{{ studentName() }}</strong>'s next grading should be
+        <strong>{{ studentNextGradingLevel() }}</strong>. Earlier levels should be
+        completed first.
       </span>
-    </p>
+    </div>
   }
 
   <!-- ====================================================================
@@ -225,7 +226,7 @@
                 (gradingEventChange)="onEventInputChange($event)"
               ></app-grading-event-input>
               <div class="detail-edit-actions">
-                <button class="subtle-button" (click)="saveEventDetails()">Save</button>
+                <button class="subtle-button" (click)="saveEventDetails()" [disabled]="eventInputInvalid()">Save</button>
                 <button class="subtle-button" (click)="cancelEventEdit()">Cancel</button>
               </div>
             </div>
@@ -355,7 +356,7 @@
           <div class="action-buttons">
             <button
               (click)="acceptAndGradeMyself()"
-              [disabled]="isSaving() || !isNextGrading()"
+              [disabled]="isSaving() || !isNextGrading() || eventInputInvalid()"
             >
               Change to Accept
             </button>
@@ -393,7 +394,7 @@
               <button
                 class="subtle-button"
                 (click)="saveEdits()"
-                [disabled]="isSaving()"
+                [disabled]="isSaving() || eventInputInvalid()"
               >
                 Save changes
               </button>
@@ -410,7 +411,7 @@
           <div class="action-buttons">
             <button
               (click)="acceptAndGradeMyself()"
-              [disabled]="isSaving() || isDirty() || !isNextGrading()"
+              [disabled]="isSaving() || isDirty() || !isNextGrading() || eventInputInvalid()"
               [title]="isDirty() ? 'Save or discard your changes first' : ''"
             >
               Accept
@@ -494,7 +495,7 @@
               (gradingEventChange)="onEventInputChange($event)"
             ></app-grading-event-input>
             <div class="detail-edit-actions">
-              <button class="subtle-button" (click)="saveEventDetails()">Save</button>
+              <button class="subtle-button" (click)="saveEventDetails()" [disabled]="eventInputInvalid()">Save</button>
               <button class="subtle-button" (click)="cancelEventEdit()">Cancel</button>
             </div>
           </div>
@@ -593,7 +594,7 @@
               (gradingEventChange)="onEventInputChange($event)"
             ></app-grading-event-input>
             <div class="detail-edit-actions">
-              <button class="subtle-button" (click)="saveEventDetails()">Save</button>
+              <button class="subtle-button" (click)="saveEventDetails()" [disabled]="eventInputInvalid()">Save</button>
               <button class="subtle-button" (click)="cancelEventEdit()">Cancel</button>
             </div>
           </div>
@@ -742,7 +743,7 @@
           <button
             class="pass-button"
             (click)="markResult(GradingStatus.Passed)"
-            [disabled]="isSaving() || isDirty()"
+            [disabled]="isSaving() || isDirty() || eventInputInvalid()"
             [title]="isDirty() ? 'Save or discard your changes first' : ''"
           >
             Mark as Passed
@@ -750,7 +751,7 @@
           <button
             class="not-pass-button"
             (click)="markResult(GradingStatus.NotPassed)"
-            [disabled]="isSaving() || isDirty()"
+            [disabled]="isSaving() || isDirty() || eventInputInvalid()"
             [title]="isDirty() ? 'Save or discard your changes first' : ''"
           >
             Mark as Not Passed
@@ -845,7 +846,7 @@
               (gradingEventChange)="onEventInputChange($event)"
             ></app-grading-event-input>
             <div class="detail-edit-actions">
-              <button class="subtle-button" (click)="saveEventDetails()">Save</button>
+              <button class="subtle-button" (click)="saveEventDetails()" [disabled]="eventInputInvalid()">Save</button>
               <button class="subtle-button" (click)="cancelEventEdit()">Cancel</button>
             </div>
           </div>
@@ -965,7 +966,7 @@
                 (gradingEventChange)="onEventInputChange($event)"
               ></app-grading-event-input>
               <div class="detail-edit-actions">
-                <button class="subtle-button" (click)="saveEventDetails()">Save</button>
+                <button class="subtle-button" (click)="saveEventDetails()" [disabled]="eventInputInvalid()">Save</button>
                 <button class="subtle-button" (click)="cancelEventEdit()">Cancel</button>
               </div>
             </div>

--- a/src/app/grading-progress/grading-progress.scss
+++ b/src/app/grading-progress/grading-progress.scss
@@ -30,6 +30,31 @@
   }
 }
 
+// Standard warning callout: amber background, left accent, warning icon.
+.warning-box {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5em;
+  margin: 0.75em 0;
+  padding: 0.6em 0.85em;
+  background-color: #fff4e5;
+  border: 1px solid #f5a623;
+  border-left-width: 4px;
+  border-radius: 6px;
+  color: #8a5200;
+  font-size: 0.92em;
+  line-height: 1.45;
+
+  app-icon {
+    flex-shrink: 0;
+    margin-top: 0.1em;
+  }
+
+  strong {
+    color: #6d3f00;
+  }
+}
+
 .grading-level-warning {
   margin-top: 0.75em;
 }

--- a/src/app/grading-progress/grading-progress.scss
+++ b/src/app/grading-progress/grading-progress.scss
@@ -433,6 +433,26 @@
   }
 }
 
+// "You have unsaved changes" bar with explicit Save / Discard, shown while the
+// inline detail edits are dirty. Workflow actions are disabled until resolved.
+.unsaved-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin: 0.5rem 0;
+  padding: 0.5rem 0.75rem;
+  background-color: #fff4e5;
+  border: 1px solid #f5a623;
+  border-radius: 6px;
+
+  .unsaved-note {
+    color: #b06000;
+    font-weight: 500;
+    margin-right: auto;
+  }
+}
+
 .event-link {
   display: inline;
   text-decoration: none;

--- a/src/app/grading-progress/grading-progress.scss
+++ b/src/app/grading-progress/grading-progress.scss
@@ -212,6 +212,23 @@
   }
 }
 
+// Student's request note, placed under the other detail rows with a little space.
+.student-note-row {
+  grid-column: 1 / -1;
+  margin-top: 0.6em;
+}
+
+// Student name link to their profile (subtle; underlines on hover).
+.student-profile-link {
+  color: inherit;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+    color: v.$focus-ring-color;
+  }
+}
+
 .result-message.passed {
   color: #155724;
 }

--- a/src/app/grading-progress/grading-progress.scss
+++ b/src/app/grading-progress/grading-progress.scss
@@ -144,6 +144,27 @@
   }
 }
 
+// Stacks the "accepted by / grading managers / waiting…" summary onto separate
+// lines instead of running them together as one long sentence.
+.accepted-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3em;
+
+  .accepted-line {
+    display: block;
+
+    strong {
+      margin-right: 0.25em;
+    }
+  }
+
+  .accepted-waiting {
+    color: v.$text-secondary;
+    font-size: 0.92em;
+  }
+}
+
 .result-message.passed {
   color: #155724;
 }

--- a/src/app/grading-progress/grading-progress.scss
+++ b/src/app/grading-progress/grading-progress.scss
@@ -165,6 +165,28 @@
   }
 }
 
+// Payment status emphasis when a grading is unpaid.
+.unpaid-flag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2em;
+  color: #e65100;
+  font-weight: 600;
+}
+
+.detail-sub {
+  color: v.$text-secondary;
+  font-size: 0.9em;
+  margin-left: 0.25em;
+}
+
+.result-notes-edit {
+  textarea {
+    width: 100%;
+    box-sizing: border-box;
+  }
+}
+
 .result-message.passed {
   color: #155724;
 }

--- a/src/app/grading-progress/grading-progress.scss
+++ b/src/app/grading-progress/grading-progress.scss
@@ -367,6 +367,7 @@
 
     input[type="text"],
     input[type="date"],
+    select,
     textarea {
       width: 100%;
       max-width: 30em;
@@ -380,6 +381,10 @@
 
     textarea {
       resize: vertical;
+    }
+
+    .payment-note-input {
+      margin-top: 0.3em;
     }
 
     ::ng-deep app-autocomplete input {

--- a/src/app/grading-progress/grading-progress.ts
+++ b/src/app/grading-progress/grading-progress.ts
@@ -23,7 +23,6 @@ import {
   computed,
   signal,
   effect,
-  OnDestroy,
 } from '@angular/core';
 import {
   Grading,
@@ -54,7 +53,7 @@ import { GradingEventInputComponent, GradingEventDetails } from '../grading-even
   templateUrl: './grading-progress.html',
   styleUrl: './grading-progress.scss',
 })
-export class GradingProgressComponent implements OnDestroy {
+export class GradingProgressComponent {
   private firebaseState = inject(FirebaseStateService);
   public dataService = inject(DataManagerService);
   private routingService = inject(RoutingService<AppPathPatterns>);
@@ -306,79 +305,39 @@ export class GradingProgressComponent implements OnDestroy {
     );
   });
 
-  saveStatus = signal<'Unsaved changes' | 'saving...' | 'saved' | ''>('');
+  // Feedback shown next to the Save button after an explicit save.
+  saveStatus = signal<'' | 'saving...' | 'saved'>('');
 
-  private autoSaveTimer: any = null;
-
-  private autoSaveEffect = effect(() => {
-    const dirty = this.isDirty();
-    const event = this.editGradingEvent();
-    const date = this.editGradingEventDate();
-    const notes = this.editResultNotes();
-    const assistants = this.editGradingManagerIds();
-    const instructor = this.editInstructorId();
-
-    if (!dirty) {
-      return;
-    }
-
-    this.saveStatus.set('Unsaved changes');
-
-    if (this.autoSaveTimer) {
-      clearTimeout(this.autoSaveTimer);
-    }
-
-    this.autoSaveTimer = setTimeout(() => {
-      this.triggerAutoSave();
-    }, 5000);
-  });
-
-  async triggerAutoSave() {
-    if (this.autoSaveTimer) {
-      clearTimeout(this.autoSaveTimer);
-      this.autoSaveTimer = null;
-    }
-
+  // Persist the inline detail edits (event/date/result notes/instructor/managers)
+  // explicitly. The component no longer auto-saves — the user must click Save (or
+  // Discard) so changes are intentional and clearly visible.
+  saveEdits() {
     if (!this.isDirty()) return;
-
     this.saveStatus.set('saving...');
-    try {
-      const update: Partial<Grading> = {
-        gradingEvent: this.editGradingEvent(),
-        gradingEventDate: this.editGradingEventDate(),
-        resultNotes: this.editResultNotes(),
-        gradingInstructorId: this.editInstructorId(),
-        ...this.managerIdsUpdate(),
-      };
-      this.gradingUpdated.emit(update);
-      this.saveStatus.set('saved');
-      setTimeout(() => {
-        if (this.saveStatus() === 'saved') {
-          this.saveStatus.set('');
-        }
-      }, 3000);
-    } catch (e) {
-      console.error('Auto-save failed:', e);
-      this.saveStatus.set('Unsaved changes');
-    }
+    this.gradingUpdated.emit({
+      gradingEvent: this.editGradingEvent(),
+      gradingEventDate: this.editGradingEventDate(),
+      gradingEventDocId: this.editGradingEventDocId(),
+      resultNotes: this.editResultNotes(),
+      gradingInstructorId: this.editInstructorId(),
+      ...this.managerIdsUpdate(),
+    });
+    this.saveStatus.set('saved');
+    setTimeout(() => {
+      if (this.saveStatus() === 'saved') this.saveStatus.set('');
+    }, 3000);
   }
 
-  ngOnDestroy() {
-    if (this.autoSaveTimer) {
-      clearTimeout(this.autoSaveTimer);
-      this.autoSaveTimer = null;
-    }
-
-    if (this.isDirty()) {
-      const update: Partial<Grading> = {
-        gradingEvent: this.editGradingEvent(),
-        gradingEventDate: this.editGradingEventDate(),
-        resultNotes: this.editResultNotes(),
-        gradingInstructorId: this.editInstructorId(),
-        ...this.managerIdsUpdate(),
-      };
-      this.gradingUpdated.emit(update);
-    }
+  // Revert the inline detail edits back to the saved grading.
+  discardEdits() {
+    const g = this.grading();
+    this.editInstructorId.set(g.gradingInstructorId);
+    this.editGradingEvent.set(g.gradingEvent);
+    this.editGradingEventDate.set(g.gradingEventDate);
+    this.editGradingEventDocId.set(g.gradingEventDocId);
+    this.editGradingManagerIds.set(gradingManagerIdsOf(g));
+    this.editResultNotes.set(g.resultNotes);
+    this.saveStatus.set('');
   }
 
   // --- Step 1 dirty check: has the student changed anything? ---

--- a/src/app/grading-progress/grading-progress.ts
+++ b/src/app/grading-progress/grading-progress.ts
@@ -325,6 +325,14 @@ export class GradingProgressComponent {
     );
   });
 
+  // Free-text event info that isn't linked to a listed event and isn't marked
+  // "not at a listed event" — an ambiguous state the grading can't be saved in
+  // (mirrors the warning shown by the event input). Ticking the checkbox clears
+  // the event text and linking sets the docId, so either resolves it.
+  eventInputInvalid = computed(
+    () => this.editGradingEvent().trim() !== '' && !this.editGradingEventDocId(),
+  );
+
   // Feedback shown next to the Save button after an explicit save.
   saveStatus = signal<'' | 'saving...' | 'saved'>('');
 
@@ -332,7 +340,7 @@ export class GradingProgressComponent {
   // explicitly. The component no longer auto-saves — the user must click Save (or
   // Discard) so changes are intentional and clearly visible.
   saveEdits() {
-    if (!this.isDirty()) return;
+    if (!this.isDirty() || this.eventInputInvalid()) return;
     this.saveStatus.set('saving...');
     this.gradingUpdated.emit({
       gradingEvent: this.editGradingEvent(),
@@ -400,6 +408,7 @@ export class GradingProgressComponent {
   }
 
   saveEventDetails() {
+    if (this.eventInputInvalid()) return;
     this.gradingUpdated.emit({
       gradingEvent: this.editGradingEvent(),
       gradingEventDate: this.editGradingEventDate(),
@@ -521,8 +530,9 @@ export class GradingProgressComponent {
 
   acceptAndGradeMyself() {
     // A grading can only be accepted when it's the student's next grading in the
-    // progression (guarded here as well as in the template).
-    if (!this.isNextGrading()) return;
+    // progression (guarded here as well as in the template), and not while the
+    // event input is in an invalid (unlinked free-text) state.
+    if (!this.isNextGrading() || this.eventInputInvalid()) return;
     this.isSaving.set(true);
     const today = new Date().toISOString().split('T')[0];
     const actor = this.currentActor();
@@ -544,6 +554,7 @@ export class GradingProgressComponent {
 
   // Step 3: Mark result
   markResult(status: GradingStatus.Passed | GradingStatus.NotPassed) {
+    if (this.eventInputInvalid()) return;
     this.isSaving.set(true);
     const update: Partial<Grading> = {
       status,

--- a/src/app/grading-progress/grading-progress.ts
+++ b/src/app/grading-progress/grading-progress.ts
@@ -34,6 +34,10 @@ import {
   previousGradingLevel,
   instructorCanAssessLevel,
   gradingManagerIdsOf,
+  isGradingPaid,
+  PaymentStatus,
+  PAYMENT_STATUSES,
+  PAYMENT_STATUS_LABELS,
 } from '../../../functions/src/data-model';
 import { IconComponent } from '../icons/icon.component';
 import { DataManagerService } from '../data-manager.service';
@@ -264,6 +268,8 @@ export class GradingProgressComponent {
   protected editGradingManagerIds = signal<string[]>([]);
   protected editResultNotes = signal('');
   protected editDeclineNotes = signal('');
+  protected editPaymentStatus = signal<PaymentStatus>(PaymentStatus.PaidOther);
+  protected editPaymentNote = signal('');
   protected showDeclineForm = signal(false);
   protected isEditingRequest = signal(false);
   protected isSaving = signal(false);
@@ -272,6 +278,18 @@ export class GradingProgressComponent {
   protected isEditingEvent = signal(false);
   protected isEditingInstructor = signal(false);
   protected isEditingManagers = signal(false);
+  protected isEditingPayment = signal(false);
+  protected isEditingResultNotes = signal(false);
+
+  // Payment-status selector options for the template.
+  protected PaymentStatus = PaymentStatus;
+  protected paymentStatuses = PAYMENT_STATUSES;
+  paymentStatusLabel = (s: string) =>
+    PAYMENT_STATUS_LABELS[s as PaymentStatus] ?? s;
+
+  // The grading's current payment status label + whether it counts as unpaid.
+  currentPaymentLabel = computed(() => this.paymentStatusLabel(this.grading().paymentStatus));
+  isUnpaid = computed(() => !isGradingPaid(this.grading()));
 
   // Sync local editing signals from grading input whenever it changes.
   private syncEffect = effect(() => {
@@ -284,6 +302,8 @@ export class GradingProgressComponent {
     this.editGradingManagerIds.set(gradingManagerIdsOf(g));
     this.editResultNotes.set(g.resultNotes);
     this.editDeclineNotes.set(g.declineNotes || '');
+    this.editPaymentStatus.set(g.paymentStatus);
+    this.editPaymentNote.set(g.paymentNote || '');
   });
 
   // The manager-id update written on save: both the canonical `gradingManagerIds`
@@ -411,6 +431,31 @@ export class GradingProgressComponent {
   cancelManagerEdit() {
     this.editGradingManagerIds.set(gradingManagerIdsOf(this.grading()));
     this.isEditingManagers.set(false);
+  }
+
+  savePaymentDetails() {
+    this.gradingUpdated.emit({
+      paymentStatus: this.editPaymentStatus(),
+      paymentNote: this.editPaymentNote(),
+    });
+    this.isEditingPayment.set(false);
+  }
+
+  cancelPaymentEdit() {
+    const g = this.grading();
+    this.editPaymentStatus.set(g.paymentStatus);
+    this.editPaymentNote.set(g.paymentNote || '');
+    this.isEditingPayment.set(false);
+  }
+
+  saveResultNotes() {
+    this.gradingUpdated.emit({ resultNotes: this.editResultNotes() });
+    this.isEditingResultNotes.set(false);
+  }
+
+  cancelResultNotesEdit() {
+    this.editResultNotes.set(this.grading().resultNotes);
+    this.isEditingResultNotes.set(false);
   }
 
   cancelRequest() {

--- a/src/app/grading-progress/grading-progress.ts
+++ b/src/app/grading-progress/grading-progress.ts
@@ -329,6 +329,8 @@ export class GradingProgressComponent {
       this.editGradingEventDate() !== g.gradingEventDate ||
       this.editResultNotes() !== g.resultNotes ||
       this.editInstructorId() !== g.gradingInstructorId ||
+      this.editPaymentStatus() !== g.paymentStatus ||
+      this.editPaymentNote() !== (g.paymentNote || '') ||
       JSON.stringify(this.editGradingManagerIds()) !== JSON.stringify(gradingManagerIdsOf(g))
     );
   });
@@ -356,6 +358,8 @@ export class GradingProgressComponent {
       gradingEventDocId: this.editGradingEventDocId(),
       resultNotes: this.editResultNotes(),
       gradingInstructorId: this.editInstructorId(),
+      paymentStatus: this.editPaymentStatus(),
+      paymentNote: this.editPaymentNote(),
       ...this.managerIdsUpdate(),
     });
     this.saveStatus.set('saved');
@@ -373,6 +377,8 @@ export class GradingProgressComponent {
     this.editGradingEventDocId.set(g.gradingEventDocId);
     this.editGradingManagerIds.set(gradingManagerIdsOf(g));
     this.editResultNotes.set(g.resultNotes);
+    this.editPaymentStatus.set(g.paymentStatus);
+    this.editPaymentNote.set(g.paymentNote || '');
     this.saveStatus.set('');
   }
 

--- a/src/app/grading-progress/grading-progress.ts
+++ b/src/app/grading-progress/grading-progress.ts
@@ -39,6 +39,7 @@ import {
   PAYMENT_STATUSES,
   PAYMENT_STATUS_LABELS,
 } from '../../../functions/src/data-model';
+import { NgTemplateOutlet } from '@angular/common';
 import { IconComponent } from '../icons/icon.component';
 import { DataManagerService } from '../data-manager.service';
 import { FirebaseStateService } from '../firebase-state.service';
@@ -46,6 +47,7 @@ import { InstructorSelectorComponent } from '../instructor-selector/instructor-s
 import { RoutingService } from '../routing.service';
 import { AppPathPatterns, Views } from '../app.config';
 import { GradingEventInputComponent, GradingEventDetails } from '../grading-event-input/grading-event-input';
+import { MemberProfileLinkService } from '../member-profile-link.service';
 
 
 
@@ -53,7 +55,7 @@ import { GradingEventInputComponent, GradingEventDetails } from '../grading-even
   selector: 'app-grading-progress',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [IconComponent, InstructorSelectorComponent, GradingEventInputComponent],
+  imports: [NgTemplateOutlet, IconComponent, InstructorSelectorComponent, GradingEventInputComponent],
   templateUrl: './grading-progress.html',
   styleUrl: './grading-progress.scss',
 })
@@ -61,6 +63,7 @@ export class GradingProgressComponent {
   private firebaseState = inject(FirebaseStateService);
   public dataService = inject(DataManagerService);
   private routingService = inject(RoutingService<AppPathPatterns>);
+  private profileLinks = inject(MemberProfileLinkService);
 
   grading = input.required<Grading>();
   gradingUpdated = output<Partial<Grading>>();
@@ -203,6 +206,11 @@ export class GradingProgressComponent {
       g.studentName,
     );
   });
+
+  // Link to the student's profile, present only for viewers permitted to see it
+  // (admins, the student's primary instructor, or a manager of their primary
+  // school). Null otherwise — the name then renders as plain text.
+  studentProfileLink = computed(() => this.profileLinks.profileLink(this.studentMember()));
 
   gradingInstructor = computed(() => {
     const id = this.grading().gradingInstructorId;

--- a/src/app/grading-row-header/grading-row-header.html
+++ b/src/app/grading-row-header/grading-row-header.html
@@ -11,6 +11,12 @@
     >
   }
 
+  @if (isUnpaid()) {
+    <span class="unpaid-chip" title="Accepted/completed but not yet paid">
+      <app-icon name="error" width="13" height="13"></app-icon>Unpaid
+    </span>
+  }
+
   <span class="name">
     @if (studentName()) {
       {{ studentName() }}

--- a/src/app/grading-row-header/grading-row-header.scss
+++ b/src/app/grading-row-header/grading-row-header.scss
@@ -41,6 +41,21 @@
   }
 }
 
+// Warning chip for gradings accepted/completed but not yet paid.
+.unpaid-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 0.85em;
+  font-weight: 600;
+  flex-shrink: 0;
+  white-space: nowrap;
+  background-color: #ffe0b2;
+  color: #8a5200;
+}
+
 .name {
   font-weight: bold;
   flex-shrink: 0;

--- a/src/app/grading-row-header/grading-row-header.ts
+++ b/src/app/grading-row-header/grading-row-header.ts
@@ -6,7 +6,7 @@
  */
 
 import { Component, computed, inject, input } from '@angular/core';
-import { Grading, GradingStatus, getPrettyGradingStatus, previousGradingLevel } from '../../../functions/src/data-model';
+import { Grading, GradingStatus, getPrettyGradingStatus, previousGradingLevel, isGradingPaid } from '../../../functions/src/data-model';
 import { IconComponent } from '../icons/icon.component';
 import { DataManagerService } from '../data-manager.service';
 import { RoutingService } from '../routing.service';
@@ -31,6 +31,17 @@ export class GradingRowHeaderComponent {
 
   GradingStatus = GradingStatus;
   getPrettyGradingStatus = getPrettyGradingStatus;
+
+  // Flag gradings that have been accepted or completed but are not yet paid —
+  // payment is expected by that point, so the row shows an "unpaid" warning.
+  isUnpaid = computed(() => {
+    const g = this.grading();
+    const acceptedOrDone =
+      g.status === GradingStatus.AwaitingGrading ||
+      g.status === GradingStatus.Passed ||
+      g.status === GradingStatus.NotPassed;
+    return acceptedOrDone && !isGradingPaid(g);
+  });
 
   studentName = computed(() => {
     const g = this.grading();

--- a/src/app/member-profile-link.service.ts
+++ b/src/app/member-profile-link.service.ts
@@ -1,0 +1,51 @@
+import { Injectable, inject } from '@angular/core';
+import { Member } from '../../functions/src/data-model';
+import { FirebaseStateService } from './firebase-state.service';
+import { RoutingService } from './routing.service';
+import { AppPathPatterns, Views } from './app.config';
+
+/**
+ * Builds a link to a member's profile that is appropriate for — and only
+ * present for — the current viewer. Each audience reaches a member through a
+ * different, permission-scoped page, so the route depends on the relationship:
+ *
+ *   - admins                          → the member management view
+ *   - the member's primary instructor → their "my students" student view
+ *   - an owner/manager of the member's primary school → the school member view
+ *
+ * Returns null when the viewer has no permitted view of the member (e.g. a
+ * grading instructor who isn't the student's sifu, or the student themselves).
+ * Factored out here because the same "who can see whom, and where" logic is
+ * needed in several places across the app.
+ */
+@Injectable({ providedIn: 'root' })
+export class MemberProfileLinkService {
+  private firebaseState = inject(FirebaseStateService);
+  private routing = inject(RoutingService<AppPathPatterns>);
+
+  profileLink(member: Member | undefined | null): string | null {
+    const user = this.firebaseState.user();
+    if (!user || !member) return null;
+    // The member-view routes accept the human memberId, falling back to the
+    // Firestore doc ID (the views resolve either).
+    const memberId = member.memberId || member.docId;
+    if (!memberId) return null;
+
+    if (user.isAdmin) {
+      return this.routing.hrefForView(Views.ManageMemberView, { memberId });
+    }
+    if (
+      user.member.instructorId &&
+      member.primaryInstructorId === user.member.instructorId
+    ) {
+      return this.routing.hrefForView(Views.MyStudentView, { memberId });
+    }
+    if (member.primarySchoolId && user.schoolsManaged.includes(member.primarySchoolId)) {
+      return this.routing.hrefForView(Views.SchoolMemberView, {
+        schoolId: member.primarySchoolId,
+        memberId,
+      });
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
**PR 4 of 6** in the grading-system refinement series. UI/UX in the grading progression.

## Save UX (`grading-progress`)
- **Removed the silent 5s auto-save.** Edits no longer persist on their own.
- Added an **"You have unsaved changes"** bar with **Save** / **Discard**, shown while the inline detail edits (event/date/result notes/grading instructor/managers) are dirty.
- **Workflow actions** (Accept, Mark Passed / Not Passed, Decline) are **disabled until edits are saved or discarded**, so recording a result is a deliberate step.
- Consistent **"Grading Instructor"** wording for the grading role.

## Event input redesign (`grading-event-input`)
- **Date first**, and **always shown** — even when an ILC event is linked.
- Replaced the *Linked ILC event / Other event* tab toggle with a single **"Grading was not at a listed workshop/event"** checkbox. When checked, the grading is **date-only** (no name/link needed). When unchecked, the search appears under **"Grading happened at event:"**.
- Event search window widened to **±15 days** around the grading date.

Applies in both the inline progression view and the admin grading-edit form (shared component).

## Verification
- `pnpm build` (Angular) ✓
- `pnpm test:once` → 379 pass (incl. grading-progress 13)

> Best reviewed by clicking through a grading: edit a result note → the Save/Discard bar appears and Mark-as-Passed is disabled until you Save/Discard; and the event picker now leads with the date + the "not at a listed event" checkbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)