### PR TITLE
feat(gradings): let members request their next grading before paying

### DIFF
--- a/functions/src/common.spec.ts
+++ b/functions/src/common.spec.ts
@@ -1,0 +1,42 @@
+/* common.spec.ts — tests for shared membership helpers. */
+import { describe, it, expect } from 'vitest';
+import { hasActiveMembership } from './common';
+import { Member, MembershipType } from './data-model';
+
+describe('hasActiveMembership', () => {
+  const today = new Date().toISOString().split('T')[0];
+  const future = '2999-01-01';
+  const past = '2000-01-01';
+
+  it('is true for a Life member regardless of expiry', () => {
+    const m = { membershipType: MembershipType.Life, currentMembershipExpires: '' } as Member;
+    expect(hasActiveMembership(m)).toBe(true);
+  });
+
+  it('is true for an Annual member whose membership expires in the future', () => {
+    const m = { membershipType: MembershipType.Annual, currentMembershipExpires: future } as Member;
+    expect(hasActiveMembership(m)).toBe(true);
+  });
+
+  it('is true for an Annual member expiring today', () => {
+    const m = { membershipType: MembershipType.Annual, currentMembershipExpires: today } as Member;
+    expect(hasActiveMembership(m)).toBe(true);
+  });
+
+  it('is false for an Annual member whose membership has expired', () => {
+    const m = { membershipType: MembershipType.Annual, currentMembershipExpires: past } as Member;
+    expect(hasActiveMembership(m)).toBe(false);
+  });
+
+  it('is false for an Annual member with no expiry date', () => {
+    const m = { membershipType: MembershipType.Annual, currentMembershipExpires: '' } as Member;
+    expect(hasActiveMembership(m)).toBe(false);
+  });
+
+  it('is false for non-annual / non-life membership types', () => {
+    for (const type of [MembershipType.Inactive, MembershipType.Deceased, MembershipType.NotYetAMember]) {
+      const m = { membershipType: type, currentMembershipExpires: future } as Member;
+      expect(hasActiveMembership(m)).toBe(false);
+    }
+  });
+});

--- a/functions/src/common.ts
+++ b/functions/src/common.ts
@@ -1,6 +1,6 @@
 import { environment } from './environment/environment';
 import * as admin from 'firebase-admin';
-import { Member, School } from './data-model';
+import { Member, MembershipType, School } from './data-model';
 import { CallableRequest, HttpsError } from 'firebase-functions/v2/https';
 import { FieldValue } from 'firebase-admin/firestore';
 
@@ -52,6 +52,30 @@ export async function getMemberByEmail(
   }
 
   throw new HttpsError('not-found', 'Member not found');
+}
+
+// Whether a member has an active (non-expired) membership today. Life
+// memberships are always active; Annual memberships are active while
+// currentMembershipExpires is today or later. Mirrors the expiry check used
+// for event proposals and the client-side member-tags logic.
+export function hasActiveMembership(member: Member): boolean {
+  if (member.membershipType === MembershipType.Life) return true;
+  if (member.membershipType !== MembershipType.Annual) return false;
+  const today = new Date().toISOString().split('T')[0];
+  return !!member.currentMembershipExpires && member.currentMembershipExpires >= today;
+}
+
+// The Firestore member doc IDs a login email is allowed to manage, read from
+// the ACL document. Mirrors the `getUserMemberDocIds()` notion used by the
+// Firestore security rules. Returns [] when the email has no ACL entry.
+export async function getUserMemberDocIds(
+  email: string,
+  db: admin.firestore.Firestore,
+): Promise<string[]> {
+  const aclDoc = await db.collection('acl').doc(email).get();
+  if (!aclDoc.exists) return [];
+  const acl = aclDoc.data() as { memberDocIds?: string[] };
+  return acl.memberDocIds ?? [];
 }
 
 export async function getSchool(

--- a/functions/src/data-model.ts
+++ b/functions/src/data-model.ts
@@ -382,7 +382,7 @@ export const PAYMENT_STATUSES = Object.values(PaymentStatus);
 /** Human-readable labels for each payment status. */
 export const PAYMENT_STATUS_LABELS: Record<PaymentStatus, string> = {
   [PaymentStatus.NotYetPaid]: 'Not yet paid',
-  [PaymentStatus.PaidBySquarespace]: 'Paid (Squarespace)',
+  [PaymentStatus.PaidBySquarespace]: 'Paid online',
   [PaymentStatus.PaidByCash]: 'Paid (cash)',
   [PaymentStatus.PaidOther]: 'Paid (other)',
 };

--- a/functions/src/grading-request.ts
+++ b/functions/src/grading-request.ts
@@ -1,0 +1,119 @@
+/* grading-request.ts
+ *
+ * Callable Cloud Function letting a member request their next grading before
+ * paying for it. Creation is guarded here (rather than via a client Firestore
+ * write) so we can enforce membership/level/one-open-request rules and populate
+ * fields the student cannot set directly. The resulting grading is unpaid
+ * (PaymentStatus.NotYetPaid); it flips to "Paid online" automatically when the
+ * matching Squarespace grading order is later processed (see
+ * squarespace-orders/grading.ts), and only updates the student's level once it
+ * is both paid and passed (see on-grading-update.ts).
+ */
+
+import { onCall, HttpsError, CallableRequest } from 'firebase-functions/v2/https';
+import * as admin from 'firebase-admin';
+import * as logger from 'firebase-functions/logger';
+import { FieldValue } from 'firebase-admin/firestore';
+import {
+  Grading,
+  GradingStatus,
+  Member,
+  PaymentStatus,
+  initGrading,
+  isGradingPaid,
+  nextGradingLevel,
+} from './data-model';
+import {
+  allowedOrigins,
+  getUserMemberDocIds,
+  hasActiveMembership,
+} from './common';
+
+export const requestGrading = onCall(
+  { cors: allowedOrigins },
+  async (request: CallableRequest<{ memberDocId: string }>) => {
+    if (!request.auth || !request.auth.token.email) {
+      throw new HttpsError('unauthenticated', 'Must be authenticated to request a grading.');
+    }
+    const email = request.auth.token.email;
+    const memberDocId = request.data?.memberDocId;
+    if (!memberDocId) {
+      throw new HttpsError('invalid-argument', 'memberDocId is required.');
+    }
+
+    const db = admin.firestore();
+
+    // The caller must own (manage) this member profile.
+    const ownedDocIds = await getUserMemberDocIds(email, db);
+    if (!ownedDocIds.includes(memberDocId)) {
+      throw new HttpsError(
+        'permission-denied',
+        'You do not have permission to request a grading for this member.',
+      );
+    }
+
+    const memberSnap = await db.collection('members').doc(memberDocId).get();
+    if (!memberSnap.exists) {
+      throw new HttpsError('not-found', 'Member not found.');
+    }
+    const member = { ...memberSnap.data(), docId: memberSnap.id } as Member;
+
+    // Must be an active member to grade.
+    if (!hasActiveMembership(member)) {
+      throw new HttpsError(
+        'permission-denied',
+        'You must be an active member to request a grading.',
+      );
+    }
+
+    // Auto-populate the next level the student needs to grade for.
+    const level = nextGradingLevel(member.studentLevel, member.applicationLevel);
+    if (!level) {
+      throw new HttpsError(
+        'failed-precondition',
+        'There is no further grading level to request.',
+      );
+    }
+
+    // Only one active (unpaid) grading at a time. A completed-but-failed grading
+    // (NotPassed) does not count; everything else unpaid blocks a new request.
+    const existing = await db
+      .collection('gradings')
+      .where('studentMemberDocId', '==', memberDocId)
+      .get();
+    const hasOpenRequest = existing.docs.some((d) => {
+      const g = d.data() as Grading;
+      return !isGradingPaid(g) && g.status !== GradingStatus.NotPassed;
+    });
+    if (hasOpenRequest) {
+      throw new HttpsError(
+        'failed-precondition',
+        'You already have an open grading request. Finish or pay for it before requesting another.',
+      );
+    }
+
+    const grading: Grading = {
+      ...initGrading(),
+      studentMemberId: member.memberId,
+      studentMemberDocId: memberDocId,
+      level,
+      status: GradingStatus.AwaitingRequest,
+      paymentStatus: PaymentStatus.NotYetPaid,
+      orderId: '',
+      gradingPurchaseDate: '',
+    };
+
+    const gradingRef = db.collection('gradings').doc();
+    grading.docId = gradingRef.id;
+    await gradingRef.set({
+      ...grading,
+      lastUpdated: FieldValue.serverTimestamp(),
+    });
+
+    logger.info(
+      `Member ${member.memberId} (${memberDocId}) requested grading ${gradingRef.id} for ${level}.`,
+    );
+
+    return { gradingDocId: gradingRef.id };
+  },
+);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -30,6 +30,8 @@ export {
   onGradingDeleted,
 } from './on-grading-update';
 
+export { requestGrading } from './grading-request';
+
 export { sendPushOnNotification } from './send-push';
 
 export { scheduledBackup, manualBackup, listBackups } from './backup';

--- a/functions/src/proposed-events.ts
+++ b/functions/src/proposed-events.ts
@@ -12,8 +12,8 @@ import { onCall, HttpsError, CallableRequest } from 'firebase-functions/v2/https
 import { onDocumentCreated, onDocumentUpdated, onDocumentDeleted } from 'firebase-functions/v2/firestore';
 import * as admin from 'firebase-admin';
 import * as logger from 'firebase-functions/logger';
-import { IlcEvent, EventStatus, EventSourceKind, MembershipType, Member, EventDocument, initEvent } from './data-model';
-import { getMemberByEmail, allowedOrigins } from './common';
+import { IlcEvent, EventStatus, EventSourceKind, Member, EventDocument, initEvent } from './data-model';
+import { getMemberByEmail, allowedOrigins, hasActiveMembership } from './common';
 import axios from 'axios';
 import { environment } from './environment/environment';
 import { contentChanged } from './content-cache';
@@ -57,11 +57,7 @@ export function validateProposal(member: Member, data: Record<string, unknown>):
     return 'Must have a valid Member ID to propose events.';
   }
 
