### PR TITLE
fix(events): repair orphaned My Events mirror copies on owner change

### DIFF
--- a/functions/src/proposed-events.ts
+++ b/functions/src/proposed-events.ts
@@ -182,8 +182,14 @@ export const onEventUpdated = onDocumentUpdated('/events/{docId}', async (event)
     managerEmails.push(...emails);
   }
 
-  const ownerEmailsChanged = JSON.stringify(ownerEmails) !== JSON.stringify(after.ownerEmails || []);
-  const managerEmailsChanged = JSON.stringify(managerEmails) !== JSON.stringify(after.managerEmails || []);
+  // Compare as order-independent multisets: the stored and freshly-derived
+  // lists hold the same emails but their order depends on the member email
+  // array / managerDocIds ordering, which can change without the set changing.
+  // Sorting copies avoids spurious email rewrites (and an extra trigger cycle).
+  const sameEmails = (a: string[], b: string[]) =>
+    JSON.stringify([...a].sort()) === JSON.stringify([...b].sort());
+  const ownerEmailsChanged = !sameEmails(ownerEmails, after.ownerEmails || []);
+  const managerEmailsChanged = !sameEmails(managerEmails, after.managerEmails || []);
 
   if (ownerEmailsChanged || managerEmailsChanged) {
     logger.info(`Updating emails for event ${event.params.docId}.`);

--- a/functions/src/proposed-events.ts
+++ b/functions/src/proposed-events.ts
@@ -130,9 +130,48 @@ export const onEventUpdated = onDocumentUpdated('/events/{docId}', async (event)
 
   if (!before || !after) return;
 
-  // Resolve emails if missing or if owner/managers changed
   const db = admin.firestore();
-  
+
+  // Mirror to member subcollections for owner and managers.
+  //
+  // This MUST run on the same invocation that observes the membership change.
+  // Resolving emails below can trigger a follow-up write (to persist
+  // ownerEmails/managerEmails) whose before/after no longer reflect the
+  // owner/manager change — so deferring the mirror to that follow-up would
+  // leave a removed member's stale copy orphaned in their subcollection.
+  const previousTargets = new Set([before.ownerDocId, ...(before.managerDocIds || [])].filter(Boolean));
+  const currentTargets = new Set([after.ownerDocId, ...(after.managerDocIds || [])].filter(Boolean));
+
+  // Remove from targets no longer associated
+  for (const docId of previousTargets) {
+    if (!currentTargets.has(docId)) {
+      await db
+        .collection('members')
+        .doc(docId)
+        .collection('events')
+        .doc(event.params.docId)
+        .delete();
+      logger.info(`Removed mirrored event ${event.params.docId} from member ${docId} subcollection.`);
+    }
+  }
+
+  // Update/Add to all current targets
+  // Destructuring extracts ownerEmails and managerEmails to ignore them (renaming to _ and __ to avoid
+  // collision with variables in scope). The rest operator (...) puts the remaining fields in eventToMirror.
+  const { ownerEmails: _, managerEmails: __, ...eventToMirror } = after;
+
+  for (const docId of currentTargets) {
+    await db
+      .collection('members')
+      .doc(docId)
+      .collection('events')
+      .doc(event.params.docId)
+      .set(eventToMirror);
+    logger.info(`Updated mirrored event ${event.params.docId} for member ${docId} subcollection.`);
+  }
+
+  // Resolve emails if missing or if owner/managers changed. Done after
+  // mirroring (above) so a membership change is never lost.
   const ownerDoc = await db.collection('members').doc(after.ownerDocId).get();
   const ownerEmails = ownerDoc.data()?.emails || [];
 
@@ -152,39 +191,7 @@ export const onEventUpdated = onDocumentUpdated('/events/{docId}', async (event)
       ownerEmails,
       managerEmails
     });
-    return; // Let the next trigger handle mirroring
-  }
-
-  // Mirror to member subcollections for owner and managers
-  const previousTargets = new Set([before.ownerDocId, ...(before.managerDocIds || [])].filter(Boolean));
-  const currentTargets = new Set([after.ownerDocId, ...(after.managerDocIds || [])].filter(Boolean));
-
-  // Remove from targets no longer associated
-  for (const docId of previousTargets) {
-    if (!currentTargets.has(docId)) {
-      await admin.firestore()
-        .collection('members')
-        .doc(docId)
-        .collection('events')
-        .doc(event.params.docId)
-        .delete();
-      logger.info(`Removed mirrored event ${event.params.docId} from member ${docId} subcollection.`);
-    }
-  }
-
-  // Update/Add to all current targets
-  // Destructuring extracts ownerEmails and managerEmails to ignore them (renaming to _ and __ to avoid
-  // collision with variables in scope). The rest operator (...) puts the remaining fields in eventToMirror.
-  const { ownerEmails: _, managerEmails: __, ...eventToMirror } = after;
-
-  for (const docId of currentTargets) {
-    await admin.firestore()
-      .collection('members')
-      .doc(docId)
-      .collection('events')
-      .doc(event.params.docId)
-      .set(eventToMirror);
-    logger.info(`Updated mirrored event ${event.params.docId} for member ${docId} subcollection.`);
+    return; // Let the follow-up trigger handle Google Calendar sync.
   }
 
   // Clean up Storage files for documents that were removed.

