### PR TITLE
feat(notifications): reconcile catch-up notifications with their source

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -70,7 +70,13 @@ service cloud.firestore {
         allow read: if isNotificationOwner() || isAdmin();
         allow create: if isNotificationOwner() || isAdmin();
         allow delete: if isNotificationOwner() || isAdmin();
-        allow update: if isNotificationOwner() && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['dismissed']);
+        // The owner may dismiss a notification and may refresh the content of
+        // their own notifications during client-side reconciliation (keeping a
+        // notification's markdown/data in step with the source it was generated
+        // from). Owners can already create/delete their own notifications, so this
+        // grants no new authority; it just keeps the writable surface scoped to
+        // these fields (kind/createdAt stay immutable).
+        allow update: if isNotificationOwner() && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['dismissed', 'markdown', 'data']);
       }
 
       // Web Push subscriptions for this member's devices. The member manages

--- a/src/app/notification.service.spec.ts
+++ b/src/app/notification.service.spec.ts
@@ -1,8 +1,26 @@
 import { TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
+import { writeBatch, getDocs, where } from 'firebase/firestore';
 import { NotificationService } from './notification.service';
 import { FirebaseStateService, createFirebaseStateServiceMock } from './firebase-state.service';
 import { MemberNotification, NotificationKind } from '../../functions/src/data-model';
+
+// Partial-mock firebase/firestore so reconciliation's writes/reads can be
+// captured. getFirestore (used in the service constructor) keeps its real
+// implementation; the query-builder fns are inert stand-ins since the tests
+// drive getDocs' return value directly.
+vi.mock('firebase/firestore', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('firebase/firestore')>();
+  return {
+    ...actual,
+    writeBatch: vi.fn(),
+    getDocs: vi.fn(),
+    query: vi.fn((...a: unknown[]) => a),
+    collection: vi.fn((...a: unknown[]) => ({ __collection: a })),
+    where: vi.fn((...a: unknown[]) => ({ __where: a })),
+    limit: vi.fn((...a: unknown[]) => ({ __limit: a })),
+  };
+});
 
 describe('NotificationService', () => {
   let service: NotificationService;
@@ -97,5 +115,228 @@ describe('NotificationService', () => {
     expect(spyLocalStorageSet).toHaveBeenCalledWith('pushedNotificationDocIds', JSON.stringify(['id1', 'id2']));
 
     vi.unstubAllGlobals();
+  });
+
+  describe('reconcileNotifications', () => {
+    // Builds a fake Firestore query-doc snapshot the helper can consume: it reads
+    // `.id`/`.data()` (via firestoreDocToMemberNotification) and `.ref` (for the
+    // batch update).
+    const makeDoc = (n: MemberNotification) => ({
+      id: n.docId,
+      ref: { id: n.docId },
+      data: () => n,
+    });
+
+    const notif = (over: Partial<MemberNotification>): MemberNotification => ({
+      docId: 'x',
+      markdown: 'old',
+      createdAt: '2026-05-14T12:00:00Z',
+      dismissed: false,
+      kind: NotificationKind.OrderNeedsAttention,
+      data: { orderDocId: 'o-x', orderRef: 'X', status: 'error', issues: [] },
+      ...over,
+    } as MemberNotification);
+
+    it('rewrites + dismisses resolved, updates changed in place, and skips unchanged', async () => {
+      const updates: { ref: { id: string }; patch: Record<string, unknown> }[] = [];
+      const commit = vi.fn().mockResolvedValue(undefined);
+      (writeBatch as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+        update: (ref: { id: string }, patch: Record<string, unknown>) =>
+          updates.push({ ref, patch }),
+        commit,
+      });
+
+      const resolved = notif({ docId: 'resolved', markdown: 'old', data: { orderDocId: 'o1' } as any });
+      const changed = notif({ docId: 'changed', markdown: 'old', data: { orderDocId: 'o2' } as any });
+      const unchanged = notif({ docId: 'unchanged', markdown: 'same', data: { orderDocId: 'o3' } as any });
+      const dismissed = notif({ docId: 'dismissed', markdown: 'old', dismissed: true, data: { orderDocId: 'o4' } as any });
+      const noEntity = notif({ docId: 'no-entity', markdown: 'old', data: {} as any });
+
+      await (service as any).reconcileNotifications(
+        [resolved, changed, unchanged, dismissed, noEntity].map(makeDoc),
+        'orderDocId',
+        async (n: MemberNotification) => {
+          switch (n.docId) {
+            case 'resolved':
+              return { markdown: 'now resolved', data: n.data, resolved: true };
+            case 'changed':
+              return { markdown: 'new text', data: n.data, resolved: false };
+            case 'unchanged':
+              return { markdown: n.markdown, data: n.data, resolved: false };
+            case 'dismissed':
+              return { markdown: 'new text', data: n.data, resolved: false };
+            default:
+              return null;
+          }
+        },
+      );
+
+      const byId = (id: string) => updates.find((u) => u.ref.id === id)?.patch;
+
+      // resolved: markdown rewritten AND dismissed set.
+      expect(byId('resolved')).toEqual({ markdown: 'now resolved', dismissed: true });
+      // changed but live: markdown only, dismissed untouched.
+      expect(byId('changed')).toEqual({ markdown: 'new text' });
+      // unchanged: no write.
+      expect(byId('unchanged')).toBeUndefined();
+      // already-dismissed + still live: updated in place, NOT re-surfaced.
+      expect(byId('dismissed')).toEqual({ markdown: 'new text' });
+      // no entity id / null resolve: skipped.
+      expect(byId('no-entity')).toBeUndefined();
+
+      expect(commit).toHaveBeenCalledTimes(1);
+    });
+
+    it('blog reconcile looks the post up by its source `id` field and refreshes the title', async () => {
+      // Regression: posts are keyed in Firestore by an auto-generated doc ID, not
+      // by their source `id`, so the lookup must query the `id` field (not getDoc
+      // by document ID) or it never finds the post and the title never updates.
+      (getDocs as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+        empty: false,
+        docs: [
+          {
+            data: () => ({
+              id: 'src-123',
+              title: 'New Title',
+              urlId: 'new-title',
+              publishOn: 1700000000000,
+            }),
+          },
+        ],
+      });
+
+      const feed = { collection: 'members-post', label: 'Members', route: 'members-area/post' };
+      const notif: MemberNotification = {
+        docId: 'n1',
+        markdown: 'New Members post: [Old Title](#/members-area/post/old-title)',
+        createdAt: '2026-05-14T12:00:00Z',
+        dismissed: false,
+        kind: NotificationKind.BlogPost,
+        data: {
+          blogPath: 'members-post',
+          blogCategory: '',
+          lastSeenDateStr: '2026-05-14T12:00:00Z',
+          blogPostId: 'src-123',
+          blogPostUrlId: 'old-title',
+        },
+      };
+
+      const result = await (service as any).resolveBlogNotification(feed, notif);
+
+      // Looked up by the source id field, not the document id.
+      expect(where).toHaveBeenCalledWith('id', '==', 'src-123');
+      expect(result.resolved).toBe(false);
+      expect(result.markdown).toBe(
+        'New Members post: [New Title](#/members-area/post/new-title)',
+      );
+    });
+
+    it('blog reconcile marks a missing post as removed + resolved', async () => {
+      (getDocs as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+        empty: true,
+        docs: [],
+      });
+
+      const feed = { collection: 'members-post', label: 'Members', route: 'members-area/post' };
+      const notif: MemberNotification = {
+        docId: 'n1',
+        markdown: 'New Members post: [Old Title](#/members-area/post/old-title)',
+        createdAt: '2026-05-14T12:00:00Z',
+        dismissed: false,
+        kind: NotificationKind.BlogPost,
+        data: {
+          blogPath: 'members-post',
+          blogCategory: '',
+          lastSeenDateStr: '2026-05-14T12:00:00Z',
+          blogPostId: 'src-404',
+          blogPostUrlId: 'old-title',
+        },
+      };
+
+      const result = await (service as any).resolveBlogNotification(feed, notif);
+      expect(result.resolved).toBe(true);
+      expect(result.markdown).toBe('~~New Members post~~ (post removed)');
+    });
+
+    it('syncBlogFeedNotifications reconciles existing posts even when no NEW posts exist', async () => {
+      // Regression: reconciliation used to sit after the create pass's "no new
+      // posts" early-return, so a re-titled post (which produces no new post) was
+      // never reconciled. This drives the per-feed sync with an empty posts query
+      // and asserts the existing notification still gets its title refreshed.
+      const getDocsMock = getDocs as unknown as ReturnType<typeof vi.fn>;
+      getDocsMock.mockReset();
+
+      const existingNotif: MemberNotification = {
+        docId: 'n1',
+        markdown: 'New Members post: [Old Title](#/members-area/post/old-title)',
+        createdAt: '2026-05-14T12:00:00Z',
+        dismissed: false,
+        kind: NotificationKind.BlogPost,
+        data: {
+          blogPath: 'members-post',
+          blogCategory: '',
+          lastSeenDateStr: '2026-05-14T12:00:00Z',
+          blogPostId: 'src-123',
+          blogPostUrlId: 'old-title',
+        },
+      };
+      const existingDoc = { id: 'n1', ref: { id: 'n1' }, data: () => existingNotif };
+      const existingSnap = {
+        forEach: (cb: (d: unknown) => void) => [existingDoc].forEach(cb),
+        docs: [existingDoc],
+      };
+
+      getDocsMock
+        // 1) existing BlogPost notifications for this member
+        .mockResolvedValueOnce(existingSnap)
+        // 2) latest posts query — empty: nothing new published since the cut-off
+        .mockResolvedValueOnce({ empty: true, docs: [] })
+        // 3) reconcile lookup of the post by its source `id` — returns new title
+        .mockResolvedValueOnce({
+          empty: false,
+          docs: [
+            {
+              data: () => ({
+                id: 'src-123',
+                title: 'New Title',
+                urlId: 'new-title',
+                publishOn: 1700000000000,
+              }),
+            },
+          ],
+        });
+
+      const updates: { patch: Record<string, unknown> }[] = [];
+      (writeBatch as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+        set: vi.fn(),
+        update: (_ref: unknown, patch: Record<string, unknown>) => updates.push({ patch }),
+        commit: vi.fn().mockResolvedValue(undefined),
+      });
+
+      const feed = { collection: 'members-post', label: 'Members', route: 'members-area/post' };
+      await (service as any).syncBlogFeedNotifications('member1', feed);
+
+      expect(updates).toHaveLength(1);
+      expect(updates[0].patch['markdown']).toBe(
+        'New Members post: [New Title](#/members-area/post/new-title)',
+      );
+    });
+
+    it('does not commit when nothing changed (idempotent re-run)', async () => {
+      const commit = vi.fn().mockResolvedValue(undefined);
+      (writeBatch as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+        update: vi.fn(),
+        commit,
+      });
+
+      const n = notif({ docId: 'a', markdown: 'same', data: { orderDocId: 'o1' } as any });
+      await (service as any).reconcileNotifications([makeDoc(n)], 'orderDocId', async () => ({
+        markdown: 'same',
+        data: n.data,
+        resolved: false,
+      }));
+
+      expect(commit).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/app/notification.service.ts
+++ b/src/app/notification.service.ts
@@ -17,6 +17,7 @@ import {
   where,
   Unsubscribe,
   writeBatch,
+  QueryDocumentSnapshot,
 } from 'firebase/firestore';
 import { FirebaseStateService } from './firebase-state.service';
 import {
@@ -29,10 +30,15 @@ import {
   Member,
   MembershipType,
   MemberNotification,
+  NotificationBlogPostData,
+  NotificationEventData,
+  NotificationGradingData,
   NotificationKind,
+  NotificationOrderIssueData,
   Order,
   OrderStatus,
   PushSubscriptionDoc,
+  eventStatusLabel,
   firestoreDocToGrading,
   firestoreDocToMemberNotification,
   firestoreDocToOrder,
@@ -424,6 +430,81 @@ export class NotificationService implements OnDestroy {
   }
 
   // ---------------------------------------------------------------------------
+  // Reconciliation: keep existing catch-up notifications in step with their source
+  // ---------------------------------------------------------------------------
+
+  // Reconciles already-created notifications against the current state of the
+  // entity they were generated from. For each existing notification of a kind,
+  // `resolve` looks up the live entity (via the id in the notification's `data`)
+  // and returns the markdown/data the notification *should* now carry, plus
+  // whether the underlying condition is resolved:
+  //   - condition still holds  -> content is refreshed in place, dismissed state
+  //     is preserved (we never re-surface something the user has dismissed);
+  //   - condition resolved      -> content is rewritten to say so and the
+  //     notification is dismissed.
+  // Only documents that actually differ are written, so re-running on the next
+  // login is a no-op. `resolve` returning null leaves the notification untouched
+  // (e.g. we couldn't read the entity); individual failures never abort the rest.
+  private async reconcileNotifications(
+    existingDocs: QueryDocumentSnapshot[],
+    entityIdField: string,
+    resolve: (
+      notif: MemberNotification,
+    ) => Promise<{ markdown: string; data: object; resolved: boolean } | null>,
+  ): Promise<void> {
+    const batch = writeBatch(this.db);
+    let writes = 0;
+
+    for (const d of existingDocs) {
+      const notif = firestoreDocToMemberNotification(d);
+      const data = notif.data as unknown as Record<string, unknown> | undefined;
+      if (!data || !data[entityIdField]) continue;
+
+      let desired: { markdown: string; data: object; resolved: boolean } | null;
+      try {
+        desired = await resolve(notif);
+      } catch (e) {
+        console.error('Failed to reconcile notification', notif.docId, e);
+        continue;
+      }
+      if (!desired) continue;
+
+      const patch: Record<string, unknown> = {};
+      if (desired.markdown !== notif.markdown) patch['markdown'] = desired.markdown;
+      if (this.stableStringify(desired.data) !== this.stableStringify(notif.data)) {
+        patch['data'] = desired.data;
+      }
+      if (desired.resolved && !notif.dismissed) patch['dismissed'] = true;
+
+      if (Object.keys(patch).length > 0) {
+        batch.update(d.ref, patch);
+        writes++;
+      }
+    }
+
+    if (writes > 0) await batch.commit();
+  }
+
+  // Order-stable JSON serialisation, used to compare a notification's stored
+  // `data` against the freshly-built desired value so reconciliation only writes
+  // on a real change regardless of object key ordering.
+  private stableStringify(value: unknown): string {
+    if (value === null || typeof value !== 'object') return JSON.stringify(value);
+    if (Array.isArray(value)) {
+      return '[' + value.map((v) => this.stableStringify(v)).join(',') + ']';
+    }
+    const obj = value as Record<string, unknown>;
+    return (
+      '{' +
+      Object.keys(obj)
+        .sort()
+        .map((k) => JSON.stringify(k) + ':' + this.stableStringify(obj[k]))
+        .join(',') +
+      '}'
+    );
+  }
+
+  // ---------------------------------------------------------------------------
   // Blog post catch-up notifications
   // ---------------------------------------------------------------------------
 
@@ -488,6 +569,8 @@ export class NotificationService implements OnDestroy {
     );
     let cutoffMs = 0;
     const notifiedPostIds = new Set<string>();
+    // Existing notifications for this specific feed, used for reconciliation below.
+    const feedDocs: QueryDocumentSnapshot[] = [];
     existingSnap.forEach((d) => {
       const data = (d.data() as MemberNotification).data as {
         blogPath?: string;
@@ -495,6 +578,7 @@ export class NotificationService implements OnDestroy {
         blogPostId?: string;
       };
       if (!data || data.blogPath !== feed.collection) return;
+      feedDocs.push(d);
       if (data.blogPostId) notifiedPostIds.add(data.blogPostId);
       const ms = data.lastSeenDateStr ? Date.parse(data.lastSeenDateStr) : NaN;
       if (!isNaN(ms) && ms > cutoffMs) cutoffMs = ms;
@@ -515,38 +599,89 @@ export class NotificationService implements OnDestroy {
         : query(postsCollection, orderBy('publishOn', 'desc'), limit(max));
 
     const postsSnap = await getDocs(postsQuery);
-    if (postsSnap.empty) return;
 
-    // Newest first; skip any post we've already notified about.
+    // Newest first; skip any post we've already notified about. May be empty when
+    // nothing new has been published since the cut-off — that's the common case,
+    // and we still fall through to reconciliation below.
     const posts = postsSnap.docs
       .map((d) => ({ ...initCachedBlogPost(), ...(d.data() as CachedBlogPost) }))
       .filter((p) => p.id && !notifiedPostIds.has(p.id));
-    if (posts.length === 0) return;
 
-    const batch = writeBatch(this.db);
-    for (const post of posts) {
-      const ref = doc(notifCollection); // auto-generated ID
-      const link = `#/${feed.route}/${post.urlId}`;
-      // Stamp the notification with the post's publish date (not "now") so the
-      // date shown on the card reflects when the post was published.
-      const publishedIso = new Date(post.publishOn || 0).toISOString();
-      const notification: MemberNotification = {
-        docId: ref.id,
-        markdown: `New ${feed.label} post: [${post.title || 'Untitled'}](${link})`,
-        createdAt: publishedIso,
-        dismissed: false,
-        kind: NotificationKind.BlogPost,
-        data: {
-          blogPath: feed.collection,
-          blogCategory: '',
-          lastSeenDateStr: publishedIso,
-          blogPostId: post.id,
-          blogPostUrlId: post.urlId,
-        },
-      };
-      batch.set(ref, notification);
+    if (posts.length > 0) {
+      const batch = writeBatch(this.db);
+      for (const post of posts) {
+        const ref = doc(notifCollection); // auto-generated ID
+        const fields = this.blogPostFields(feed, post);
+        const notification: MemberNotification = {
+          docId: ref.id,
+          markdown: fields.markdown,
+          // Stamp the notification with the post's publish date (not "now") so the
+          // date shown on the card reflects when the post was published.
+          createdAt: fields.data.lastSeenDateStr,
+          dismissed: false,
+          kind: NotificationKind.BlogPost,
+          data: fields.data,
+        };
+        batch.set(ref, notification);
+      }
+      await batch.commit();
     }
-    await batch.commit();
+
+    // Reconcile previously-created notifications for this feed against the posts
+    // as they stand now: re-titled/re-slugged posts have their card refreshed in
+    // place, and posts that have since been removed are marked as such + dismissed.
+    // Runs regardless of whether there were new posts to create above.
+    await this.reconcileNotifications(feedDocs, 'blogPostId', (notif) =>
+      this.resolveBlogNotification(feed, notif),
+    );
+  }
+
+  // Computes the desired state of a blog-post notification from the post as it
+  // stands now. Posts are keyed in Firestore by an auto-generated doc ID, not by
+  // their source `id`; blogPostId holds the source `id`, so the post is looked up
+  // by querying that field rather than by document ID.
+  private async resolveBlogNotification(
+    feed: { collection: string; label: string; route: string },
+    notif: MemberNotification,
+  ): Promise<{ markdown: string; data: object; resolved: boolean } | null> {
+    const data = notif.data as NotificationBlogPostData;
+    if (!data.blogPostId) return null;
+    const snap = await getDocs(
+      query(
+        collection(this.db, feed.collection),
+        where('id', '==', data.blogPostId),
+        limit(1),
+      ),
+    );
+    if (snap.empty) {
+      return {
+        markdown: `~~New ${feed.label} post~~ (post removed)`,
+        data: { ...data },
+        resolved: true,
+      };
+    }
+    const post = { ...initCachedBlogPost(), ...(snap.docs[0].data() as CachedBlogPost) };
+    return { ...this.blogPostFields(feed, post), resolved: false };
+  }
+
+  // The markdown + data for a blog-post notification, shared by the create and
+  // reconcile passes so both stay in lock-step.
+  private blogPostFields(
+    feed: { collection: string; label: string; route: string },
+    post: CachedBlogPost,
+  ): { markdown: string; data: NotificationBlogPostData } {
+    const link = `#/${feed.route}/${post.urlId}`;
+    const publishedIso = new Date(post.publishOn || 0).toISOString();
+    return {
+      markdown: `New ${feed.label} post: [${post.title || 'Untitled'}](${link})`,
+      data: {
+        blogPath: feed.collection,
+        blogCategory: '',
+        lastSeenDateStr: publishedIso,
+        blogPostId: post.id,
+        blogPostUrlId: post.urlId,
+      },
+    };
   }
 
   // ---------------------------------------------------------------------------
@@ -587,34 +722,69 @@ export class NotificationService implements OnDestroy {
         limit(NotificationService.MAX_PENDING_EVENT_NOTIFICATIONS),
       ),
     );
-    if (eventsSnap.empty) return;
-
+    // May be empty when no proposals are outstanding — we still fall through to
+    // reconciliation below.
     const events = eventsSnap.docs
       .map((d) => ({ ...initEvent(), ...(d.data() as IlcEvent), docId: d.id }))
       .filter((e) => !notifiedEventIds.has(e.docId));
-    if (events.length === 0) return;
 
-    const batch = writeBatch(this.db);
-    for (const event of events) {
-      const ref = doc(notifCollection); // auto-generated ID
-      const link = `#/manage-events/${event.docId}`;
-      // Stamp with the proposal's creation time (not "now") so the card date
-      // reflects when the event was proposed.
-      const createdIso = event.createdAt || new Date().toISOString();
-      const notification: MemberNotification = {
-        docId: ref.id,
-        markdown: `Event awaiting approval: [${event.title || 'Untitled event'}](${link})`,
-        createdAt: createdIso,
-        dismissed: false,
-        kind: NotificationKind.PendingEventApproval,
-        data: {
-          eventId: event.docId,
-          title: event.title || 'Untitled event',
-        },
-      };
-      batch.set(ref, notification);
+    if (events.length > 0) {
+      const batch = writeBatch(this.db);
+      for (const event of events) {
+        const ref = doc(notifCollection); // auto-generated ID
+        const title = event.title || 'Untitled event';
+        const notification: MemberNotification = {
+          docId: ref.id,
+          markdown: this.pendingEventMarkdown(event.docId, title),
+          // Stamp with the proposal's creation time (not "now") so the card date
+          // reflects when the event was proposed.
+          createdAt: event.createdAt || new Date().toISOString(),
+          dismissed: false,
+          kind: NotificationKind.PendingEventApproval,
+          data: { eventId: event.docId, title },
+        };
+        batch.set(ref, notification);
+      }
+      await batch.commit();
     }
-    await batch.commit();
+
+    // Reconcile already-surfaced approval notifications: a still-proposed event
+    // has its title refreshed; an event that has since been approved/rejected/
+    // cancelled (or deleted) is rewritten to say so and dismissed. A per-event
+    // getDoc also lets us distinguish "no longer proposed" from "beyond the live
+    // query's limit", which the create pass's capped query cannot.
+    await this.reconcileNotifications(existingSnap.docs, 'eventId', async (notif) => {
+      const data = notif.data as NotificationEventData;
+      const snap = await getDoc(doc(this.db, 'events', data.eventId));
+      if (!snap.exists()) {
+        return {
+          markdown: `Event "${data.title}" — removed`,
+          data: { ...data },
+          resolved: true,
+        };
+      }
+      const event = { ...initEvent(), ...(snap.data() as IlcEvent), docId: snap.id };
+      const title = event.title || 'Untitled event';
+      const link = `#/manage-events/${event.docId}`;
+      if (event.status !== EventStatus.Proposed) {
+        return {
+          markdown: `Event [${title}](${link}) — ${eventStatusLabel(event.status).toLowerCase()}`,
+          data: { eventId: event.docId, title },
+          resolved: true,
+        };
+      }
+      return {
+        markdown: this.pendingEventMarkdown(event.docId, title),
+        data: { eventId: event.docId, title },
+        resolved: false,
+      };
+    });
+  }
+
+  // The markdown for a pending-event-approval notification, shared by the create
+  // and reconcile passes.
+  private pendingEventMarkdown(eventDocId: string, title: string): string {
+    return `Event awaiting approval: [${title}](#/manage-events/${eventDocId})`;
   }
 
   // ---------------------------------------------------------------------------
@@ -661,43 +831,77 @@ export class NotificationService implements OnDestroy {
         where('ilcAppOrderStatus', 'in', NotificationService.ORDER_ATTENTION_STATUSES),
       ),
     );
-    if (ordersSnap.empty) return;
-
+    // May be empty when no orders currently need attention — we still fall
+    // through to reconciliation below.
     const orders = ordersSnap.docs
       .map((d) => firestoreDocToOrder(d))
       .filter((o) => !notifiedOrderIds.has(o.docId))
       // Most recently updated first, then cap to avoid flooding the feed.
       .sort((a, b) => (b.lastUpdated || '').localeCompare(a.lastUpdated || ''))
       .slice(0, NotificationService.MAX_ORDER_ISSUE_NOTIFICATIONS);
-    if (orders.length === 0) return;
 
-    const batch = writeBatch(this.db);
-    for (const order of orders) {
-      const ref = doc(notifCollection); // auto-generated ID
-      const link = `#/order-view/${order.docId}`;
-      const orderRef = this.orderRef(order);
-      const status = order.ilcAppOrderStatus as OrderStatus;
-      const verb = status === 'error' ? 'failed with an error' : 'needs manual processing';
-      const issues = order.ilcAppOrderIssues || [];
-      const issuesSuffix = issues.length > 0 ? ` — ${issues.join('; ')}` : '';
-      const notification: MemberNotification = {
-        docId: ref.id,
-        markdown: `Order [#${orderRef}](${link}) ${verb}${issuesSuffix}`,
-        // Stamp with the order's last-updated time so the card date reflects the
-        // order rather than "now".
-        createdAt: order.lastUpdated || new Date().toISOString(),
-        dismissed: false,
-        kind: NotificationKind.OrderNeedsAttention,
-        data: {
-          orderDocId: order.docId,
-          orderRef,
-          status,
-          issues,
-        },
-      };
-      batch.set(ref, notification);
+    if (orders.length > 0) {
+      const batch = writeBatch(this.db);
+      for (const order of orders) {
+        const ref = doc(notifCollection); // auto-generated ID
+        const fields = this.orderIssueFields(order);
+        const notification: MemberNotification = {
+          docId: ref.id,
+          markdown: fields.markdown,
+          // Stamp with the order's last-updated time so the card date reflects the
+          // order rather than "now".
+          createdAt: order.lastUpdated || new Date().toISOString(),
+          dismissed: false,
+          kind: NotificationKind.OrderNeedsAttention,
+          data: fields.data,
+        };
+        batch.set(ref, notification);
+      }
+      await batch.commit();
     }
-    await batch.commit();
+
+    // Reconcile already-surfaced order-issue notifications: an order still flagged
+    // has its status/issues refreshed; an order that has since been resolved (no
+    // longer in an attention status, or deleted) is rewritten to say so and
+    // dismissed.
+    await this.reconcileNotifications(existingSnap.docs, 'orderDocId', async (notif) => {
+      const data = notif.data as NotificationOrderIssueData;
+      const snap = await getDoc(doc(this.db, 'orders', data.orderDocId));
+      if (!snap.exists()) {
+        return {
+          markdown: `Order #${data.orderRef} — no longer present`,
+          data: { ...data },
+          resolved: true,
+        };
+      }
+      const order = firestoreDocToOrder(snap);
+      const status = order.ilcAppOrderStatus as OrderStatus;
+      if (!NotificationService.ORDER_ATTENTION_STATUSES.includes(status)) {
+        return {
+          markdown: `Order [#${this.orderRef(order)}](#/order-view/${order.docId}) — now resolved (${status})`,
+          data: this.orderIssueFields(order).data,
+          resolved: true,
+        };
+      }
+      return { ...this.orderIssueFields(order), resolved: false };
+    });
+  }
+
+  // The markdown + data for an order-issue notification, shared by the create and
+  // reconcile passes.
+  private orderIssueFields(order: Order): {
+    markdown: string;
+    data: NotificationOrderIssueData;
+  } {
+    const orderRef = this.orderRef(order);
+    const status = order.ilcAppOrderStatus as OrderStatus;
+    const verb = status === 'error' ? 'failed with an error' : 'needs manual processing';
+    const issues = order.ilcAppOrderIssues || [];
+    const issuesSuffix = issues.length > 0 ? ` — ${issues.join('; ')}` : '';
+    return {
+      markdown: `Order [#${orderRef}](#/order-view/${order.docId}) ${verb}${issuesSuffix}`,
+      data: { orderDocId: order.docId, orderRef, status, issues },
+    };
   }
 
   // Surfaces gradings that are completed (passed/not-passed) but not yet paid as
@@ -752,29 +956,72 @@ export class NotificationService implements OnDestroy {
           !notifiedGradingIds.has(g.docId),
       )
       .slice(0, NotificationService.MAX_UNPAID_GRADING_NOTIFICATIONS);
-    if (unpaid.length === 0) return;
 
-    const batch = writeBatch(this.db);
-    for (const g of unpaid) {
-      const ref = doc(notifCollection);
-      const link = `#/gradings/${g.docId}`;
-      const forSelf = g.studentMemberDocId === member.docId;
-      const markdown = forSelf
-        ? `⚠️ Your grading for **${g.level}** is complete but **not yet paid**. ` +
-          `Please arrange payment so it can be finalised. [Open the grading](${link}).`
-        : `⚠️ **${g.studentName || 'A student'}**'s grading for **${g.level}** is complete but ` +
-          `**not yet paid**. [Open the grading](${link}).`;
-      const notification: MemberNotification = {
-        docId: ref.id,
-        markdown,
-        createdAt: new Date().toISOString(),
-        dismissed: false,
-        kind: NotificationKind.GradingUnpaid,
-        data: { gradingDocId: g.docId, level: g.level },
-      };
-      batch.set(ref, notification);
+    // May be empty when nothing new is outstanding — we still fall through to
+    // reconciliation below.
+    if (unpaid.length > 0) {
+      const batch = writeBatch(this.db);
+      for (const g of unpaid) {
+        const ref = doc(notifCollection);
+        const notification: MemberNotification = {
+          docId: ref.id,
+          markdown: this.unpaidGradingMarkdown(g, g.studentMemberDocId === member.docId),
+          createdAt: new Date().toISOString(),
+          dismissed: false,
+          kind: NotificationKind.GradingUnpaid,
+          data: { gradingDocId: g.docId, level: g.level },
+        };
+        batch.set(ref, notification);
+      }
+      await batch.commit();
     }
-    await batch.commit();
+
+    // Reconcile already-surfaced unpaid-grading TODOs: a grading that is now paid
+    // (or no longer completed, or deleted) is rewritten to say so and dismissed; an
+    // outstanding one has its message refreshed in place.
+    await this.reconcileNotifications(existingSnap.docs, 'gradingDocId', async (notif) => {
+      const data = notif.data as NotificationGradingData;
+      const snap = await getDoc(doc(this.db, 'gradings', data.gradingDocId));
+      if (!snap.exists()) {
+        return {
+          markdown: `Grading for **${data.level}** — no longer present.`,
+          data: { ...data },
+          resolved: true,
+        };
+      }
+      const g = firestoreDocToGrading(snap);
+      const gradingData = { gradingDocId: g.docId, level: g.level };
+      if (!NotificationService.COMPLETED_GRADING_STATUSES.includes(g.status)) {
+        return {
+          markdown: `Grading for **${g.level}** — no longer awaiting payment.`,
+          data: gradingData,
+          resolved: true,
+        };
+      }
+      if (isGradingPaid(g)) {
+        return {
+          markdown: `✅ Grading for **${g.level}** is now paid.`,
+          data: gradingData,
+          resolved: true,
+        };
+      }
+      return {
+        markdown: this.unpaidGradingMarkdown(g, g.studentMemberDocId === member.docId),
+        data: gradingData,
+        resolved: false,
+      };
+    });
+  }
+
+  // The markdown for an unpaid-grading TODO notification, shared by the create and
+  // reconcile passes. `forSelf` is true when the recipient is the student.
+  private unpaidGradingMarkdown(g: Grading, forSelf: boolean): string {
+    const link = `#/gradings/${g.docId}`;
+    return forSelf
+      ? `⚠️ Your grading for **${g.level}** is complete but **not yet paid**. ` +
+          `Please arrange payment so it can be finalised. [Open the grading](${link}).`
+      : `⚠️ **${g.studentName || 'A student'}**'s grading for **${g.level}** is complete but ` +
+          `**not yet paid**. [Open the grading](${link}).`;
   }
 
   private seedPushedCache(activeNotifications: MemberNotification[]) {

--- a/src/app/notifications-list/notifications-list.html
+++ b/src/app/notifications-list/notifications-list.html
@@ -10,7 +10,7 @@
       </button>
     </div>
     <div class="notifications-list">
-      @for (n of notifications(); track n.docId) {
+      @for (n of visibleNotifications(); track n.docId) {
         <div class="notification-row" [class.collapsing]="collapsingIds().has(n.docId)">
         <div
           class="notification-card"
@@ -85,5 +85,11 @@
         </div>
       }
     </div>
+    @if (hasMore()) {
+      <a class="subtle-button view-all-link" [href]="notificationsHref">
+        View all {{ notifications().length }} notifications
+        <app-icon name="arrow_forward" width="16px" height="16px"></app-icon>
+      </a>
+    }
   </div>
 }

--- a/src/app/notifications-list/notifications-list.scss
+++ b/src/app/notifications-list/notifications-list.scss
@@ -3,6 +3,14 @@
 .notifications-section {
   margin-bottom: 1.5rem;
 
+  // Layout only — visual style comes from the global .subtle-button class.
+  .view-all-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    margin-top: 0.75rem;
+  }
+
   .section-header {
     display: flex;
     justify-content: space-between;

--- a/src/app/notifications-list/notifications-list.spec.ts
+++ b/src/app/notifications-list/notifications-list.spec.ts
@@ -50,6 +50,7 @@ describe('NotificationsListComponent', () => {
     mockRoutingService = {
       navigateToParts: vi.fn(),
       hrefForView: vi.fn().mockReturnValue('#/gradings/grading-1'),
+      hrefWithParams: vi.fn().mockReturnValue('#/notifications?filter=unread'),
     };
 
     await TestBed.configureTestingModule({
@@ -114,5 +115,32 @@ describe('NotificationsListComponent', () => {
     await fixture.whenStable();
 
     expect(mockRoutingService.navigateToParts).not.toHaveBeenCalled();
+  });
+
+  it('caps the home feed at 3 cards and shows a view-all link when there are more', async () => {
+    const many = [1, 2, 3, 4].map((i) => ({ ...mockNotif, docId: `id${i}` }));
+    mockNotificationService.notifications.set(many);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(fixture.nativeElement.querySelectorAll('.notification-card').length).toBe(3);
+    const viewAll = fixture.nativeElement.querySelector('.view-all-link') as HTMLAnchorElement;
+    expect(viewAll).toBeTruthy();
+    expect(viewAll.textContent).toContain('View all 4 notifications');
+    // The link opens the notifications page filtered to unread.
+    expect(mockRoutingService.hrefWithParams).toHaveBeenCalledWith('/notifications?filter=unread');
+    expect(viewAll.getAttribute('href')).toBe('#/notifications?filter=unread');
+  });
+
+  it('shows no view-all link when there are 3 or fewer notifications', async () => {
+    mockNotificationService.notifications.set([
+      { ...mockNotif, docId: 'id1' },
+      { ...mockNotif, docId: 'id2' },
+    ]);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(fixture.nativeElement.querySelectorAll('.notification-card').length).toBe(2);
+    expect(fixture.nativeElement.querySelector('.view-all-link')).toBeFalsy();
   });
 });

--- a/src/app/notifications-list/notifications-list.ts
+++ b/src/app/notifications-list/notifications-list.ts
@@ -45,11 +45,35 @@ export class NotificationsListComponent {
   // up before the underlying doc is dismissed and removed from the stream.
   protected collapsingIds = signal<ReadonlySet<string>>(new Set());
 
+  // Most recent N notifications shown inline on the home page; the rest are
+  // reached via the "view all" link to the dedicated notifications page.
+  private static readonly HOME_MAX = 3;
+
   notifications = computed(() => {
     const list = this.notificationService.notifications();
     const settings = this.user()?.member?.notificationSettings;
     return list.filter((n) => settings?.homeEnabled?.[n.kind] !== false);
   });
+
+  // The slice actually rendered on the home page (newest first; the underlying
+  // stream is already sorted by createdAt desc).
+  protected visibleNotifications = computed(() =>
+    this.notifications().slice(0, NotificationsListComponent.HOME_MAX),
+  );
+
+  // True when there are more active notifications than we show inline, so the
+  // "view all" link should be offered.
+  protected hasMore = computed(
+    () => this.notifications().length > NotificationsListComponent.HOME_MAX,
+  );
+
+  // Deep link to the dedicated notifications page, opening on the "unread" filter
+  // (the home feed shows unread items, so "view all" should land on the same set
+  // with the rest of the history one click away). The explicit query param is
+  // preserved by resolveUrlWithParams.
+  protected notificationsHref = this.routingService.hrefWithParams(
+    '/notifications?filter=unread',
+  );
 
   private markCollapsing(...ids: string[]) {
     this.collapsingIds.update((s) => new Set([...s, ...ids]));

--- a/tests/firestore.rules.spec.ts
+++ b/tests/firestore.rules.spec.ts
@@ -1026,7 +1026,25 @@ describe('Firestore Rules', () => {
       );
     });
 
-    it('should deny member from updating restricted fields on their own notification', async () => {
+    it('should allow member to refresh markdown/data on their own notification (reconciliation)', async () => {
+      const db = testEnv
+        .authenticatedContext('student1', { email: 'student1@ilc.com' })
+        .firestore();
+      await assertSucceeds(
+        db
+          .collection('members')
+          .doc('FirestoreDocID-student1')
+          .collection('notifications')
+          .doc('notif-1')
+          .update({
+            markdown: 'Refreshed content',
+            data: { blogPath: 'members-post', blogPostId: 'src-1' },
+            dismissed: true,
+          }),
+      );
+    });
+
+    it('should deny member from updating immutable notification fields (kind/createdAt)', async () => {
       const db = testEnv
         .authenticatedContext('student1', { email: 'student1@ilc.com' })
         .firestore();
@@ -1037,7 +1055,7 @@ describe('Firestore Rules', () => {
           .collection('notifications')
           .doc('notif-1')
           .update({
-            markdown: 'Hacked content',
+            kind: 'OrderNeedsAttention',
           }),
       );
     });


### PR DESCRIPTION
## Summary

Login-time catch-up checks (blog posts, pending events, order issues, unpaid gradings) were **create-only**: once the underlying entity changed, the notification went stale. This PR makes each check **reconcile** existing notifications against the current state of the source entity they were generated from.

- **Condition still holds, content changed** → markdown/data refreshed in place, the user's `dismissed` state preserved (never re-surfaced).
- **Condition resolved** (order fixed, event approved/rejected, grading paid, post removed) → markdown rewritten to say so, and the notification dismissed.
- **Idempotent** → only writes when the stored doc actually differs.

### Notable fixes folded in
- Reconcile now runs **even when there are no new entities to create** — the previous early-returns skipped reconciliation in exactly the steady-state case where it matters (e.g. editing a post title produces no new post).
- Blog posts are looked up by their source `id` field, not the auto-generated Firestore doc id.

### UI
- Home feed capped at the **3 most recent** active notifications, with a "View all N notifications" link to the notifications page opened on the **unread** filter (`#/notifications?filter=unread`).

### Security rules
- The notification owner may now update `markdown`/`data` (not just `dismissed`) on their own notifications, scoped so `kind`/`createdAt` stay immutable. Owners can already create/delete their own notifications, so this grants no new authority.

## Testing
- `pnpm test` — 389 passed (new reconcile unit tests, blog-lookup regression test, no-new-posts regression test, home-feed cap + unread-link tests).
- `pnpm test:rules` — 96 passed (updated notification update-rule tests).

> Note: the firestore.rules change requires `firebase deploy --only firestore:rules` to take effect in the live project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)