-  const today = new Date().toISOString().split('T')[0];
-  const isLife = member.membershipType === MembershipType.Life;
-  const isExpired = !isLife && (!member.currentMembershipExpires || member.currentMembershipExpires < today);
-
-  if (isExpired) {
+  if (!hasActiveMembership(member)) {
     return 'Must have an active membership to propose events.';
   }
 

--- a/functions/src/squarespace-orders/grading.spec.ts
+++ b/functions/src/squarespace-orders/grading.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { parseGradingOrderInfo, processGradingOrder } from './grading';
-import { SquareSpaceOrder, SquareSpaceLineItem, GradingStatus } from '../data-model';
+import { SquareSpaceOrder, SquareSpaceLineItem, GradingStatus, PaymentStatus } from '../data-model';
 import * as admin from 'firebase-admin';
 
 describe('parseGradingOrderInfo', () => {
@@ -526,6 +526,154 @@ describe('processGradingOrder', () => {
     expect(savedGrading.status).toBe(GradingStatus.RequiresReview);
     expect(savedGrading.studentMemberDocId).toBe('');
     expect(savedGrading.reviewIssue).toContain('Member ID US999 not found in database');
+  });
+
+  // Helper building a mock DB where the gradings collection returns
+  // `existingGradingDocs` when filtered by studentMemberDocId (the reuse query)
+  // and empty for the orderId idempotency query. The member lookup returns a
+  // single student doc.
+  function buildReuseMockDb(existingGradingDocs: any[]) {
+    const mockStudentDoc = {
+      id: 'student-doc-id',
+      ref: { id: 'student-doc-id', update: vi.fn().mockResolvedValue({}) },
+      data: () => ({
+        memberId: 'US402',
+        emails: ['lucas.dixon@gmail.com'],
+        studentLevel: 'Student Level 6',
+        applicationLevel: 'Application Level 3',
+        name: 'Lucas Dixon',
+      }),
+    };
+
+    const mockGet = vi.fn().mockImplementation(async function (this: any) {
+      const filters = this._filters || [];
+      const has = (field: string) => filters.find((f: any) => f.field === field);
+      if (has('orderId')) return { empty: true, docs: [] };
+      if (has('studentMemberDocId')) {
+        return { empty: existingGradingDocs.length === 0, docs: existingGradingDocs };
+      }
+      if (has('memberId') && has('memberId').value === 'US402') {
+        return { empty: false, docs: [mockStudentDoc] };
+      }
+      return { empty: true, docs: [] };
+    });
+
+    const mockSet = vi.fn().mockResolvedValue({});
+    const mockDoc = vi.fn().mockReturnValue({ id: 'new-grading-doc-id', set: mockSet });
+
+    function createQueryMock(filters: any[] = []): any {
+      return {
+        _filters: filters,
+        where(field: string, op: string, value: any) {
+          return createQueryMock([...filters, { field, op, value }]);
+        },
+        limit() { return this; },
+        get: mockGet,
+        doc: mockDoc,
+      };
+    }
+
+    const mockDb = {
+      collection: vi.fn().mockImplementation((name) => {
+        if (name === 'members' || name === 'gradings') return createQueryMock();
+        return { doc: mockDoc };
+      }),
+    } as unknown as admin.firestore.Firestore;
+
+    return { mockDb, mockSet, mockDoc };
+  }
+
+  const reuseOrder = {
+    docId: 'order-reuse-1',
+    orderNumber: '42',
+    createdOn: '2026-03-01T10:00:00.000Z',
+    modifiedOn: '2026-03-01T10:00:00.000Z',
+    customerEmail: 'lucas.dixon@iliqchuan.com',
+    lastUpdated: '2026-03-01T10:00:00.000Z',
+  } as SquareSpaceOrder;
+
+  const reuseGradingItem = {
+    id: 'line-item-reuse',
+    productId: 'prod-1',
+    productName: 'GRADING : Student Levels',
+    variantOptions: [{ optionName: 'Level', value: 'Student Level 7' }],
+    customizations: [
+      { label: 'Member ID', value: 'US402' },
+      { label: 'Email', value: 'lucas.dixon@gmail.com' },
+    ],
+  } as SquareSpaceLineItem;
+
+  it('reuses an existing unpaid request for the same level, marking it paid online and recording the order, with no duplicate', async () => {
+    const mockUpdate = vi.fn().mockResolvedValue({});
+    const existing = {
+      id: 'existing-grading-id',
+      ref: { update: mockUpdate },
+      data: () => ({
+        level: 'Student 7',
+        status: GradingStatus.AwaitingAcceptance,
+        paymentStatus: PaymentStatus.NotYetPaid,
+        studentMemberDocId: 'student-doc-id',
+        studentMemberId: 'US402',
+        gradingPurchaseDate: '',
+        orderId: '',
+      }),
+    };
+
+    const { mockDb, mockSet } = buildReuseMockDb([existing]);
+    const result = await processGradingOrder(reuseOrder, 'order-reuse-1', reuseGradingItem, mockDb);
+
+    expect(result).toEqual({ kind: 'success', gradingDocId: 'existing-grading-id' });
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    const update = mockUpdate.mock.calls[0][0];
+    expect(update.paymentStatus).toBe(PaymentStatus.PaidBySquarespace);
+    expect(update.orderId).toBe('order-reuse-1');
+    expect(update.gradingPurchaseDate).toBe('2026-03-01');
+    // No new grading document is created.
+    expect(mockSet).not.toHaveBeenCalled();
+  });
+
+  it('does not reuse a completed (not-passed) unpaid grading, creating a new grading instead', async () => {
+    const mockUpdate = vi.fn().mockResolvedValue({});
+    const existing = {
+      id: 'failed-grading-id',
+      ref: { update: mockUpdate },
+      data: () => ({
+        level: 'Student 7',
+        status: GradingStatus.NotPassed,
+        paymentStatus: PaymentStatus.NotYetPaid,
+        studentMemberDocId: 'student-doc-id',
+        studentMemberId: 'US402',
+      }),
+    };
+
+    const { mockDb, mockSet } = buildReuseMockDb([existing]);
+    const result = await processGradingOrder(reuseOrder, 'order-reuse-1', reuseGradingItem, mockDb);
+
+    expect(result).toEqual({ kind: 'success', gradingDocId: 'new-grading-doc-id' });
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(mockSet).toHaveBeenCalled();
+  });
+
+  it('does not reuse a grading for a different level, creating a new grading instead', async () => {
+    const mockUpdate = vi.fn().mockResolvedValue({});
+    const existing = {
+      id: 'other-level-grading-id',
+      ref: { update: mockUpdate },
+      data: () => ({
+        level: 'Student 5',
+        status: GradingStatus.AwaitingRequest,
+        paymentStatus: PaymentStatus.NotYetPaid,
+        studentMemberDocId: 'student-doc-id',
+        studentMemberId: 'US402',
+      }),
+    };
+
+    const { mockDb, mockSet } = buildReuseMockDb([existing]);
+    const result = await processGradingOrder(reuseOrder, 'order-reuse-1', reuseGradingItem, mockDb);
+
+    expect(result).toEqual({ kind: 'success', gradingDocId: 'new-grading-doc-id' });
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(mockSet).toHaveBeenCalled();
   });
 });
 

--- a/functions/src/squarespace-orders/grading.spec.ts
+++ b/functions/src/squarespace-orders/grading.spec.ts
@@ -10,7 +10,7 @@ describe('parseGradingOrderInfo', () => {
       orderNumber: '14',
       createdOn: '2026-02-22T23:54:59.673Z',
       modifiedOn: '2026-02-22T23:54:59.953Z',
-      customerEmail: 'lucas.dixon@iliqchuan.com',
+      customerEmail: 'orders@example.com',
       lastUpdated: '2026-02-22T23:54:59.953Z',
     } as SquareSpaceOrder;
 
@@ -35,7 +35,7 @@ describe('parseGradingOrderInfo', () => {
         },
         {
           label: 'Email',
-          value: 'lucas.dixon@gmail.com'
+          value: 'student@example.com'
         },
         {
           label: 'Current Student Level',
@@ -63,7 +63,7 @@ describe('parseGradingOrderInfo', () => {
     const parsed = parseGradingOrderInfo(orderData, gradingItem);
 
     expect(parsed).toEqual({
-      email: 'lucas.dixon@gmail.com',
+      email: 'student@example.com',
       currentStudentLevel: 'Student 6',
       currentApplicationLevel: 'Application 3',
       gradingInfo: expect.objectContaining({
@@ -156,7 +156,7 @@ describe('processGradingOrder', () => {
       orderNumber: '14',
       createdOn: '2026-02-22T23:54:59.673Z',
       modifiedOn: '2026-02-22T23:54:59.953Z',
-      customerEmail: 'lucas.dixon@iliqchuan.com',
+      customerEmail: 'orders@example.com',
       lastUpdated: '2026-02-22T23:54:59.953Z',
     } as SquareSpaceOrder;
 
@@ -168,7 +168,7 @@ describe('processGradingOrder', () => {
       customizations: [
         { label: 'Name', value: 'Lucas Dixon' },
         { label: 'Member ID', value: 'US402' },
-        { label: 'Email', value: 'lucas.dixon@gmail.com' },
+        { label: 'Email', value: 'student@example.com' },
         { label: 'Current Student Level', value: 'Student Level 6' },
         { label: 'Current Application Level', value: 'Application Level 3' },
       ],
@@ -183,7 +183,7 @@ describe('processGradingOrder', () => {
       },
       data: () => ({
         memberId: 'US402',
-        emails: ['lucas.dixon@gmail.com'],
+        emails: ['student@example.com'],
         studentLevel: 'Student Level 6',
         applicationLevel: 'Application Level 3',
         name: 'Lucas Dixon',
@@ -254,7 +254,7 @@ describe('processGradingOrder', () => {
       orderNumber: '14',
       createdOn: '2026-02-22T23:54:59.673Z',
       modifiedOn: '2026-02-22T23:54:59.953Z',
-      customerEmail: 'lucas.dixon@iliqchuan.com',
+      customerEmail: 'orders@example.com',
       lastUpdated: '2026-02-22T23:54:59.953Z',
     } as SquareSpaceOrder;
 
@@ -266,7 +266,7 @@ describe('processGradingOrder', () => {
       customizations: [
         { label: 'Name', value: 'Lucas Dixon' },
         { label: 'Member ID', value: 'US402' },
-        { label: 'Email', value: 'lucas.dixon@gmail.com' },
+        { label: 'Email', value: 'student@example.com' },
         { label: 'Current Student Level', value: 'Student Level 6' },
         { label: 'Current Application Level', value: 'Application Level 3' },
         { label: 'Evaluating Instructor Instructor ID', value: 'Sam Chin [1]' },
@@ -282,7 +282,7 @@ describe('processGradingOrder', () => {
       },
       data: () => ({
         memberId: 'US402',
-        emails: ['lucas.dixon@gmail.com'],
+        emails: ['student@example.com'],
         studentLevel: 'Student Level 6',
         applicationLevel: 'Application Level 3',
         name: 'Lucas Dixon',
@@ -367,7 +367,7 @@ describe('processGradingOrder', () => {
       orderNumber: '14',
       createdOn: '2026-02-22T23:54:59.673Z',
       modifiedOn: '2026-02-22T23:54:59.953Z',
-      customerEmail: 'lucas.dixon@iliqchuan.com',
+      customerEmail: 'orders@example.com',
       lastUpdated: '2026-02-22T23:54:59.953Z',
     } as SquareSpaceOrder;
 
@@ -379,7 +379,7 @@ describe('processGradingOrder', () => {
       customizations: [
         { label: 'Name', value: 'Lucas Dixon' },
         { label: 'Member ID', value: 'US402' },
-        { label: 'Email', value: 'lucas.dixon@gmail.com' },
+        { label: 'Email', value: 'student@example.com' },
         { label: 'Current Student Level', value: 'Student Level 6' },
         { label: 'Current Application Level', value: 'Application Level 3' },
         { label: 'Evaluating Instructor Instructor ID', value: '999' },
@@ -395,7 +395,7 @@ describe('processGradingOrder', () => {
       },
       data: () => ({
         memberId: 'US402',
-        emails: ['lucas.dixon@gmail.com'],
+        emails: ['student@example.com'],
         studentLevel: 'Student Level 6',
         applicationLevel: 'Application Level 3',
         name: 'Lucas Dixon',
@@ -538,7 +538,7 @@ describe('processGradingOrder', () => {
       ref: { id: 'student-doc-id', update: vi.fn().mockResolvedValue({}) },
       data: () => ({
         memberId: 'US402',
-        emails: ['lucas.dixon@gmail.com'],
+        emails: ['student@example.com'],
         studentLevel: 'Student Level 6',
         applicationLevel: 'Application Level 3',
         name: 'Lucas Dixon',
@@ -588,7 +588,7 @@ describe('processGradingOrder', () => {
     orderNumber: '42',
     createdOn: '2026-03-01T10:00:00.000Z',
     modifiedOn: '2026-03-01T10:00:00.000Z',
-    customerEmail: 'lucas.dixon@iliqchuan.com',
+    customerEmail: 'orders@example.com',
     lastUpdated: '2026-03-01T10:00:00.000Z',
   } as SquareSpaceOrder;
 
@@ -599,7 +599,7 @@ describe('processGradingOrder', () => {
     variantOptions: [{ optionName: 'Level', value: 'Student Level 7' }],
     customizations: [
       { label: 'Member ID', value: 'US402' },
-      { label: 'Email', value: 'lucas.dixon@gmail.com' },
+      { label: 'Email', value: 'student@example.com' },
     ],
   } as SquareSpaceLineItem;
 

--- a/functions/src/squarespace-orders/grading.ts
+++ b/functions/src/squarespace-orders/grading.ts
@@ -7,7 +7,7 @@ through Squarespace.
 
 import * as admin from 'firebase-admin';
 import * as logger from 'firebase-functions/logger';
-import { Member, Grading, GradingStatus, PaymentStatus, initGrading, SquareSpaceOrder, SquareSpaceLineItem, SquareSpaceCustomization } from '../data-model';
+import { Member, Grading, GradingStatus, PaymentStatus, initGrading, isGradingPaid, SquareSpaceOrder, SquareSpaceLineItem, SquareSpaceCustomization } from '../data-model';
 import { canonicalizeGradingLevel, canonicalizeStudentLevel, canonicalizeApplicationLevel } from '../level-utils';
 import { GradingResult } from './common';
 import { inferMemberIdFromOrder } from './infer-member';
@@ -183,6 +183,37 @@ export async function processGradingOrder(
     });
 
     return { kind: 'success', gradingDocId: gradingRef.id };
+  }
+
+  // Reuse an existing unpaid request for the same level instead of creating a
+  // duplicate. If the student already requested this grading (e.g. via the
+  // requestGrading callable) and now paid for it, mark that record paid online
+  // and record the order number, preserving its current status/instructor. A
+  // failed (NotPassed) grading does not absorb a new payment.
+  const existingGradings = await db.collection('gradings')
+    .where('studentMemberDocId', '==', memberDocRef.id)
+    .get();
+  const reusable = existingGradings.docs
+    .map((d) => ({ ref: d.ref, g: { ...(d.data() as Grading), docId: d.id } }))
+    .filter(({ g }) =>
+      g.level === level &&
+      !isGradingPaid(g) &&
+      g.status !== GradingStatus.NotPassed)
+    .sort((a, b) => (b.g.gradingPurchaseDate || '').localeCompare(a.g.gradingPurchaseDate || ''))[0];
+
+  if (reusable) {
+    const update: Record<string, unknown> = {
+      paymentStatus: PaymentStatus.PaidBySquarespace,
+      orderId,
+      lastUpdated: admin.firestore.FieldValue.serverTimestamp(),
+    };
+    if (!reusable.g.gradingPurchaseDate) {
+      update.gradingPurchaseDate = gradingInfo.gradingPurchaseDate;
+    }
+    logger.info(`[Grading] Order ${orderId}: matched existing unpaid grading ${reusable.g.docId} ` +
+      `for ${level}; marking paid online instead of creating a duplicate.`);
+    await reusable.ref.update(update);
+    return { kind: 'success', gradingDocId: reusable.g.docId };
   }
 
   let hasValidInstructor = false;

--- a/functions/src/squarespace-orders/instructor-license.spec.ts
+++ b/functions/src/squarespace-orders/instructor-license.spec.ts
@@ -16,7 +16,7 @@ const realLineItem: SquareSpaceLineItem = {
   ],
   customizations: [
     { label: 'Name', value: 'Lucas Dixon' },
-    { value: 'lucas.dixon@gmail.com', label: 'Email ' },
+    { value: 'student@example.com', label: 'Email ' },
     { label: 'Member ID', value: 'US402' },
   ],
 };
@@ -32,7 +32,7 @@ const realOrder: SquareSpaceOrder = {
   orderNumber: '61815',
   createdOn: '2026-03-02T10:44:26.747Z',
   modifiedOn: '2026-03-02T10:44:27.148Z',
-  customerEmail: 'lucas.dixon@gmail.com',
+  customerEmail: 'student@example.com',
   fulfillmentStatus: 'PENDING',
   billingAddress: {
     address2: 'Apt 4',
@@ -53,7 +53,7 @@ describe('parseInstructorLicenseInfo', () => {
     const parsed = parseInstructorLicenseInfo(realOrder, realLineItem);
     expect(parsed).toEqual({
       memberId: 'US402',
-      email: 'lucas.dixon@gmail.com',
+      email: 'student@example.com',
       orderDate: '2026-03-02',
     });
   });
@@ -67,7 +67,7 @@ describe('parseInstructorLicenseInfo', () => {
     };
 
     const parsed = parseInstructorLicenseInfo(realOrder, lineItem);
-    expect(parsed.email).toBe('lucas.dixon@gmail.com');
+    expect(parsed.email).toBe('student@example.com');
   });
 
   it('should handle empty customizations', () => {
@@ -78,7 +78,7 @@ describe('parseInstructorLicenseInfo', () => {
 
     const parsed = parseInstructorLicenseInfo(realOrder, lineItem);
     expect(parsed.memberId).toBe('');
-    expect(parsed.email).toBe('lucas.dixon@gmail.com');
+    expect(parsed.email).toBe('student@example.com');
     expect(parsed.orderDate).toBe('2026-03-02');
   });
 });

--- a/functions/src/squarespace-orders/life-membership.spec.ts
+++ b/functions/src/squarespace-orders/life-membership.spec.ts
@@ -16,7 +16,7 @@ const realOrder: SquareSpaceOrder = {
   orderNumber: '61814',
   createdOn: '2026-03-02T07:45:11.869Z',
   modifiedOn: '2026-03-02T07:47:04.763Z',
-  customerEmail: 'lucas.dixon@gmail.com',
+  customerEmail: 'student@example.com',
   fulfillmentStatus: 'FULFILLED',
   billingAddress: {
     countryCode: 'FR',
@@ -43,13 +43,13 @@ const realOrder: SquareSpaceOrder = {
       ],
       customizations: [
         { value: 'Lucas4 Dixon', label: 'Name' },
-        { value: 'lucas.dixon+4@gmail.com', label: 'Email' },
+        { value: 'member4@example.com', label: 'Email' },
         { value: '11/23/1979', label: 'Date of birth' },
         { value: 'New membership', label: 'Is this a new membership?' },
         { value: '', label: 'Member ID' },
         { value: 'France', label: 'Country' },
         { value: 'Lucas5 Dixon', label: 'Spouse name' },
-        { value: 'lucas.dixon+4@gmail.com', label: 'Spouse email' },
+        { value: 'member4@example.com', label: 'Spouse email' },
         { value: '11/23/1979', label: 'Spouse date of birth' },
         { value: 'New membership', label: 'Is this a new membership for the spouse?' },
         { value: '', label: 'Spouse member ID' },
@@ -71,7 +71,7 @@ describe('parseLifeMembershipInfo', () => {
 
     // Member info
     expect(parsed.member.name).toBe('Lucas4 Dixon');
-    expect(parsed.member.email).toBe('lucas.dixon+4@gmail.com');
+    expect(parsed.member.email).toBe('member4@example.com');
     expect(parsed.member.dateOfBirth).toBe('11/23/1979');
     expect(parsed.member.country).toBe('France');
     expect(parsed.member.memberId).toBe('');
@@ -80,7 +80,7 @@ describe('parseLifeMembershipInfo', () => {
     // Spouse info
     expect(parsed.spouse).toBeDefined();
     expect(parsed.spouse!.name).toBe('Lucas5 Dixon');
-    expect(parsed.spouse!.email).toBe('lucas.dixon+4@gmail.com');
+    expect(parsed.spouse!.email).toBe('member4@example.com');
     expect(parsed.spouse!.dateOfBirth).toBe('11/23/1979');
     expect(parsed.spouse!.country).toBe('France');
     expect(parsed.spouse!.memberId).toBe('');
@@ -158,7 +158,7 @@ describe('parseLifeMembershipInfo', () => {
 
     const parsed = parseLifeMembershipInfo(realOrder, lineItem);
     // Main member should fall back to customerEmail
-    expect(parsed.member.email).toBe('lucas.dixon@gmail.com');
+    expect(parsed.member.email).toBe('student@example.com');
     // Spouse should NOT fall back to customerEmail
     expect(parsed.spouse!.email).toBe('');
   });
@@ -173,7 +173,7 @@ describe('parseLifeMembershipInfo', () => {
     expect(parsed.hasSpouse).toBe(false);
     expect(parsed.spouse).toBeUndefined();
     expect(parsed.member.memberId).toBe('');
-    expect(parsed.member.email).toBe('lucas.dixon@gmail.com');
+    expect(parsed.member.email).toBe('student@example.com');
     expect(parsed.member.name).toBe('');
   });
 });

--- a/functions/src/squarespace-orders/membership.spec.ts
+++ b/functions/src/squarespace-orders/membership.spec.ts
@@ -19,7 +19,7 @@ const realLineItem: SquareSpaceLineItem = {
     { value: 'Renewing an existing member', label: 'Is this membership for a new member?' },
     { value: 'FR102', label: 'Member ID' },
     { label: 'Name', value: 'Lucas testing' },
-    { value: 'moilucasdixon@gmail.com', label: 'Email' },
+    { value: 'member@example.com', label: 'Email' },
     { value: '11/23/1979', label: 'Date of birth' },
     { label: 'Country', value: 'France' },
     { label: 'Terms and conditions', value: 'I agree' },
@@ -37,7 +37,7 @@ const realOrder: SquareSpaceOrder = {
   orderNumber: '61811',
   createdOn: '2026-03-01T16:11:17.601Z',
   modifiedOn: '2026-03-01T16:12:19.244Z',
-  customerEmail: 'moilucasdixon@gmail.com',
+  customerEmail: 'member@example.com',
   fulfillmentStatus: 'FULFILLED',
   billingAddress: {
     postalCode: '93500',
@@ -60,7 +60,7 @@ describe('parseMembershipRenewalInfo', () => {
     expect(parsed).toEqual({
       member: {
         memberId: 'FR102',
-        email: 'moilucasdixon@gmail.com',
+        email: 'member@example.com',
         name: 'Lucas testing',
         dateOfBirth: '11/23/1979',
         country: 'France',
@@ -102,7 +102,7 @@ describe('parseMembershipRenewalInfo', () => {
     };
 
     const parsed = parseMembershipRenewalInfo(realOrder, noEmailLineItem);
-    expect(parsed.member.email).toBe('moilucasdixon@gmail.com');
+    expect(parsed.member.email).toBe('member@example.com');
   });
 
   it('should fall back to billing address country when no country in customizations', () => {
@@ -135,7 +135,7 @@ describe('parseMembershipRenewalInfo', () => {
 
     const parsed = parseMembershipRenewalInfo(realOrder, emptyLineItem);
     expect(parsed.member.memberId).toBe('');
-    expect(parsed.member.email).toBe('moilucasdixon@gmail.com');
+    expect(parsed.member.email).toBe('member@example.com');
     expect(parsed.member.name).toBe('');
     expect(parsed.member.country).toBe('');
     expect(parsed.member.isNewMember).toBeUndefined();

--- a/functions/src/squarespace-orders/school-license.spec.ts
+++ b/functions/src/squarespace-orders/school-license.spec.ts
@@ -58,7 +58,7 @@ const realLineItem: SquareSpaceLineItem = {
   ],
   customizations: [
     { label: 'Name', value: 'Lucas Dixon' },
-    { label: 'Email ', value: 'lucas.dixon@gmail.com' },
+    { label: 'Email ', value: 'student@example.com' },
     { value: 'US402', label: 'MemberID' },
     { label: 'School ID', value: 'SCH-101' },
     { value: 'Paris Zhong Xin Dao', label: 'Name of the School' },
@@ -76,7 +76,7 @@ const realOrder: SquareSpaceOrder = {
   orderNumber: '61813',
   createdOn: '2026-03-01T16:19:19.698Z',
   modifiedOn: '2026-03-01T16:19:20.081Z',
-  customerEmail: 'moilucasdixon@gmail.com',
+  customerEmail: 'member@example.com',
   fulfillmentStatus: 'PENDING',
   billingAddress: {
     lastName: 'Dixon',
@@ -103,7 +103,7 @@ const monthlyLineItem: SquareSpaceLineItem = {
   variantOptions: [],
   customizations: [
     { value: 'Yen Chin', label: 'Name' },
-    { label: 'Email ', value: 'yen@iliqchuan.com' },
+    { label: 'Email ', value: 'yen@example.com' },
     { label: 'MemberID', value: 'Family' },
     { label: 'School ID', value: 'ILC NYC' },
   ],
@@ -119,7 +119,7 @@ const monthlyOrder: SquareSpaceOrder = {
   orderNumber: '61808',
   createdOn: '2026-03-01T05:30:18.579Z',
   modifiedOn: '2026-03-01T22:48:58.056Z',
-  customerEmail: 'yen@iliqchuan.com',
+  customerEmail: 'yen@example.com',
   fulfillmentStatus: 'FULFILLED',
   billingAddress: {
     lastName: 'Chin',
@@ -145,7 +145,7 @@ describe('parseSchoolLicenseInfo', () => {
 
     expect(parsed).toEqual({
       schoolId: 'SCH-101',
-      email: 'lucas.dixon@gmail.com',
+      email: 'student@example.com',
       memberId: 'US402',
       orderDate: '2026-03-01',
     });
@@ -156,7 +156,7 @@ describe('parseSchoolLicenseInfo', () => {
 
     expect(parsed).toEqual({
       schoolId: 'ILC NYC',
-      email: 'yen@iliqchuan.com',
+      email: 'yen@example.com',
       memberId: 'Family',
       orderDate: '2026-03-01',
     });
@@ -172,7 +172,7 @@ describe('parseSchoolLicenseInfo', () => {
     };
 
     const parsed = parseSchoolLicenseInfo(realOrder, lineItem);
-    expect(parsed.email).toBe('moilucasdixon@gmail.com');
+    expect(parsed.email).toBe('member@example.com');
     expect(parsed.schoolId).toBe('SCH-200');
   });
 
@@ -228,7 +228,7 @@ describe('parseSchoolLicenseInfo', () => {
     const parsed = parseSchoolLicenseInfo(realOrder, lineItem);
     expect(parsed.schoolId).toBe('');
     expect(parsed.memberId).toBe('');
-    expect(parsed.email).toBe('moilucasdixon@gmail.com');
+    expect(parsed.email).toBe('member@example.com');
     expect(parsed.orderDate).toBe('2026-03-01');
   });
 });

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -148,6 +148,19 @@ export class App {
   onInstructorTitleLoaded(title: string) {
     this.loadedInstructorTitle.set(title);
   }
+  // Whether the grading currently open in GradingView belongs to the signed-in
+  // user (they are its student, on any of their member profiles). Drives the
+  // parent breadcrumb so it matches the back link in grading-view.
+  public gradingViewIsOwn = computed(() => {
+    const gradingId = this.routingService.signals[Views.GradingView].pathVars.gradingId();
+    if (!gradingId) return false;
+    const grading = this.dataService.gradings.get(gradingId)
+      ?? this.dataService.myGradings.get(gradingId)
+      ?? this.dataService.myGradingsAssessed.get(gradingId);
+    if (!grading) return false;
+    const profiles = this.firebaseService.user()?.memberProfiles ?? [];
+    return profiles.some((p) => p.docId === grading.studentMemberDocId);
+  });
   public breadcrumbs = computed<Breadcrumb[]>(() => {
     const baseBreadcrumbs: Breadcrumb[] = [
       { label: 'I Liq Chuan', shortLabel: 'ILC', url: 'https://iliqchuan.com' },
@@ -230,7 +243,14 @@ export class App {
       } else if (view === Views.MySchoolEdit) {
         baseBreadcrumbs.push({ label: 'My Schools', url: '#/my-schools' });
       } else if (view === Views.GradingView) {
-        baseBreadcrumbs.push({ label: 'Manage Gradings', url: '#/gradings' });
+        // When viewing your own grading, the parent is "My Gradings"; otherwise
+        // (an admin viewing someone else's) it's "Manage Gradings". Mirrors the
+        // back link in grading-view.
+        if (this.gradingViewIsOwn()) {
+          baseBreadcrumbs.push({ label: 'My Gradings', url: '#/my-gradings' });
+        } else {
+          baseBreadcrumbs.push({ label: 'Manage Gradings', url: '#/gradings' });
+        }
       }
       const isEventView = view === Views.EventView || view === Views.MyEventView || view === Views.ManageEventView;
       const isEventEdit = view === Views.EventEdit || view === Views.MyEventEdit || view === Views.ManageEventEdit;

--- a/src/app/data-manager.service.ts
+++ b/src/app/data-manager.service.ts
@@ -1298,6 +1298,17 @@ export class DataManagerService {
     await fn();
   }
 
+  // Request a new (unpaid) grading for the member's next level via the guarded
+  // Cloud Function. Returns the new grading's doc ID.
+  async requestGrading(memberDocId: string): Promise<string> {
+    const fn = httpsCallable<{ memberDocId: string }, { gradingDocId: string }>(
+      this.functions,
+      'requestGrading',
+    );
+    const result = await fn({ memberDocId });
+    return result.data.gradingDocId;
+  }
+
   async reprocessOrder(docId: string): Promise<void> {
     const fn = httpsCallable<{ docId: string }, { success: boolean }>(
       this.functions,

--- a/src/app/grading-list/grading-list.ts
+++ b/src/app/grading-list/grading-list.ts
@@ -99,10 +99,13 @@ export class GradingListComponent {
   private dataService = inject(DataManagerService);
   private routingService: RoutingService<AppPathPatterns> = inject(RoutingService);
   user = this.firebaseStateService.user;
+  // Only admins, and only on the "Manage Gradings" page (viewMode 'all'), can
+  // create a grading directly. The member-facing "My Gradings" lists (viewMode
+  // 'member'/'instructor') use the request flow instead.
   canMakeNewGradings = computed(() => {
     const user = this.user();
     if (!user) return false;
-    return user.isAdmin;
+    return user.isAdmin && this.viewMode() === 'all';
   });
 
   viewMode = input<'all' | 'instructor' | 'member'>('all');

--- a/src/app/grading-progress/grading-progress.html
+++ b/src/app/grading-progress/grading-progress.html
@@ -182,6 +182,20 @@
         }
       }
 
+      <!-- Payment prompt: an unpaid grading the student still needs to pay for. -->
+      @if (userIsStudent() && isUnpaid()) {
+        <div class="warning-box payment-prompt">
+          <app-icon name="error" width="18" height="18" fill="#b06000"></app-icon>
+          <span>
+            <strong>Not paid yet.</strong> You can request and plan this grading
+            now, but it must be paid before your result counts.
+            <button type="button" class="purchase-grading-btn" (click)="purchaseGrading()">
+              <app-icon name="arrow_forward" width="16" height="16"></app-icon> Purchase grading
+            </button>
+          </span>
+        </div>
+      }
+
       <!-- Context message -->
       @if (userIsStudent()) {
         @if (
@@ -1191,6 +1205,11 @@
             </span>
             @if (grading().paymentNote) {
               <span class="detail-sub">— {{ grading().paymentNote }}</span>
+            }
+            @if (isUnpaid() && userIsStudent()) {
+              <button type="button" class="payment-purchase-btn" (click)="purchaseGrading()">
+                <app-icon name="arrow_forward" width="14" height="14"></app-icon> Purchase
+              </button>
             }
             @if (canEditGradingDetails()) {
               <button class="icon-only-button detail-edit-btn" (click)="isEditingPayment.set(true)" title="Edit payment status"><app-icon name="edit"></app-icon></button>

--- a/src/app/grading-progress/grading-progress.scss
+++ b/src/app/grading-progress/grading-progress.scss
@@ -199,6 +199,26 @@
   font-weight: 600;
 }
 
+// "Purchase grading" prompt shown to a student with an unpaid grading, rendered
+// as a warning box with the app's normal (raised) button to make paying an
+// obvious next step.
+.payment-prompt {
+  .purchase-grading-btn {
+    display: flex;
+    width: fit-content;
+    margin-top: 0.6em;
+    white-space: nowrap;
+  }
+}
+
+.payment-purchase-btn {
+  display: inline-flex;
+  margin-left: 0.5em;
+  font-size: 0.85em;
+  white-space: nowrap;
+  vertical-align: middle;
+}
+
 .detail-sub {
   color: v.$text-secondary;
   font-size: 0.9em;

--- a/src/app/grading-progress/grading-progress.ts
+++ b/src/app/grading-progress/grading-progress.ts
@@ -48,6 +48,7 @@ import { RoutingService } from '../routing.service';
 import { AppPathPatterns, Views } from '../app.config';
 import { GradingEventInputComponent, GradingEventDetails } from '../grading-event-input/grading-event-input';
 import { MemberProfileLinkService } from '../member-profile-link.service';
+import { environment } from '../../environments/environment';
 
 
 
@@ -358,6 +359,15 @@ export class GradingProgressComponent {
   // The grading's current payment status label + whether it counts as unpaid.
   currentPaymentLabel = computed(() => this.paymentStatusLabel(this.grading().paymentStatus));
   isUnpaid = computed(() => !isGradingPaid(this.grading()));
+
+  // Link to the grading product page, shown to a student with an unpaid grading
+  // so they can pay for it (after which the order flips it to "Paid online").
+  gradingProductLink = environment.links.grading;
+
+  // Open the grading product page in a new tab to purchase the grading.
+  purchaseGrading() {
+    window.open(this.gradingProductLink, '_blank', 'noopener');
+  }
 
   // Sync local editing signals from grading input whenever it changes.
   private syncEffect = effect(() => {

--- a/src/app/grading-view/grading-view.html
+++ b/src/app/grading-view/grading-view.html
@@ -1,6 +1,6 @@
 <!-- Back navigation -->
 <a class="subtle-button" [href]="backHref()">
-  <app-icon name="arrow_back"></app-icon> Back to Gradings
+  <app-icon name="arrow_back"></app-icon> {{ backLabel() }}
 </a>
 
 @if (asyncError(); as errMsg) {

--- a/src/app/grading-view/grading-view.ts
+++ b/src/app/grading-view/grading-view.ts
@@ -69,12 +69,26 @@ export class GradingViewComponent {
       this.dataService.myGradingsAssessed.loading();
   });
 
+  // True when the signed-in user is the student of the grading being viewed
+  // (one of their own member profiles). Such a viewer navigates back to their
+  // own "My Gradings" page, even if they are also an admin.
+  protected isOwnGrading = computed(() => {
+    const user = this.firebaseState.user();
+    const g = this.grading();
+    if (!user || !g) return false;
+    return user.memberProfiles.some((p) => p.docId === g.studentMemberDocId);
+  });
+
   protected backHref = computed(() => {
-    if (this.userIsAdmin()) {
+    if (this.userIsAdmin() && !this.isOwnGrading()) {
       return this.routingService.hrefForView(Views.ManageGradings);
     }
     return this.routingService.hrefForView(Views.MemberGradings);
   });
+
+  protected backLabel = computed(() =>
+    this.isOwnGrading() ? 'Back to My Gradings' : 'Back to Gradings',
+  );
 
   // Emit the title when the grading is loaded.
   private _emitTitle = effect(() => {

--- a/src/app/import-export/import-orders/import-orders.component.spec.ts
+++ b/src/app/import-export/import-orders/import-orders.component.spec.ts
@@ -473,10 +473,10 @@ describe('ImportOrdersComponent', () => {
       { ...initMember(), memberId: 'DE12', emails: ['krischek@web.de'], name: 'Bernd Krischek' },
       // No member for PL62WLKP89 — will test email fallback
       { ...initMember(), memberId: 'PL-OTHER', emails: ['tomasz.nowak@nowapracownia.pl'], name: 'Tomasz Nowak' },
-      { ...initMember(), memberId: 'US318AZ', emails: ['thecharlesjean@gmail.com'], name: 'Charles Jean' },
+      { ...initMember(), memberId: 'US318AZ', emails: ['charles@example.com'], name: 'Charles Jean' },
       // No member for Ryu Cheng — will test not-found
       // Mikalai Filipau has Member Number N/A — will test email fallback
-      { ...initMember(), memberId: 'BY-001', emails: ['filippov.nikolai.v@gmail.com'], name: 'Mikalai Filipau' },
+      { ...initMember(), memberId: 'BY-001', emails: ['nikolai@example.com'], name: 'Mikalai Filipau' },
     ];
 
     // Build parsed rows as PapaParse would produce from the user's sample TSV.
@@ -534,10 +534,10 @@ describe('ImportOrdersComponent', () => {
         order_number_formatted: '6468',
         order_number: '',
         order_date: '2018-06-12 17:30:47',
-        line_items: 'id:983|name:Student Membership - Lifetime|product_id:2898|sku:|quantity:1|subtotal:500.00|subtotal_tax:0.00|total:500.00|total_tax:0.00|refunded:0.00|refunded_qty:0|meta:Membership Level=Lifetime,Member Number=N/A,Student Of=Dzmitry Siomau,Name=Mikalai Filipau,Email=filippov.nikolai.v@gmail.com,Address=4/1 285\\, Mogilevskaya\\, Minsk\\, Minsk\\, 220007\\, Belarus,Date of Birth=08/10/1988,Agree=I Agree',
+        line_items: 'id:983|name:Student Membership - Lifetime|product_id:2898|sku:|quantity:1|subtotal:500.00|subtotal_tax:0.00|total:500.00|total_tax:0.00|refunded:0.00|refunded_qty:0|meta:Membership Level=Lifetime,Member Number=N/A,Student Of=Dzmitry Siomau,Name=Mikalai Filipau,Email=nikolai@example.com,Address=4/1 285\\, Mogilevskaya\\, Minsk\\, Minsk\\, 220007\\, Belarus,Date of Birth=08/10/1988,Agree=I Agree',
         first_name: 'Mikalai',
         last_name: 'Filipau',
-        billing_email: 'filippov.nikolai.v@gmail.com',
+        billing_email: 'nikolai@example.com',
         billing_address_1: '4/1 Mogilevskaya',
         billing_address_2: '285',
         billing_postcode: '220007',
@@ -612,7 +612,7 @@ describe('ImportOrdersComponent', () => {
       const entry = delta.new.get('6468') || delta.issues.find(i => i.key === '6468');
       expect(entry).toBeTruthy();
       // N/A → externalId empty, email preserved for calculateSideEffects
-      expect(entry!.newItem.email).toBe('filippov.nikolai.v@gmail.com');
+      expect(entry!.newItem.email).toBe('nikolai@example.com');
     });
 
     it('should set externalId for unknown member numbers (validation later)', async () => {
@@ -622,10 +622,10 @@ describe('ImportOrdersComponent', () => {
         order_number_formatted: '6118',
         order_number: '',
         order_date: '2018-05-04 2:16:46',
-        line_items: 'id:797|name:Student Membership - Lifetime|product_id:2898|sku:|quantity:1|subtotal:500.00|subtotal_tax:0.00|total:500.00|total_tax:0.00|refunded:0.00|refunded_qty:0|meta:Membership Level=Lifetime,Member Number=US431-71,Student Of=Bernard Langan,Name=Ryu Cheng,Email=Ryu.cheng@gmail.com,Phone=(415) 860-7982,Address=4532 tulip avenue\\, Oakland\\, California\\, 94619\\, United States,Date of Birth=02/01/1979,Agree=I Agree',
+        line_items: 'id:797|name:Student Membership - Lifetime|product_id:2898|sku:|quantity:1|subtotal:500.00|subtotal_tax:0.00|total:500.00|total_tax:0.00|refunded:0.00|refunded_qty:0|meta:Membership Level=Lifetime,Member Number=US431-71,Student Of=Bernard Langan,Name=Ryu Cheng,Email=ryu@example.com,Phone=(415) 860-7982,Address=4532 tulip avenue\\, Oakland\\, California\\, 94619\\, United States,Date of Birth=02/01/1979,Agree=I Agree',
         first_name: 'Ryu',
         last_name: 'Cheng',
-        billing_email: 'Ryu.cheng@gmail.com',
+        billing_email: 'ryu@example.com',
         billing_address_1: '4532 tulip avenue',
         billing_address_2: '',
         billing_postcode: '94619',
@@ -994,7 +994,7 @@ describe('ImportOrdersComponent', () => {
   describe('Older Sheets Format (transaction ID / membership type headers)', () => {
     // Mock members matching the sample data External IDs
     const sheetsMembers: Member[] = [
-      { ...initMember(), memberId: 'US13', emails: ['yungbky@hotmail.com'], name: 'Bill Yung', lastRenewalDate: '', currentMembershipExpires: '' },
+      { ...initMember(), memberId: 'US13', emails: ['bill@example.com'], name: 'Bill Yung', lastRenewalDate: '', currentMembershipExpires: '' },
       { ...initMember(), memberId: 'US66', emails: ['hschneiker@hdslights.com'], name: 'Henry Schneiker', lastRenewalDate: '', currentMembershipExpires: '' },
       { ...initMember(), memberId: 'US80', emails: [], name: 'Dan Pasek' },
       { ...initMember(), memberId: 'AT1', emails: [], name: 'Miroslav Kovacik' },
@@ -1004,7 +1004,7 @@ describe('ImportOrdersComponent', () => {
     const sheetHeaders = ['Order', 'transaction ID', 'External ID', 'Student Of', 'membership type', 'New/Renew', 'Date Paid', 'Start Date', 'Last Name', 'First Name', 'email'];
 
     const sheetParsedRows: Record<string, string>[] = [
-      { 'Order': '', 'transaction ID': '2006016', 'External ID': 'US13', 'Student Of': '1', 'membership type': 'Member Dues - Life', 'New/Renew': '', 'Date Paid': '15-Jun-06', 'Start Date': '', 'Last Name': 'Yung', 'First Name': 'Bill', 'email': 'yungbky@hotmail.com' },
+      { 'Order': '', 'transaction ID': '2006016', 'External ID': 'US13', 'Student Of': '1', 'membership type': 'Member Dues - Life', 'New/Renew': '', 'Date Paid': '15-Jun-06', 'Start Date': '', 'Last Name': 'Yung', 'First Name': 'Bill', 'email': 'bill@example.com' },
       { 'Order': '', 'transaction ID': '2007099', 'External ID': 'US66', 'Student Of': '31', 'membership type': 'Member Dues - Life', 'New/Renew': '', 'Date Paid': '22-Apr-07', 'Start Date': '', 'Last Name': 'Schneiker', 'First Name': 'Henry', 'email': 'HSchneiker@hdslights.com' },
       { 'Order': '', 'transaction ID': '2007141', 'External ID': 'US80', 'Student Of': '1', 'membership type': 'Member Dues - Life', 'New/Renew': '', 'Date Paid': '7-Sep-07', 'Start Date': '', 'Last Name': 'Pasek', 'First Name': 'Dan', 'email': '' },
       { 'Order': '', 'transaction ID': '2008081', 'External ID': 'AT1', 'Student Of': '1', 'membership type': 'Member Dues - Life', 'New/Renew': '', 'Date Paid': '25-Jun-08', 'Start Date': '', 'Last Name': 'Kovacik', 'First Name': 'Miroslav', 'email': '' },
@@ -1047,7 +1047,7 @@ describe('ImportOrdersComponent', () => {
       expect(order.datePaid).toBe('2006-06-15');
       expect(order.lastName).toBe('Yung');
       expect(order.firstName).toBe('Bill');
-      expect(order.email).toBe('yungbky@hotmail.com');
+      expect(order.email).toBe('bill@example.com');
     });
 
     it('should handle rows without email and match by External ID', async () => {

--- a/src/app/login/login.spec.ts
+++ b/src/app/login/login.spec.ts
@@ -89,7 +89,7 @@ describe('LoginComponent', () => {
       isGoogleManaged: true,
     });
 
-    component.loginEmail.set('member@gmail.com');
+    component.loginEmail.set('member@example.com');
     await component.checkEmail();
 
     expect(component.loginStep()).toBe(LoginStep.GoogleSignin);
@@ -178,7 +178,7 @@ describe('LoginComponent', () => {
   it('should clear cache when goBackToEmail is called', async () => {
     // Set up a cache entry first.
     setCachedLoginInfo({
-      email: 'member@gmail.com',
+      email: 'member@example.com',
       isGoogleManaged: true,
       hasAuthAccount: true,
     });
@@ -198,7 +198,7 @@ describe('LoginComponent', () => {
   describe('with cached Google user', () => {
     beforeEach(async () => {
       setCachedLoginInfo({
-        email: 'member@gmail.com',
+        email: 'member@example.com',
         isGoogleManaged: true,
         hasAuthAccount: true,
       });
@@ -218,7 +218,7 @@ describe('LoginComponent', () => {
     });
 
     it('should pre-fill the email from cache', () => {
-      expect(component.loginEmail()).toBe('member@gmail.com');
+      expect(component.loginEmail()).toBe('member@example.com');
     });
 
     it('should set emailStatus from cache', () => {
@@ -329,12 +329,12 @@ describe('LoginComponent', () => {
       success: true,
       userCredential: {} as UserCredential,
     });
-    component.loginEmail.set('user@gmail.com');
+    component.loginEmail.set('user@example.com');
     await component.loginWithGoogle();
 
     const cached = getCachedLoginInfo();
     expect(cached).toEqual({
-      email: 'user@gmail.com',
+      email: 'user@example.com',
       isGoogleManaged: true,
       hasAuthAccount: true,
     });

--- a/src/app/member-gradings/member-gradings.html
+++ b/src/app/member-gradings/member-gradings.html
@@ -10,23 +10,43 @@
         <span class="label">Next Grading:</span>
         <span class="value">
           {{ nextGrading() }}
-          @if (nextGradingPurchased()) {
+          @if (openUnpaidGradingId()) {
+            <a [href]="openUnpaidGradingLink()" class="purchased-badge clickable-badge">
+              <app-icon name="arrow_forward" class="link-icon" /> Continue your request
+            </a>
+          } @else if (nextGradingPurchased()) {
             <a [href]="nextGradingLink()" class="purchased-badge clickable-badge">
               <app-icon name="check" /> Purchased
               <app-icon name="arrow_forward" class="link-icon" />
             </a>
-          } @else {
-            <a
-              href="https://www.iliqchuan.com/products/gradings"
-              target="_blank"
-              rel="noopener noreferrer"
+          } @else if (canRequestGrading()) {
+            <button
               class="subtle-button purchase-btn"
+              (click)="requestGrading()"
+              [disabled]="isRequesting()"
             >
-              <app-icon name="arrow_forward" /> Purchase
-            </a>
+              <app-icon name="arrow_forward" /> Request grading
+            </button>
+          } @else if (!isActiveMember()) {
+            <span class="needs-membership">
+              You must be an active member to grade.
+              <a
+                [href]="membershipLink"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="subtle-button purchase-btn"
+              >
+                <app-icon name="arrow_forward" /> Membership
+              </a>
+            </span>
           }
         </span>
       </div>
+      @if (requestError()) {
+        <div class="summary-item request-error">
+          <app-icon name="error" /> {{ requestError() }}
+        </div>
+      }
     }
   </div>
 

--- a/src/app/member-gradings/member-gradings.scss
+++ b/src/app/member-gradings/member-gradings.scss
@@ -42,6 +42,26 @@
   padding: 0.2em 0.6em;
 }
 
+// Inline "you must be an active member" prompt next to the next-grading level.
+.needs-membership {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  font-size: 0.7em;
+  font-weight: 500;
+  color: v.$text-secondary;
+}
+
+.request-error {
+  flex-direction: row;
+  align-items: center;
+  gap: 6px;
+  color: var(--error-color, #b3261e);
+  font-size: 0.85em;
+  font-weight: 500;
+}
+
 .purchased-badge {
   display: inline-flex;
   align-items: center;

--- a/src/app/member-gradings/member-gradings.ts
+++ b/src/app/member-gradings/member-gradings.ts
@@ -4,9 +4,11 @@ import { DataManagerService } from '../data-manager.service';
 import { FirebaseStateService } from '../firebase-state.service';
 import { GradingListComponent } from '../grading-list/grading-list';
 import { IconComponent } from '../icons/icon.component';
-import { nextGradingLevel, GradingStatus } from '../../../functions/src/data-model';
+import { nextGradingLevel, GradingStatus, ExpiryStatus, isGradingPaid } from '../../../functions/src/data-model';
+import { getMemberExpiryStatus } from '../member-tags';
 import { RoutingService } from '../routing.service';
 import { AppPathPatterns, Views } from '../app.config';
+import { environment } from '../../environments/environment';
 
 type GradingTab = 'examined' | 'students' | 'mine';
 const VALID_TABS: GradingTab[] = ['examined', 'students', 'mine'];
@@ -26,10 +28,69 @@ export class MemberGradingsComponent {
 
   user = this.firebaseStateService.user;
 
+  // Link to the membership product page, shown to non-active members.
+  membershipLink = environment.links.membership;
+
+  private today = computed(() => new Date().toISOString().split('T')[0]);
+
   isInstructor = computed(() => {
     const u = this.user();
     return !!(u && u.member.instructorId);
   });
+
+  // Whether the member's membership is currently active (required to grade).
+  isActiveMember = computed(() => {
+    const u = this.user();
+    if (!u) return false;
+    return getMemberExpiryStatus(u.member, this.today()) === ExpiryStatus.Valid;
+  });
+
+  // The docId of an existing open (unpaid, not-failed) grading the member can
+  // continue editing, or '' if none. A member may only have one at a time.
+  openUnpaidGradingId = computed(() => {
+    const grading = this.dataService.myGradings
+      .entries()
+      .find((g) => !isGradingPaid(g) && g.status !== GradingStatus.NotPassed);
+    return grading ? grading.docId : '';
+  });
+
+  // Link to continue an existing open grading request.
+  openUnpaidGradingLink = computed(() => {
+    const id = this.openUnpaidGradingId();
+    if (!id) return '';
+    return this.routingService.hrefForView(Views.GradingView, { gradingId: id });
+  });
+
+  // Whether the member can request a brand-new grading: active member, has a
+  // next level to grade, and doesn't already have an open request or a purchased
+  // grading for that level.
+  canRequestGrading = computed(
+    () =>
+      this.isActiveMember() &&
+      !!this.nextGrading() &&
+      !this.openUnpaidGradingId() &&
+      !this.nextGradingPurchased(),
+  );
+
+  isRequesting = signal(false);
+  requestError = signal<string>('');
+
+  async requestGrading() {
+    const u = this.user();
+    if (!u || this.isRequesting()) return;
+    this.isRequesting.set(true);
+    this.requestError.set('');
+    try {
+      const gradingId = await this.dataService.requestGrading(u.member.docId);
+      this.routingService.navigateTo(`gradings/${gradingId}`);
+    } catch (e: unknown) {
+      this.requestError.set(
+        e instanceof Error ? e.message : 'Could not request a grading. Please try again.',
+      );
+    } finally {
+      this.isRequesting.set(false);
+    }
+  }
 
   // Derive the active tab from the URL `tab` parameter.
   // Selects the correct view signals based on which grading route matched.

--- a/src/environments/environment.emulator.ts
+++ b/src/environments/environment.emulator.ts
@@ -39,5 +39,6 @@ export const environment = {
     membership: 'http://localhost:5000/membership',
     license: 'http://localhost:5000/license',
     videos: 'http://localhost:5000/videos',
+    grading: 'http://localhost:5000/grading',
   },
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -40,6 +40,7 @@ export const environment = {
   links: {
     membership: 'YOUR_MEMBERSHIP_PRODUCT_URL',
     license: 'YOUR_LICENSE_PRODUCT_URL',
-    videos: 'YOUR_VIDEOS_PRODUCT_URL'
+    videos: 'YOUR_VIDEOS_PRODUCT_URL',
+    grading: 'YOUR_GRADING_PRODUCT_URL'
   }
 };

--- a/tests/user-edit-permissions.spec.ts
+++ b/tests/user-edit-permissions.spec.ts
@@ -11,8 +11,8 @@ import { describe, it, beforeAll, afterAll, beforeEach } from 'vitest';
 /**
  * These tests reproduce the member-edit permissions scenario for two real users:
  *
- *   1. brett.drinkwater@iliqchuan.com — non-admin, no school, is owner of own member doc
- *   2. moilucasdixon@gmail.com        — non-admin, has school (not manager/owner), is owner of own member doc
+ *   1. brett@example.com — non-admin, no school, is owner of own member doc
+ *   2. member@example.com        — non-admin, has school (not manager/owner), is owner of own member doc
  *
  * Both should be able to update a specific subset of allowed fields on their own
  * member document (the owner-update rule). The data below is a snapshot pulled
@@ -31,7 +31,7 @@ const PROJECT_ID = 'ilc-user-edit-permissions';
 // ============================================================================
 
 const BRETT = {
-  email: 'brett.drinkwater@iliqchuan.com',
+  email: 'brett@example.com',
   acl: {
     memberDocIds: ['mSUDPNATSQa8uB55Oaq6'],
     isAdmin: false,
@@ -76,7 +76,7 @@ const BRETT = {
       primarySchoolDocId: '',
       primaryInstructorId: '105',
       primarySchoolId: '',
-      emails: ['awakenedmonki0@gmail.com', 'brett.drinkwater@iliqchuan.com'],
+      emails: ['brett.alt@example.com', 'brett@example.com'],
       lastUpdated: '2026-02-25T08:28:48.508Z',
       docId: 'mSUDPNATSQa8uB55Oaq6',
     },
@@ -84,7 +84,7 @@ const BRETT = {
 };
 
 const MOI = {
-  email: 'moilucasdixon@gmail.com',
+  email: 'member@example.com',
   acl: {
     isAdmin: false,
     memberDocIds: ['hUr2Qv3Q9hpx8KjlvkHy'],
@@ -114,7 +114,7 @@ const MOI = {
       classVideoLibrarySubscription: true,
       instructorId: 'foo-1',
       phone: '+33 648136124',
-      emails: ['moilucasdixon+test@gmail.com', 'moilucasdixon@gmail.com'],
+      emails: ['member+test@example.com', 'member@example.com'],
       country: 'United States',
       zipCode: '93500',
       gender: 'male',
@@ -123,7 +123,7 @@ const MOI = {
       name: 'moi ld',
       dateOfBirth: '2026-01-24',
       primaryInstructorId: '2',
-      publicEmail: 'moilucasdixon+test@gmail.com',
+      publicEmail: 'member+test@example.com',
       publicPhone: '+33 (0) 648136124',
       publicRegionOrCity: 'Pantin',
       publicCountyOrState: '',
@@ -149,7 +149,7 @@ const MOI = {
       schoolCountyOrState: 'Ile de France',
       schoolZipCode: '93500',
       schoolName: 'Zhong Xin Dao Paris',
-      ownerEmail: 'lucas.dixon@gmail.com',
+      ownerEmail: 'student@example.com',
       docId: '8JbQZ3KbNDQPfI5QpbC2',
       lastUpdated: '2026-02-25T00:48:46.732Z',
       schoolId: 'SCH-101',
@@ -220,8 +220,8 @@ describe('User Edit Permissions (Live Data Fixtures)', () => {
   // =====================================================================
   // Brett Drinkwater Tests
   // =====================================================================
-  describe('brett.drinkwater@iliqchuan.com (owner, non-admin, no school)', () => {
-    const email = 'brett.drinkwater@iliqchuan.com';
+  describe('brett@example.com (owner, non-admin, no school)', () => {
+    const email = 'brett@example.com';
     const memberDocId = 'mSUDPNATSQa8uB55Oaq6';
 
     function getDb() {
@@ -275,7 +275,7 @@ describe('User Edit Permissions (Live Data Fixtures)', () => {
       const db = getDb();
       await assertSucceeds(
         db.collection('members').doc(memberDocId).update({
-          emails: ['awakenedmonki0@gmail.com', 'brett.drinkwater@iliqchuan.com', 'new@email.com'],
+          emails: ['brett.alt@example.com', 'brett@example.com', 'new@example.com'],
           lastUpdated: serverTimestamp(),
         }),
       );
@@ -430,10 +430,10 @@ describe('User Edit Permissions (Live Data Fixtures)', () => {
   });
 
   // =====================================================================
-  // moilucasdixon@gmail.com Tests
+  // member@example.com Tests
   // =====================================================================
-  describe('moilucasdixon@gmail.com (owner, non-admin, has school but not manager)', () => {
-    const email = 'moilucasdixon@gmail.com';
+  describe('member@example.com (owner, non-admin, has school but not manager)', () => {
+    const email = 'member@example.com';
     const memberDocId = 'hUr2Qv3Q9hpx8KjlvkHy';
 
     function getDb() {
@@ -519,7 +519,7 @@ describe('User Edit Permissions (Live Data Fixtures)', () => {
   describe('Cross-user access', () => {
     it('brett should NOT be able to read moi member doc', async () => {
       const db = testEnv
-        .authenticatedContext('brett_uid', { email: 'brett.drinkwater@iliqchuan.com' })
+        .authenticatedContext('brett_uid', { email: 'brett@example.com' })
         .firestore();
       await assertFails(
         db.collection('members').doc('hUr2Qv3Q9hpx8KjlvkHy').get(),
@@ -528,7 +528,7 @@ describe('User Edit Permissions (Live Data Fixtures)', () => {
 
     it('moi should NOT be able to read brett member doc', async () => {
       const db = testEnv
-        .authenticatedContext('moi_uid', { email: 'moilucasdixon@gmail.com' })
+        .authenticatedContext('moi_uid', { email: 'member@example.com' })
         .firestore();
       await assertFails(
         db.collection('members').doc('mSUDPNATSQa8uB55Oaq6').get(),
@@ -537,7 +537,7 @@ describe('User Edit Permissions (Live Data Fixtures)', () => {
 
     it('brett should NOT be able to update moi member doc', async () => {
       const db = testEnv
-        .authenticatedContext('brett_uid', { email: 'brett.drinkwater@iliqchuan.com' })
+        .authenticatedContext('brett_uid', { email: 'brett@example.com' })
         .firestore();
       await assertFails(
         db.collection('members').doc('hUr2Qv3Q9hpx8KjlvkHy').update({


### PR DESCRIPTION
## Summary

Members can now **request their next grading before paying**. Previously a grading could only be created by an admin or by a Squarespace purchase, so members had to buy first.

- A **guarded callable** (`requestGrading`) creates a single **unpaid** request for the member's next level. It verifies the caller owns the member profile (via ACL), requires an **active membership**, computes the next level server-side, and enforces **one open unpaid request at a time**.
- When the matching Squarespace grading order is later processed, the existing unpaid request is **reused** (marked `Paid online`, order number recorded) instead of creating a duplicate.
- The student's level is still promoted **only once a grading is both paid and passed** (unchanged trigger logic).

## Changes

**Functions**
- New `functions/src/grading-request.ts` (`requestGrading` callable), exported from `index.ts`.
- `squarespace-orders/grading.ts`: reuse-on-purchase for a matching unpaid request.
- `common.ts`: shared `hasActiveMembership` + `getUserMemberDocIds`; `proposed-events.ts` reuses the membership check.
- Rename payment label `Paid (Squarespace)` → `Paid online`.

**UI**
- `member-gradings`: "Next Grading" row now drives the request flow — request / continue / purchased / needs-active-membership (with membership link).
- `grading-progress`: warning-box "Purchase grading" prompt for unpaid gradings, and the unpaid payment chip becomes a purchase button (app's normal button style).
- `grading-list`: "New Grading" button restricted to admins on Manage Gradings only.
- `grading-view`: back link + breadcrumb read "My Gradings" and route there when viewing your own grading.
- Added `links.grading` to environments.

## Testing

- Functions: `pnpm --prefix functions build` + `test` — 213 tests pass (new reuse-on-purchase and `hasActiveMembership` tests).
- App: `pnpm build` + `pnpm test:once` — 389 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)