--- a/scripts/reconcile-event-mirrors.ts
+++ b/scripts/reconcile-event-mirrors.ts
@@ -1,0 +1,127 @@
+/* reconcile-event-mirrors.ts
+ *
+ * One-off repair: reconcile the per-member event mirror copies under
+ * `members/{memberDocId}/events/{eventId}` against the canonical events in the
+ * top-level `events` collection.
+ *
+ * Background: each event is mirrored into the subcollection of its owner and
+ * managers (used by the "My Events" view). A bug in `onEventUpdated` could
+ * leave a removed owner/manager's mirror copy orphaned (e.g. after an event's
+ * ownership was transferred), so the My Events list showed a stale contact.
+ *
+ * For every mirror copy this script:
+ *   - deletes it if the canonical event no longer exists, or if the member is
+ *     no longer the event's owner or a manager (orphan);
+ *   - otherwise re-writes it from the canonical event (minus the private
+ *     owner/manager email fields) if it has drifted.
+ * It then ensures every canonical event has an up-to-date mirror for each of
+ * its current targets.
+ *
+ * Idempotent: a second run makes no further writes.
+ *
+ * Usage (Application Default Credentials, like the other admin scripts):
+ *   # dry run — report what would change, write nothing:
+ *   pnpm --prefix functions exec ts-node -O '{"module":"commonjs"}' \
+ *     ../scripts/reconcile-event-mirrors.ts
+ *   # apply the changes:
+ *   pnpm --prefix functions exec ts-node -O '{"module":"commonjs"}' \
+ *     ../scripts/reconcile-event-mirrors.ts --commit
+ *   # target a different project (defaults to ilc-paris-class-tracker):
+ *   pnpm --prefix functions exec ts-node -O '{"module":"commonjs"}' \
+ *     ../scripts/reconcile-event-mirrors.ts --project=<project-id>
+ */
+
+import * as admin from 'firebase-admin';
+
+const COMMIT = process.argv.includes('--commit');
+const DEFAULT_PROJECT = 'ilc-paris-class-tracker';
+const projectArg = process.argv.find((a) => a.startsWith('--project='));
+const PROJECT_ID = projectArg ? projectArg.split('=')[1] : DEFAULT_PROJECT;
+
+// Fields stripped from the mirror copy (private; never shown in My Events).
+const PRIVATE_FIELDS = ['ownerEmails', 'managerEmails'] as const;
+
+function mirrorData(canonical: Record<string, unknown>): Record<string, unknown> {
+  const copy = { ...canonical };
+  for (const f of PRIVATE_FIELDS) delete copy[f];
+  return copy;
+}
+
+function targetsOf(canonical: Record<string, unknown>): Set<string> {
+  const owner = (canonical['ownerDocId'] as string) || '';
+  const managers = (canonical['managerDocIds'] as string[]) || [];
+  return new Set([owner, ...managers].filter(Boolean));
+}
+
+// Stable, key-order-independent comparison of mirror payloads.
+function sameData(a: Record<string, unknown>, b: Record<string, unknown>): boolean {
+  const norm = (o: Record<string, unknown>) =>
+    JSON.stringify(Object.keys(o).sort().map((k) => [k, o[k]]));
+  return norm(a) === norm(b);
+}
+
+async function main() {
+  console.log(`Using project: ${PROJECT_ID}`);
+  console.log(COMMIT ? 'MODE: COMMIT (writes enabled)' : 'MODE: DRY RUN (no writes)');
+  admin.initializeApp({ projectId: PROJECT_ID });
+  const db = admin.firestore();
+
+  // Load all canonical events.
+  const eventsSnap = await db.collection('events').get();
+  const canonical = new Map<string, Record<string, unknown>>();
+  eventsSnap.forEach((d) => canonical.set(d.id, d.data() as Record<string, unknown>));
+  console.log(`Loaded ${canonical.size} canonical events.`);
+
+  let deletes = 0;
+  let updates = 0;
+
+  // Pass 1: walk every existing mirror copy (collectionGroup matches the
+  // top-level `events` collection too, so skip docs without a member parent).
+  const mirrorsSnap = await db.collectionGroup('events').get();
+  // Track which (member,event) mirrors already exist and are correct.
+  for (const doc of mirrorsSnap.docs) {
+    const memberDoc = doc.ref.parent.parent;
+    if (!memberDoc || memberDoc.parent.id !== 'members') continue; // top-level event
+    const memberDocId = memberDoc.id;
+    const eventId = doc.id;
+
+    const event = canonical.get(eventId);
+    if (!event) {
+      console.log(`DELETE orphan (no canonical event): members/${memberDocId}/events/${eventId}`);
+      if (COMMIT) await doc.ref.delete();
+      deletes++;
+      continue;
+    }
+    if (!targetsOf(event).has(memberDocId)) {
+      console.log(`DELETE orphan (member not owner/manager): members/${memberDocId}/events/${eventId}`);
+      if (COMMIT) await doc.ref.delete();
+      deletes++;
+      continue;
+    }
+    const desired = mirrorData(event);
+    if (!sameData(doc.data() as Record<string, unknown>, desired)) {
+      console.log(`UPDATE drifted mirror: members/${memberDocId}/events/${eventId}`);
+      if (COMMIT) await doc.ref.set(desired);
+      updates++;
+    }
+  }
+
+  // Pass 2: ensure each canonical event has a mirror for every current target.
+  for (const [eventId, event] of canonical) {
+    const desired = mirrorData(event);
+    for (const memberDocId of targetsOf(event)) {
+      const ref = db.collection('members').doc(memberDocId).collection('events').doc(eventId);
+      const snap = await ref.get();
+      if (!snap.exists) {
+        console.log(`CREATE missing mirror: members/${memberDocId}/events/${eventId}`);
+        if (COMMIT) await ref.set(desired);
+        updates++;
+      }
+    }
+  }
+
+  console.log(`\nDone. ${deletes} delete(s), ${updates} create/update(s).` +
+    (COMMIT ? '' : ' (dry run — re-run with --commit to apply)'));
+}
+
+main().then(() => process.exit(0)).catch((e) => { console.error(e); process.exit(1); });

