### PR TITLE
feat(gradings): internal notes, unpaid list filter, unpaid request guard (PR 5/6)

### DIFF
--- a/docs/user-stories/grading-unpaid-request-guard.md
+++ b/docs/user-stories/grading-unpaid-request-guard.md
@@ -1,0 +1,29 @@
+# Block new grading requests while payment is outstanding
+
+- **ID:** grading-unpaid-request-guard
+- **Status:** Implemented
+- **Area:** Gradings
+
+## Story
+
+As **ILC**, I want a student who has a completed grading that hasn't been paid
+for yet to be unable to request a new grading from an instructor, so that
+students settle outstanding gradings before booking more.
+
+A grading counts as "completed but unpaid" when its status is `passed` or
+`not-passed` and its `paymentStatus` is `not-yet-paid` (see `isGradingPaid`).
+
+## Acceptance criteria
+
+- When a non-admin student tries to request a grading (move it to
+  `awaiting-instructor-acceptance`) while they have any other completed grading
+  that is not yet paid, the request is refused.
+  - **Client:** the request form shows a "Payment outstanding" warning and the
+    Submit button is disabled (`grading-progress`).
+  - **Server:** the `onGradingUpdated` trigger reverts the status (and grading
+    instructor) back to its previous value and notifies the student. This is the
+    authoritative check, since Firestore rules cannot query the student's other
+    gradings.
+- **Admins are exempt** — they can move a grading into acceptance regardless
+  (the trigger skips the check when the acting member, `statusChangedByMemberDocId`,
+  is an admin).

--- a/functions/src/on-grading-update.ts
+++ b/functions/src/on-grading-update.ts
@@ -237,6 +237,33 @@ async function resolveGradingNames(
   return { studentName, gradingInstructorName };
 }
 
