### PR TITLE
fix(grading): always show event date separately above the event

### DIFF
--- a/src/app/grading-progress/grading-progress.html
+++ b/src/app/grading-progress/grading-progress.html
@@ -247,6 +247,14 @@
               </div>
             </div>
           } @else {
+            @if (g.gradingEventDate) {
+              <p class="detail-note">
+                Preferred date: {{ g.gradingEventDate }}
+                @if (canEditEvent()) {
+                  <button class="icon-only-button detail-edit-btn" (click)="isEditingEvent.set(true)" title="Edit event details"><app-icon name="edit"></app-icon></button>
+                }
+              </p>
+            }
             @if (g.gradingEvent) {
               <p class="detail-note">
                 Planned event:
@@ -255,14 +263,6 @@
                 } @else {
                   {{ g.gradingEvent }}
                 }
-                @if (canEditEvent()) {
-                  <button class="icon-only-button detail-edit-btn" (click)="isEditingEvent.set(true)" title="Edit event details"><app-icon name="edit"></app-icon></button>
-                }
-              </p>
-            }
-            @if (g.gradingEventDate && !eventLink()) {
-              <p class="detail-note">
-                Preferred date: {{ g.gradingEventDate }}
                 @if (canEditEvent()) {
                   <button class="icon-only-button detail-edit-btn" (click)="isEditingEvent.set(true)" title="Edit event details"><app-icon name="edit"></app-icon></button>
                 }
@@ -626,6 +626,14 @@
             </div>
           </div>
         } @else {
+          @if (g.gradingEventDate) {
+            <p class="detail-note">
+              Scheduled date: {{ g.gradingEventDate }}
+              @if (canEditEvent()) {
+                <button class="icon-only-button detail-edit-btn" (click)="isEditingEvent.set(true)" title="Edit event details"><app-icon name="edit"></app-icon></button>
+              }
+            </p>
+          }
           @if (g.gradingEvent) {
             <p class="detail-note">
               Event:
@@ -634,14 +642,6 @@
               } @else {
                 {{ g.gradingEvent }}
               }
-              @if (canEditEvent()) {
-                <button class="icon-only-button detail-edit-btn" (click)="isEditingEvent.set(true)" title="Edit event details"><app-icon name="edit"></app-icon></button>
-              }
-            </p>
-          }
-          @if (g.gradingEventDate && !eventLink()) {
-            <p class="detail-note">
-              Scheduled date: {{ g.gradingEventDate }}
               @if (canEditEvent()) {
                 <button class="icon-only-button detail-edit-btn" (click)="isEditingEvent.set(true)" title="Edit event details"><app-icon name="edit"></app-icon></button>
               }
@@ -691,13 +691,14 @@
                 <button class="subtle-button" (click)="cancelEventEdit()">Cancel</button>
               </div>
             } @else if (g.gradingEvent || g.gradingEventDate) {
+              @if (g.gradingEventDate) {
+                <span class="detail-value">{{ g.gradingEventDate }}</span>
+              }
               <span class="detail-value">
                 @if (eventLink()) {
                   <a class="event-link" [href]="eventLink()"><app-icon name="event" class="event-icon"></app-icon>{{ eventLinkLabel() }}</a>
                 } @else if (g.gradingEvent) {
-                  {{ g.gradingEvent }}@if (g.gradingEventDate) { ({{ g.gradingEventDate }}) }
-                } @else {
-                  {{ g.gradingEventDate }}
+                  {{ g.gradingEvent }}
                 }
                 <button class="icon-only-button detail-edit-btn" (click)="isEditingEvent.set(true)" title="Edit event details"><app-icon name="edit"></app-icon></button>
               </span>
@@ -930,6 +931,14 @@
             </div>
           </div>
         } @else {
+          @if (g.gradingEventDate) {
+            <p class="detail-note">
+              Date: {{ g.gradingEventDate }}
+              @if (canEditEvent()) {
+                <button class="icon-only-button detail-edit-btn" (click)="isEditingEvent.set(true)" title="Edit event details"><app-icon name="edit"></app-icon></button>
+              }
+            </p>
+          }
           @if (g.gradingEvent) {
             <p class="detail-note">
               Event:
@@ -938,14 +947,6 @@
               } @else {
                 {{ g.gradingEvent }}
               }
-              @if (canEditEvent()) {
-                <button class="icon-only-button detail-edit-btn" (click)="isEditingEvent.set(true)" title="Edit event details"><app-icon name="edit"></app-icon></button>
-              }
-            </p>
-          }
-          @if (g.gradingEventDate && !eventLink()) {
-            <p class="detail-note">
-              Date: {{ g.gradingEventDate }}
               @if (canEditEvent()) {
                 <button class="icon-only-button detail-edit-btn" (click)="isEditingEvent.set(true)" title="Edit event details"><app-icon name="edit"></app-icon></button>
               }
@@ -1050,7 +1051,7 @@
             </div>
           </div>
         } @else {
-          @if (g.gradingEventDate && !eventLink()) {
+          @if (g.gradingEventDate) {
             <span class="detail-label">Date</span>
             <span class="detail-value">
               {{ g.gradingEventDate }}

--- a/src/app/grading-progress/grading-progress.ts
+++ b/src/app/grading-progress/grading-progress.ts
@@ -313,15 +313,9 @@ export class GradingProgressComponent {
     return this.routingService.hrefForView(Views.EventView, { eventId: docId });
   });
 
-  // Label for the connected-event link. When a date is known we show
-  // "YYYY-MM-DD — Event" so the grading date travels with the event, matching
-  // how linked events are displayed in the grading event input.
-  eventLinkLabel = computed(() => {
-    const g = this.grading();
-    return g.gradingEventDate
-      ? `${g.gradingEventDate} — ${g.gradingEvent}`
-      : g.gradingEvent;
-  });
+  // Label for the connected-event link — just the event name. The grading date
+  // is shown on its own row above the event, so it isn't repeated here.
+  eventLinkLabel = computed(() => this.grading().gradingEvent);
 
   // --- Editable fields (local signals synced from grading input) ---
   protected editInstructorId = signal('');


### PR DESCRIPTION
## Summary
Makes the grading progression panel consistent: the event date is now always rendered as its own row **above** the event, in every state. Previously some states bundled the date with the event (`Event (date)` in the edit form, `YYYY-MM-DD — Event` in the linked-event label), while others showed it on a separate row below.

## Changes
- Reorder the Step 1 / Step 2 read-only views so the date row precedes the event row
- Unbundle the Step 2 edit-form value (date on its own line above the event)
- Drop the date prefix from `eventLinkLabel()` — the link now shows just the event name
- Show the date row even when the event is a linked calendar event (removed the `!eventLink()` guards that previously suppressed it)

The Step 3 completed-view grid already followed this pattern; the other states now match it.

## Testing
- `ng build ilc-members-manager` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)