--- a/src/app/event-edit/event-edit.html
+++ b/src/app/event-edit/event-edit.html
@@ -188,6 +188,13 @@
         <h3>Attached Documents</h3>
 
         <div class="rhs document-list" style="grid-column: 1 / -1;">
+          <p class="note">
+            These are additional links or files (PDFs, Word docs, etc.) related to this event,
+            that will be listed at the bottom of the event's page for attendees to download. 
+            Uploads, renaming, and deletions here are saved immediately and do not depend on 
+            the event's Save button.
+          </p>
+
           @let docs = eventFormModel().documents;
           @for (doc of docs; track $index; let last = $last) {
             <div class="document-row">
@@ -392,20 +399,15 @@
         <h3>Status & Metadata</h3>
 
         @if (ev) {
-        <label for="event-owner">Owner</label>
+        <label for="event-owner">Owner (contact)</label>
         <div class="rhs">
-          @if (userIsAdmin()) {
-            <app-autocomplete
-              [searchableSet]="dataService.instructors"
-              [placeholder]="'Search for a member'"
-              [displayFns]="instructorDisplayFns"
-              [initSearchTerm]="dataService.members.get(eventFormModel().ownerDocId)?.instructorId || ''"
-              (textUpdated)="updateOwnerDocId($event)"
-            ></app-autocomplete>
-          } @else {
-            @let owner = dataService.members.get(eventFormModel().ownerDocId);
-            <span class="readonly-value">{{ owner?.name || eventFormModel().ownerDocId }}</span>
-          }
+          <app-autocomplete
+            [searchableSet]="dataService.instructors"
+            [placeholder]="'Search for a member'"
+            [displayFns]="instructorDisplayFns"
+            [initSearchTerm]="dataService.members.get(eventFormModel().ownerDocId)?.instructorId || ''"
+            (textUpdated)="updateOwnerDocId($event)"
+          ></app-autocomplete>
           @if (eventFormModel().ownerDocId) {
             @let owner = dataService.members.get(eventFormModel().ownerDocId);
             @if (owner) {

--- a/src/app/events-calendar/event-list/event-list.html
+++ b/src/app/events-calendar/event-list/event-list.html
@@ -34,6 +34,16 @@
         name="searchTerm"
       />
     </div>
+    @if (isMyEvents()) {
+      <button
+        class="icon-only-button sort-direction-btn"
+        (click)="toggleSortDirection()"
+        [attr.aria-label]="sortDirection() === 'asc' ? 'Sorted oldest first' : 'Sorted newest first'"
+        [attr.title]="sortDirection() === 'asc' ? 'Oldest first' : 'Newest first'"
+      >
+        <app-icon [name]="sortDirection() === 'asc' ? 'arrow_upward' : 'arrow_downward'"></app-icon>
+      </button>
+    }
     <div class="options-menu-container">
       <button
         class="icon-only-button"

--- a/src/app/events-calendar/event-list/event-list.ts
+++ b/src/app/events-calendar/event-list/event-list.ts
@@ -125,6 +125,23 @@ export class EventListComponent implements OnDestroy {
     return '';
   });
 
+  // The URL `sortDir` parameter (my-events view only).
+  private urlSortDir = computed(() => {
+    if (this.routingService.matchedPatternId() === Views.MyEvents) {
+      return this.routingService.signals[Views.MyEvents].urlParams.sortDir();
+    }
+    return '';
+  });
+
+  // Sort direction for the event list. Seeded from the URL, falling back to a
+  // sensible default per context: my-events shows latest first (desc), while
+  // the public events list shows soonest first (asc). Writable via the toggle.
+  sortDirection = linkedSignal<'asc' | 'desc'>(() => {
+    const fromUrl = this.urlSortDir();
+    if (fromUrl === 'asc' || fromUrl === 'desc') return fromUrl;
+    return this.isMyEvents() ? 'desc' : 'asc';
+  });
+
   // True when a school/instructor filter is active.
   protected isFiltered = computed(() => !!this.urlSchoolId() || !!this.urlInstructorId());
 
@@ -229,8 +246,9 @@ export class EventListComponent implements OnDestroy {
       ? baseEvents.filter(e => e.status === EventStatus.Listed || !e.status)
       : baseEvents;
 
+    const dirMul = this.sortDirection() === 'asc' ? 1 : -1;
     const sortedEvents = [...filteredEvents]
-      .sort((a, b) => a.start.localeCompare(b.start));
+      .sort((a, b) => dirMul * a.start.localeCompare(b.start));
     return sortedEvents.map((event, index) => ({
       ...event,
       id: `${index}`,
@@ -452,6 +470,15 @@ export class EventListComponent implements OnDestroy {
       this.routingService.signals[Views.EventsCalendar].urlParams.q.set(value);
     } else if (match === Views.MyEvents) {
       this.routingService.signals[Views.MyEvents].urlParams.q.set(value);
+    }
+  }
+
+  // Flip the sort direction and (on my-events) persist it to the URL.
+  toggleSortDirection(): void {
+    const next = this.sortDirection() === 'asc' ? 'desc' : 'asc';
+    this.sortDirection.set(next);
+    if (this.routingService.matchedPatternId() === Views.MyEvents) {
+      this.routingService.signals[Views.MyEvents].urlParams.sortDir.set(next);
     }
   }
 

--- a/src/app/home/home.scss
+++ b/src/app/home/home.scss
@@ -12,7 +12,7 @@
 
 .cards-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(270px, 1fr));
+  grid-template-columns: repeat(3, 1fr);
   gap: 1rem;
 }
 
@@ -94,6 +94,12 @@
     }
   }
 
+}
+
+@media (max-width: 900px) {
+  .cards-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 
 @media (max-width: 600px) {

--- a/src/app/school-edit/school-edit.html
+++ b/src/app/school-edit/school-edit.html
@@ -6,6 +6,11 @@
     <a class="back-link subtle-button" [href]="backUrl()">
       <app-icon name="arrow_back"></app-icon> <span>Back to {{ backLabel() }}</span>
     </a>
+    @if (publicListingHref(); as href) {
+      <a class="subtle-button" [href]="href" target="_blank" rel="noopener noreferrer">
+        <app-icon name="link"></app-icon> <span>View public listing</span>
+      </a>
+    }
   </div>
 
   <div class="edit-form">

--- a/src/app/school-edit/school-edit.ts
+++ b/src/app/school-edit/school-edit.ts
@@ -410,6 +410,15 @@ export class SchoolEditComponent {
     return 'Manage Schools';
   });
 
+  // Link to this school's public profile page. Only available for an existing,
+  // saved school that has a human-readable schoolId.
+  publicListingHref = computed(() => {
+    if (this.isNewSchool()) return '';
+    const schoolId = this.editableSchool()?.schoolId;
+    if (!schoolId) return '';
+    return this.routingService.hrefForView(Views.SchoolView, { schoolId });
+  });
+
   constructor() {
     effect(async () => {
       const s = this.school();


### PR DESCRIPTION
## Summary

The **My Events** list reads denormalized event copies from `members/{docId}/events`. When an event's owner/managers changed, the displayed **Contact** could be wrong — e.g. an event transferred from Lucas → Marina still showed "Contact: Lucas Dixon" in Lucas's My Events.

### Root cause
`onEventUpdated` mirrors each event into its owner's and managers' subcollections. On an owner change made via the edit form, the client writes `ownerDocId` but not `ownerEmails`. The trigger detected stale emails, updated them, and **returned early** ("let the next trigger handle mirroring"). That email write fired a *second* trigger run whose `before`/`after` no longer reflected the membership change, so the removed member's mirror copy was never deleted — an orphan with a stale owner.

### Changes
- **`functions/src/proposed-events.ts`** — run subcollection mirroring (including orphan removal) on the **same** invocation that observes the membership change, *before* the email-resolution early return.
- **`src/app/event-edit/event-edit.html`** — make the **Owner (contact)** field editable by owners and managers, not just admins (matches the Managers field already there); relabel `Owner` → `Owner (contact)` to connect it to the "Contact" shown in listings; add an Attached Documents help note.
- **`scripts/reconcile-event-mirrors.ts`** — idempotent one-off repair that deletes orphaned / re-syncs drifted mirror copies (dry-run by default, `--commit` to apply).

### Data repair (already applied)
Ran the reconcile script with `--commit` against `ilc-paris-class-tracker`, deleting **5** orphaned mirror copies. A follow-up dry-run reports 0 changes (idempotent ✅).

### Also bundled (pre-existing pending work)
- My Events sort-direction toggle (`event-list`)
- Home cards grid layout (`home.scss`)
- "View public listing" link on school edit (`school-edit`)

## Test plan
- [x] `ng build ilc-members-manager` passes
- [x] `tsc --noEmit` in `functions/` passes
- [x] Reconcile script: dry-run → commit (5 deletes) → dry-run (0 changes)
- [ ] Deploy `onEventUpdated`; transfer an event's owner and confirm the old owner's My Events no longer lists it

🤖 Generated with [Claude Code](https://claude.com/claude-code)