+/** Whether the member with this doc ID is an admin. */
+async function isMemberAdmin(memberDocId: string | undefined): Promise<boolean> {
+  if (!memberDocId) return false;
+  const snap = await db.collection('members').doc(memberDocId).get();
+  return snap.exists ? !!snap.data()?.isAdmin : false;
+}
+
+/**
+ * Whether the student has any completed (passed/not-passed) gradings — other
+ * than `excludeDocId` — that are not yet paid. Used to block requesting a new
+ * grading until outstanding payments are settled.
+ */
+async function hasOutstandingUnpaidGradings(
+  studentMemberDocId: string,
+  excludeDocId: string,
+): Promise<boolean> {
+  if (!studentMemberDocId) return false;
+  const snap = await db
+    .collection('gradings')
+    .where('studentMemberDocId', '==', studentMemberDocId)
+    .where('status', 'in', [GradingStatus.Passed, GradingStatus.NotPassed])
+    .get();
+  return snap.docs.some(
+    (d) => d.id !== excludeDocId && !isGradingPaid(d.data() as Grading),
+  );
+}
+
 async function getPrimaryInstructorId(memberDocId: string | undefined): Promise<string | undefined> {
   if (!memberDocId) return undefined;
   const snap = await db.collection('members').doc(memberDocId).get();
@@ -517,6 +544,48 @@ export const onGradingUpdated = onDocumentUpdated(
     const previous = snap.before.data() as Grading;
     previous.docId = snap.before.id;
     const gradingDocId = snap.after.id;
+
+    // Enforce "settle outstanding payments before requesting again": a non-admin
+    // student may not move a grading into AwaitingAcceptance (i.e. request an
+    // instructor) while they have other completed gradings that aren't paid.
+    // Revert such a request and notify the student. Admins are exempt. The revert
+    // re-fires this trigger with a non-AwaitingAcceptance status, so it does not
+    // loop. story: docs/user-stories/grading-unpaid-request-guard.md
+    if (
+      grading.status === GradingStatus.AwaitingAcceptance &&
+      previous.status !== GradingStatus.AwaitingAcceptance &&
+      grading.studentMemberDocId
+    ) {
+      const actorIsAdmin = await isMemberAdmin(grading.statusChangedByMemberDocId);
+      if (!actorIsAdmin) {
+        const blocked = await hasOutstandingUnpaidGradings(
+          grading.studentMemberDocId,
+          gradingDocId,
+        );
+        if (blocked) {
+          await snap.after.ref.update({
+            status: previous.status,
+            gradingInstructorId: previous.gradingInstructorId,
+            lastUpdated: FieldValue.serverTimestamp(),
+          });
+          await createNotification(grading.studentMemberDocId, {
+            markdown:
+              `Your grading request for **${grading.level}** could not be sent: you have a ` +
+              `completed grading that hasn't been paid for yet. Please settle that first, ` +
+              `then request again.`,
+            createdAt: new Date().toISOString(),
+            dismissed: false,
+            kind: NotificationKind.GradingUnpaid,
+            data: { gradingDocId, level: grading.level },
+          });
+          logger.info(
+            `Grading ${gradingDocId} request reverted: student ${grading.studentMemberId} ` +
+              `has outstanding unpaid completed gradings.`,
+          );
+          return;
+        }
+      }
+    }
 
     // Re-resolve the cached display names from the current student/instructor so
     // they stay in sync on every update. Set on the in-memory grading first so

--- a/functions/src/on-grading-update.ts
+++ b/functions/src/on-grading-update.ts
@@ -248,6 +248,13 @@ async function isMemberAdmin(memberDocId: string | undefined): Promise<boolean> 
  * Whether the student has any completed (passed/not-passed) gradings — other
  * than `excludeDocId` — that are not yet paid. Used to block requesting a new
  * grading until outstanding payments are settled.
+ *
+ * Queries by `studentMemberDocId` only (a single-field equality, served by the
+ * automatic index — no composite index needed) and filters status + payment in
+ * memory. A student has few gradings, so this is cheap. Filtering `paymentStatus`
+ * in code (rather than adding it to the query) also keeps legacy docs that
+ * predate the field treated as paid (see `isGradingPaid`), and avoids a 3-field
+ * composite index.
  */
 async function hasOutstandingUnpaidGradings(
   studentMemberDocId: string,
@@ -257,11 +264,14 @@ async function hasOutstandingUnpaidGradings(
   const snap = await db
     .collection('gradings')
     .where('studentMemberDocId', '==', studentMemberDocId)
-    .where('status', 'in', [GradingStatus.Passed, GradingStatus.NotPassed])
     .get();
-  return snap.docs.some(
-    (d) => d.id !== excludeDocId && !isGradingPaid(d.data() as Grading),
-  );
+  return snap.docs.some((d) => {
+    if (d.id === excludeDocId) return false;
+    const g = d.data() as Grading;
+    const completed =
+      g.status === GradingStatus.Passed || g.status === GradingStatus.NotPassed;
+    return completed && !isGradingPaid(g);
+  });
 }
 
 async function getPrimaryInstructorId(memberDocId: string | undefined): Promise<string | undefined> {

--- a/src/app/grading-edit/grading-edit.html
+++ b/src/app/grading-edit/grading-edit.html
@@ -67,7 +67,7 @@
       </div>
 
       <label for="studentNotes" class="align-top"
-        >Note from student (optional)</label
+        >Note from the student (sent with their request)</label
       >
       <div class="rhs">
         <textarea
@@ -237,17 +237,25 @@
         ></app-grading-event-input>
       </div>
 
-      <label for="notes" class="align-top">Internal Notes (admin)</label>
-      <div class="rhs">
-        <textarea id="notes" [formField]="form.notes"></textarea>
-      </div>
-
-      <label for="resultNotes" class="align-top">Notes for the student</label>
+      <label for="resultNotes" class="align-top"
+        >Notes for the student (feedback to work on)</label
+      >
       <div class="rhs">
         <textarea
           id="resultNotes"
           [formField]="form.resultNotes"
           placeholder="Feedback or comments visible to the student..."
+        ></textarea>
+      </div>
+
+      <label for="notes" class="align-top"
+        >Internal administrative notes (not visible to the student)</label
+      >
+      <div class="rhs">
+        <textarea
+          id="notes"
+          [formField]="form.notes"
+          placeholder="Notes for admins / grading managers only..."
         ></textarea>
       </div>
 

--- a/src/app/grading-list/grading-list.html
+++ b/src/app/grading-list/grading-list.html
@@ -118,6 +118,17 @@
           (textUpdated)="onEventFilterText($event)"
         ></app-autocomplete>
       </div>
+      <div class="filter-row">
+        <label>Payment</label>
+        <label class="unpaid-filter-label">
+          <input
+            type="checkbox"
+            [checked]="filterUnpaidOnly()"
+            (change)="filterUnpaidOnly.set($any($event.target).checked); limit.set(50)"
+          />
+          Unpaid only (accepted/completed, not yet paid)
+        </label>
+      </div>
       @if (hasActiveFilters()) {
         <button class="subtle-button clear-filters-btn" (click)="clearFilters()">
           <app-icon name="close"></app-icon> Clear filters

--- a/src/app/grading-list/grading-list.scss
+++ b/src/app/grading-list/grading-list.scss
@@ -152,6 +152,14 @@
       min-width: 10em;
     }
 
+    .unpaid-filter-label {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4em;
+      cursor: pointer;
+      white-space: normal;
+    }
+
     .filter-autocomplete {
       flex: 1 1 18em;
       min-width: 14em;

--- a/src/app/grading-list/grading-list.ts
+++ b/src/app/grading-list/grading-list.ts
@@ -7,7 +7,7 @@ import {
   signal,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { Grading, GradingStatus, IlcEvent, getPrettyGradingStatus, initGrading, gradingManagerIdsOf } from '../../../functions/src/data-model';
+import { Grading, GradingStatus, IlcEvent, getPrettyGradingStatus, initGrading, gradingManagerIdsOf, isGradingPaid } from '../../../functions/src/data-model';
 import { SearchableSet } from '../searchable-set';
 import { GradingEditComponent } from '../grading-edit/grading-edit';
 import { GradingRowHeaderComponent } from '../grading-row-header/grading-row-header';
@@ -167,6 +167,8 @@ export class GradingListComponent {
   filterInstructorId = signal('');
   filterStatus = signal('');
   filterStudentMemberId = signal('');
+  // Show only gradings that have been accepted/completed but are not yet paid.
+  filterUnpaidOnly = signal(false);
 
   // The selected event filter lives in the URL `event` param so a filtered view
   // (e.g. all gradings at one event) is shareable. Both grading routes
@@ -219,7 +221,8 @@ export class GradingListComponent {
   hasActiveFilters = computed(() =>
     !!this.filterFromDate() || !!this.filterToDate() ||
     !!this.filterInstructorId() || !!this.filterStatus() ||
-    !!this.filterStudentMemberId() || !!this.filterEventDocId()
+    !!this.filterStudentMemberId() || !!this.filterEventDocId() ||
+    this.filterUnpaidOnly()
   );
 
   filteredByTab = computed<Grading[]>(() => {
@@ -271,6 +274,15 @@ export class GradingListComponent {
     }
     if (eventDocId) {
       results = results.filter(g => g.gradingEventDocId === eventDocId);
+    }
+    if (this.filterUnpaidOnly()) {
+      results = results.filter((g) => {
+        const acceptedOrDone =
+          g.status === GradingStatus.AwaitingGrading ||
+          g.status === GradingStatus.Passed ||
+          g.status === GradingStatus.NotPassed;
+        return acceptedOrDone && !isGradingPaid(g);
+      });
     }
     return results;
   });
@@ -451,6 +463,7 @@ export class GradingListComponent {
     this.filterStatus.set('');
     this.filterStudentMemberId.set('');
     this.setFilterEventDocId('');
+    this.filterUnpaidOnly.set(false);
     this.limit.set(50);
   }
 

--- a/src/app/grading-progress/grading-progress.html
+++ b/src/app/grading-progress/grading-progress.html
@@ -321,6 +321,17 @@
               ></app-grading-event-input>
             </div>
 
+            @if (requestBlockedByUnpaid()) {
+              <div class="warning-box">
+                <app-icon name="error" width="18" height="18" fill="#b06000"></app-icon>
+                <span>
+                  <strong>Payment outstanding.</strong> You have a completed
+                  grading that hasn't been paid for yet. Please settle that before
+                  requesting a new grading.
+                </span>
+              </div>
+            }
+
             <div class="field-actions">
               @if (g.status === GradingStatus.AwaitingAcceptance) {
                 <button (click)="isEditingRequest.set(false)">
@@ -329,7 +340,7 @@
               }
               <button
                 (click)="saveRequestFields()"
-                [disabled]="isSaving() || !editInstructorId()"
+                [disabled]="isSaving() || !editInstructorId() || requestBlockedByUnpaid() || eventInputInvalid()"
               >
                 Submit Request
               </button>
@@ -650,7 +661,7 @@
             ></app-grading-event-input>
           </div>
 
-          <label>Notes (optional)</label>
+          <label>Notes for the student (feedback)</label>
           <div class="field">
             <textarea
               [value]="editResultNotes()"
@@ -732,6 +743,16 @@
               (input)="editPaymentNote.set($any($event.target).value)"
               placeholder="Payment note (optional)"
             />
+          </div>
+
+          <label class="align-top">Internal notes</label>
+          <div class="field">
+            <textarea
+              [value]="editInternalNotes()"
+              (input)="editInternalNotes.set($any($event.target).value)"
+              placeholder="Internal notes — not visible to the student..."
+              rows="2"
+            ></textarea>
           </div>
         </div>
 
@@ -973,6 +994,36 @@
         <p class="detail-note">
           <button class="subtle-button detail-edit-btn" (click)="isEditingResultNotes.set(true)"><app-icon name="edit"></app-icon> Add notes for the student</button>
         </p>
+      }
+
+      <!-- Internal administrative notes — only for grading managers/instructors/
+           admins; never shown to the student. -->
+      @if (canEditGradingDetails()) {
+        @if (isEditingInternalNotes()) {
+          <div class="detail-inline-edit result-notes-edit">
+            <label>Internal notes (not visible to the student)</label>
+            <textarea
+              [value]="editInternalNotes()"
+              (input)="editInternalNotes.set($any($event.target).value)"
+              rows="3"
+              placeholder="Notes for admins / grading managers only..."
+            ></textarea>
+            <div class="detail-edit-actions">
+              <button class="subtle-button" (click)="saveInternalNotes()">Save</button>
+              <button class="subtle-button" (click)="cancelInternalNotesEdit()">Cancel</button>
+            </div>
+          </div>
+        } @else if (g.notes) {
+          <p class="detail-note internal-note">
+            <app-icon name="admin" width="14" height="14"></app-icon>
+            <strong>Internal notes (not visible to the student):</strong> {{ g.notes }}
+            <button class="icon-only-button detail-edit-btn" (click)="isEditingInternalNotes.set(true)" title="Edit internal notes"><app-icon name="edit"></app-icon></button>
+          </p>
+        } @else {
+          <p class="detail-note">
+            <button class="subtle-button detail-edit-btn" (click)="isEditingInternalNotes.set(true)"><app-icon name="edit"></app-icon> Add internal notes</button>
+          </p>
+        }
       }
 
       <div class="details-grid">

--- a/src/app/grading-progress/grading-progress.scss
+++ b/src/app/grading-progress/grading-progress.scss
@@ -218,6 +218,22 @@
   margin-top: 0.6em;
 }
 
+// Internal administrative note — visually distinct (grey) to signal it is not
+// shown to the student.
+.internal-note {
+  display: flex;
+  align-items: baseline;
+  gap: 0.35em;
+  background-color: #f1f3f4;
+  border-radius: 4px;
+  padding: 0.35em 0.55em;
+
+  app-icon {
+    flex-shrink: 0;
+    align-self: center;
+  }
+}
+
 // Student name link to their profile (subtle; underlines on hover).
 .student-profile-link {
   color: inherit;

--- a/src/app/grading-progress/grading-progress.spec.ts
+++ b/src/app/grading-progress/grading-progress.spec.ts
@@ -36,6 +36,7 @@ describe('GradingProgressComponent', () => {
     mockDataService = {
       members: new SearchableSet(['memberId'], 'memberId', []) as never,
       instructors: new SearchableSet(['instructorId'], 'instructorId', []) as never,
+      myGradings: new SearchableSet(['docId'], 'docId', []) as never,
       getMemberByDocId: () => undefined,
       getMemberByMemberId: () => undefined,
       getMyStudent: () => undefined,

--- a/src/app/grading-progress/grading-progress.ts
+++ b/src/app/grading-progress/grading-progress.ts
@@ -160,6 +160,28 @@ export class GradingProgressComponent {
   // the canonical progression). '' when grading for the first progression entry.
   previousLevel = computed(() => previousGradingLevel(this.grading().level));
 
+  // Other completed (passed/not-passed) gradings of this student that are not yet
+  // paid. While any exist the student may not request a new grading from an
+  // instructor — they must settle payment first. Read from the logged-in user's
+  // own gradings, so it only applies when the student views their own grading.
+  outstandingUnpaidGradings = computed(() => {
+    const g = this.grading();
+    return this.dataService.myGradings.entries().filter(
+      (other) =>
+        other.docId !== g.docId &&
+        other.studentMemberDocId === g.studentMemberDocId &&
+        (other.status === GradingStatus.Passed || other.status === GradingStatus.NotPassed) &&
+        !isGradingPaid(other),
+    );
+  });
+
+  // A non-admin student is blocked from submitting a new request while they have
+  // outstanding unpaid completed gradings. Admins are exempt (and the server
+  // trigger enforces the same rule, exempting admins).
+  requestBlockedByUnpaid = computed(
+    () => this.userIsStudent() && !this.userIsAdmin() && this.outstandingUnpaidGradings().length > 0,
+  );
+
   // Admin, grading instructor, or any grading manager can edit event/instructor/managers.
   canEditGradingDetails = computed(() => this.userIsAdmin() || this.userIsGradingInstructor());
 
@@ -275,6 +297,9 @@ export class GradingProgressComponent {
   // Local edit signal for grading managers (backed by `gradingManagerIds`).
   protected editGradingManagerIds = signal<string[]>([]);
   protected editResultNotes = signal('');
+  // Internal administrative notes (the grading's `notes` field) — visible to
+  // grading managers/instructors/admins only, never the student.
+  protected editInternalNotes = signal('');
   protected editDeclineNotes = signal('');
   protected editPaymentStatus = signal<PaymentStatus>(PaymentStatus.PaidOther);
   protected editPaymentNote = signal('');
@@ -288,6 +313,7 @@ export class GradingProgressComponent {
   protected isEditingManagers = signal(false);
   protected isEditingPayment = signal(false);
   protected isEditingResultNotes = signal(false);
+  protected isEditingInternalNotes = signal(false);
 
   // Payment-status selector options for the template.
   protected PaymentStatus = PaymentStatus;
@@ -309,6 +335,7 @@ export class GradingProgressComponent {
     this.editGradingEventDocId.set(g.gradingEventDocId);
     this.editGradingManagerIds.set(gradingManagerIdsOf(g));
     this.editResultNotes.set(g.resultNotes);
+    this.editInternalNotes.set(g.notes || '');
     this.editDeclineNotes.set(g.declineNotes || '');
     this.editPaymentStatus.set(g.paymentStatus);
     this.editPaymentNote.set(g.paymentNote || '');
@@ -328,6 +355,7 @@ export class GradingProgressComponent {
       this.editGradingEvent() !== g.gradingEvent ||
       this.editGradingEventDate() !== g.gradingEventDate ||
       this.editResultNotes() !== g.resultNotes ||
+      this.editInternalNotes() !== (g.notes || '') ||
       this.editInstructorId() !== g.gradingInstructorId ||
       this.editPaymentStatus() !== g.paymentStatus ||
       this.editPaymentNote() !== (g.paymentNote || '') ||
@@ -357,6 +385,7 @@ export class GradingProgressComponent {
       gradingEventDate: this.editGradingEventDate(),
       gradingEventDocId: this.editGradingEventDocId(),
       resultNotes: this.editResultNotes(),
+      notes: this.editInternalNotes(),
       gradingInstructorId: this.editInstructorId(),
       paymentStatus: this.editPaymentStatus(),
       paymentNote: this.editPaymentNote(),
@@ -377,6 +406,7 @@ export class GradingProgressComponent {
     this.editGradingEventDocId.set(g.gradingEventDocId);
     this.editGradingManagerIds.set(gradingManagerIdsOf(g));
     this.editResultNotes.set(g.resultNotes);
+    this.editInternalNotes.set(g.notes || '');
     this.editPaymentStatus.set(g.paymentStatus);
     this.editPaymentNote.set(g.paymentNote || '');
     this.saveStatus.set('');
@@ -395,8 +425,11 @@ export class GradingProgressComponent {
 
   // Step 1: Save student request fields
   saveRequestFields() {
-    this.isSaving.set(true);
     const instructorId = this.editInstructorId();
+    // Block requesting a grading from an instructor while the student has
+    // outstanding unpaid completed gradings (non-admins only; mirrored server-side).
+    if (instructorId && this.requestBlockedByUnpaid()) return;
+    this.isSaving.set(true);
     const update: Partial<Grading> = {
       gradingInstructorId: instructorId,
       studentNotes: this.editStudentNotes(),
@@ -479,6 +512,16 @@ export class GradingProgressComponent {
   cancelResultNotesEdit() {
     this.editResultNotes.set(this.grading().resultNotes);
     this.isEditingResultNotes.set(false);
+  }
+
+  saveInternalNotes() {
+    this.gradingUpdated.emit({ notes: this.editInternalNotes() });
+    this.isEditingInternalNotes.set(false);
+  }
+
+  cancelInternalNotesEdit() {
+    this.editInternalNotes.set(this.grading().notes || '');
+    this.isEditingInternalNotes.set(false);
   }
 
   cancelRequest() {

--- a/tests/e2e/grading-paid-and-snapshot.spec.ts
+++ b/tests/e2e/grading-paid-and-snapshot.spec.ts
@@ -215,3 +215,96 @@ describe('story: sifu notified when their student requests a grading', () => {
     expect(note.length).toBeGreaterThan(0);
   });
 });
+
+describe('story: new grading requests blocked while a grading is unpaid', () => {
+  const suffix = Date.now().toString(36);
+  const studentDocId = `rg-student-${suffix}`;
+  const memberId = `RG-${suffix}`;
+  const adminDocId = `rg-admin-${suffix}`;
+  let unpaidDocId = '';
+  let newDocId = '';
+
+  beforeAll(async () => {
+    await db.collection('members').doc(studentDocId).set({
+      name: 'Request Guard Student',
+      memberId,
+      isAdmin: false,
+      gradingDocIds: [],
+    });
+    await db.collection('members').doc(adminDocId).set({
+      name: 'Admin A',
+      isAdmin: true,
+    });
+    // A completed grading that has not been paid.
+    const unpaidRef = db.collection('gradings').doc();
+    unpaidDocId = unpaidRef.id;
+    await unpaidRef.set({
+      ...initGrading(),
+      level: 'Student 1',
+      studentMemberId: memberId,
+      studentMemberDocId: studentDocId,
+      status: GradingStatus.Passed,
+      paymentStatus: PaymentStatus.NotYetPaid,
+    });
+    // A fresh grading the student will try to request.
+    const newRef = db.collection('gradings').doc();
+    newDocId = newRef.id;
+    await newRef.set({
+      ...initGrading(),
+      level: 'Student 2',
+      studentMemberId: memberId,
+      studentMemberDocId: studentDocId,
+      status: GradingStatus.AwaitingRequest,
+    });
+  });
+
+  it('reverts a student request and notifies them when a grading is unpaid', async () => {
+    await db.collection('gradings').doc(newDocId).update({
+      status: GradingStatus.AwaitingAcceptance,
+      gradingInstructorId: 'INST-RG',
+      statusChangedByMemberDocId: studentDocId,
+      statusChangedByName: 'Request Guard Student',
+      lastUpdated: ts(),
+    });
+    // The trigger reverts the status back to AwaitingRequest.
+    const g = await waitFor(
+      gradingDoc(newDocId),
+      (v) => !!v && v.status === GradingStatus.AwaitingRequest,
+    );
+    expect(g!.status).toBe(GradingStatus.AwaitingRequest);
+    // The student is told why.
+    await waitFor(
+      async () => {
+        const snap = await db
+          .collection('members')
+          .doc(studentDocId)
+          .collection('notifications')
+          .where('data.gradingDocId', '==', newDocId)
+          .get();
+        return snap.docs.map((d) => d.data() as MemberNotification);
+      },
+      (notes) => notes.some((n) => n.kind === NotificationKind.GradingUnpaid),
+    );
+  });
+
+  it('lets an admin request despite the unpaid grading', async () => {
+    // Reset the new grading to AwaitingRequest first.
+    await db.collection('gradings').doc(newDocId).update({
+      status: GradingStatus.AwaitingRequest,
+      gradingInstructorId: '',
+      lastUpdated: ts(),
+    });
+    await new Promise((r) => setTimeout(r, 1500));
+    await db.collection('gradings').doc(newDocId).update({
+      status: GradingStatus.AwaitingAcceptance,
+      gradingInstructorId: 'INST-RG',
+      statusChangedByMemberDocId: adminDocId,
+      statusChangedByName: 'Admin A',
+      lastUpdated: ts(),
+    });
+    // Give the trigger time, then confirm it was NOT reverted.
+    await new Promise((r) => setTimeout(r, 3000));
+    const g = await gradingDoc(newDocId)();
+    expect(g!.status).toBe(GradingStatus.AwaitingAcceptance);
+  });
+});


### PR DESCRIPTION
**PR 5 of 6** in the grading-system refinement series.

## Notes (student-facing vs internal)
- **Admin edit form**: relabelled the note fields and reordered them — **"Notes for the student (feedback to work on)"** first, then **"Internal administrative notes (not visible to the student)"**.
- **Grading progression**: the internal `notes` field is now shown and inline-editable for **grading managers / instructors / admins only** (never the student), visually distinct (grey) from the student-facing result notes. Also editable in the awaiting-grading form.

## Unpaid filter
- **Grading list**: new **"Unpaid only"** filter — gradings that have been accepted/completed but aren't yet paid (complements the unpaid row chip from PR 4).

## Request guard (client + server)
A non-admin student **cannot request a new grading while they have a completed grading that hasn't been paid**:
- **Client** (`grading-progress`): the request form shows a "Payment outstanding" warning and disables Submit.
- **Server** (`onGradingUpdated`): a member-driven move into `awaiting-instructor-acceptance` is **reverted** and the student is notified. **Admins are exempt.** Firestore rules can't query the student's other gradings, so the trigger is the authoritative check (documented in `docs/user-stories/grading-unpaid-request-guard.md`).

## Verification
- `pnpm build` ✓, `pnpm build:functions` ✓
- `pnpm test:once` → 379 ✓
- `pnpm test:functions` → 204 ✓
- `pnpm test:e2e` → 12 ✓ (2 new: request reverted for student, admin bypass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)