### PR TITLE
Path-based routing + rich social previews for public event/instructor/school pages

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -9,7 +9,19 @@
     ],
     "rewrites": [
       {
-        "source": "/",
+        "source": "/events/*",
+        "function": "socialPreview"
+      },
+      {
+        "source": "/instructors/*",
+        "function": "socialPreview"
+      },
+      {
+        "source": "/school-profile/*",
+        "function": "socialPreview"
+      },
+      {
+        "source": "**",
         "destination": "/index.html"
       }
     ]

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -50,3 +50,5 @@ export { submitProposedEvent, onEventUpdated, onEventCreated, onEventDeleted } f
 
 export { listResources, deleteResource, getResourceDownloadUrl } from './resources';
 
+export { socialPreview } from './social-preview';
+

--- a/functions/src/social-preview.spec.ts
+++ b/functions/src/social-preview.spec.ts
@@ -1,0 +1,87 @@
+/* social-preview.spec.ts — tests for the social preview helpers. */
+import { describe, it, expect } from 'vitest';
+import { toPlainSummary, injectMeta, Preview } from './social-preview';
+
+describe('toPlainSummary', () => {
+  it('strips markdown and collapses whitespace', () => {
+    expect(toPlainSummary('# Heading\n\nSome **bold**   text.')).toBe(
+      'Heading Some bold text.',
+    );
+  });
+
+  it('strips HTML tags and decodes basic entities', () => {
+    expect(toPlainSummary('<p>Hello &amp; welcome</p>')).toBe('Hello & welcome');
+  });
+
+  it('keeps link text but drops the URL', () => {
+    expect(toPlainSummary('See [our site](https://example.com) now')).toBe(
+      'See our site now',
+    );
+  });
+
+  it('truncates to the max length with an ellipsis', () => {
+    const long = 'a'.repeat(300);
+    const out = toPlainSummary(long, 50);
+    expect(out.length).toBe(50);
+    expect(out.endsWith('…')).toBe(true);
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(toPlainSummary('')).toBe('');
+  });
+});
+
+describe('injectMeta', () => {
+  const shell =
+    '<!DOCTYPE html><html><head><title>I Liq Chuan Members Portal App</title></head><body><app-root></app-root></body></html>';
+  const preview: Preview = {
+    title: 'Spring Seminar',
+    description: 'A weekend of I Liq Chuan training.',
+    image: 'https://cdn.example.com/hero.jpg',
+  };
+
+  it('replaces the <title> with the page title and site name', () => {
+    const out = injectMeta(shell, preview, 'https://app.example.com/events/E1');
+    expect(out).toContain(
+      '<title>Spring Seminar | I Liq Chuan Members Portal</title>',
+    );
+    // The original generic title should be gone.
+    expect(out).not.toContain('<title>I Liq Chuan Members Portal App</title>');
+  });
+
+  it('injects Open Graph and Twitter tags before </head>', () => {
+    const out = injectMeta(shell, preview, 'https://app.example.com/events/E1');
+    expect(out).toContain(
+      '<meta property="og:title" content="Spring Seminar" />',
+    );
+    expect(out).toContain(
+      '<meta property="og:image" content="https://cdn.example.com/hero.jpg" />',
+    );
+    expect(out).toContain(
+      '<meta property="og:url" content="https://app.example.com/events/E1" />',
+    );
+    expect(out).toContain(
+      '<meta name="twitter:card" content="summary_large_image" />',
+    );
+    expect(out).toContain(
+      '<meta name="twitter:image" content="https://cdn.example.com/hero.jpg" />',
+    );
+    // Tags must be inside <head>.
+    expect(out.indexOf('og:title')).toBeLessThan(out.indexOf('</head>'));
+  });
+
+  it('omits image tags when there is no image', () => {
+    const out = injectMeta(shell, { ...preview, image: undefined }, 'https://x/e/1');
+    expect(out).not.toContain('og:image');
+    expect(out).not.toContain('twitter:image');
+  });
+
+  it('HTML-escapes tag content to avoid breaking out of attributes', () => {
+    const out = injectMeta(
+      shell,
+      { title: 'A "quoted" & <tag>', description: 'x' },
+      'https://x/e/1',
+    );
+    expect(out).toContain('content="A &quot;quoted&quot; &amp; &lt;tag&gt;"');
+  });
+});

--- a/functions/src/social-preview.ts
+++ b/functions/src/social-preview.ts
@@ -1,0 +1,206 @@
+/* social-preview.ts
+ *
+ * HTTP Cloud Function that serves the public detail pages — events, instructor
+ * profiles and school profiles — with per-item Open Graph / Twitter Card meta
+ * tags injected into the page <head>, so shared links unfurl with a rich
+ * preview (image, title, summary).
+ *
+ * WHY A FUNCTION: The app is a client-rendered SPA using path-based routing.
+ * Social crawlers don't run JavaScript, so they'd only see the static shell's
+ * generic tags. Firebase Hosting rewrites the three public detail routes to this
+ * function (see firebase.json), which fetches the document, injects the tags,
+ * and returns the same SPA shell — humans still get the full app, crawlers get
+ * the preview. Everything else is served statically / via the SPA fallback.
+ */
+import { onRequest } from 'firebase-functions/v2/https';
+import * as logger from 'firebase-functions/logger';
+import * as admin from 'firebase-admin';
+
+const SITE_NAME = 'I Liq Chuan Members Portal';
+
+export interface Preview {
+  title: string;
+  description: string;
+  image?: string;
+}
+
+// Per-instance cache of the SPA index.html shell, refreshed periodically so a
+// new deploy's hashed asset filenames are picked up without a cold start.
+let cachedIndexHtml: { html: string; fetchedAt: number } | null = null;
+const INDEX_CACHE_MS = 5 * 60 * 1000;
+
+async function getIndexHtml(host: string): Promise<string> {
+  const now = Date.now();
+  if (cachedIndexHtml && now - cachedIndexHtml.fetchedAt < INDEX_CACHE_MS) {
+    return cachedIndexHtml.html;
+  }
+  // index.html is a static asset (not rewritten to this function), so this
+  // returns the real SPA shell with no risk of recursion.
+  const res = await fetch(`https://${host}/index.html`);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch index.html: ${res.status}`);
+  }
+  const html = await res.text();
+  cachedIndexHtml = { html, fetchedAt: now };
+  return html;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/** Convert markdown/HTML/plain text into a truncated single-line summary. */
+export function toPlainSummary(text: string, maxLen = 200): string {
+  if (!text) return '';
+  let s = text
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ')
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/[#*_`>~]/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&(?:#39|apos);/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (s.length > maxLen) {
+    s = s.slice(0, maxLen - 1).trimEnd() + '…';
+  }
+  return s;
+}
+
+/** Fetch the first document in `collection` where `field` == `value`. */
+async function firstWhere(
+  collection: string,
+  field: string,
+  value: string,
+): Promise<admin.firestore.DocumentData | null> {
+  const snap = await admin
+    .firestore()
+    .collection(collection)
+    .where(field, '==', value)
+    .limit(1)
+    .get();
+  return snap.empty ? null : snap.docs[0].data();
+}
+
+/** Resolve a request path to a preview, or null if it's not a known detail page. */
+async function loadPreview(path: string): Promise<Preview | null> {
+  const parts = path.split('/').filter(Boolean);
+  const route = parts[0];
+  const id = decodeURIComponent(parts[1] ?? '');
+  if (!id) return null;
+
+  if (route === 'events') {
+    const db = admin.firestore();
+    const byId = await db.collection('events').doc(id).get();
+    const data = byId.exists ? byId.data() : await firstWhere('events', 'sourceId', id);
+    if (!data) return null;
+    return {
+      title: data.title ?? 'Event',
+      description: toPlainSummary(data.descriptionMarkdown || data.description || ''),
+      image: data.heroImageLargeUrl || data.heroImageUrl || undefined,
+    };
+  }
+
+  if (route === 'instructors') {
+    const data = await firstWhere('instructors', 'instructorId', id);
+    if (!data) return null;
+    const location = [data.publicRegionOrCity, data.country].filter(Boolean).join(', ');
+    const bio = toPlainSummary(data.publicBioMarkdown || '');
+    return {
+      title: `${data.name ?? id} — I Liq Chuan Instructor`,
+      description: bio || (location ? `I Liq Chuan instructor in ${location}.` : ''),
+      image: data.publicCoverImageUrl || data.publicProfileImageUrl || undefined,
+    };
+  }
+
+  if (route === 'school-profile') {
+    const data = await firstWhere('schools', 'schoolId', id);
+    if (!data) return null;
+    const location = [data.schoolCity, data.schoolCountry].filter(Boolean).join(', ');
+    const bio = toPlainSummary(data.publicBioMarkdown || '');
+    return {
+      title: `${data.schoolName || id} — I Liq Chuan School`,
+      description: bio || (location ? `I Liq Chuan school in ${location}.` : ''),
+      image: data.publicCoverImageUrl || data.publicProfileImageUrl || undefined,
+    };
+  }
+
+  return null;
+}
+
+/** Inject <title> + OG/Twitter meta tags for `preview` into the shell HTML. */
+export function injectMeta(html: string, preview: Preview, url: string): string {
+  const pageTitle = preview.title || SITE_NAME;
+  const fullTitle = preview.title ? `${preview.title} | ${SITE_NAME}` : SITE_NAME;
+  const description = preview.description;
+
+  const meta = (attr: 'name' | 'property', key: string, content: string) =>
+    `<meta ${attr}="${key}" content="${escapeHtml(content)}" />`;
+
+  const tags = [
+    meta('name', 'description', description),
+    meta('property', 'og:title', pageTitle),
+    meta('property', 'og:description', description),
+    meta('property', 'og:type', 'website'),
+    meta('property', 'og:site_name', SITE_NAME),
+    meta('property', 'og:url', url),
+    meta('name', 'twitter:card', 'summary_large_image'),
+    meta('name', 'twitter:title', pageTitle),
+    meta('name', 'twitter:description', description),
+  ];
+  if (preview.image) {
+    tags.push(meta('property', 'og:image', preview.image));
+    tags.push(meta('name', 'twitter:image', preview.image));
+  }
+
+  let out = html.replace(
+    /<title>[\s\S]*?<\/title>/,
+    `<title>${escapeHtml(fullTitle)}</title>`,
+  );
+  out = out.replace('</head>', `    ${tags.join('\n    ')}\n  </head>`);
+  return out;
+}
+
+export const socialPreview = onRequest(async (request, response) => {
+  const host =
+    request.get('x-forwarded-host') ||
+    request.get('host') ||
+    `${process.env.GCLOUD_PROJECT}.web.app`;
+  const path = request.path;
+  const canonicalUrl = `https://${host}${path}`;
+
+  let html: string;
+  try {
+    html = await getIndexHtml(host);
+  } catch (error) {
+    // If we can't get the shell we can't serve anything useful; let Hosting's
+    // normal SPA fallback take over by redirecting to the same path minus the
+    // rewrite (a plain redirect to index would drop the deep link, so 500).
+    logger.error('socialPreview: failed to load index.html', error);
+    response.status(500).send('Unable to load application shell.');
+    return;
+  }
+
+  try {
+    const preview = await loadPreview(path);
+    if (preview) {
+      html = injectMeta(html, preview, canonicalUrl);
+    }
+  } catch (error) {
+    // On any lookup failure, fall through and serve the unmodified shell so the
+    // SPA still loads for humans.
+    logger.error('socialPreview: failed to build preview', { path, error });
+  }
+
+  response.set('Content-Type', 'text/html; charset=utf-8');
+  response.set('Cache-Control', 'public, max-age=300, s-maxage=300');
+  response.status(200).send(html);
+});

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -195,7 +195,7 @@
             [collectionPath]="'members/' + user.member.docId + '/events'"
             [showBackButton]="true"
             backLabel="Back to Home"
-            backUrl="#/"
+            backUrl="/"
           ></app-event-list>
         }
         @case (Views.MySchools) {

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -67,6 +67,9 @@ describe('App', () => {
   it('should render title', async () => {
     const fixture = TestBed.createComponent(App);
     const app = fixture.componentInstance;
+    // Stub navigation so the logged-out Home redirect effect is a no-op and the
+    // view stays on Home (navigateTo now applies History changes synchronously).
+    vi.spyOn(app.routingService, 'navigateToParts').mockImplementation(() => {});
     app.routingService.matchedPatternId.set(Views.Home);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
@@ -93,7 +96,7 @@ describe('App', () => {
     const fixture = TestBed.createComponent(App);
     const app = fixture.componentInstance;
 
-    vi.spyOn(app.routingService, 'navigateToParts');
+    vi.spyOn(app.routingService, 'navigateToParts').mockImplementation(() => {});
 
     // Simulate being on the login page while logged in (no returnUrl set)
     firebaseStateServiceMock.loginStatus!.set(LoginStatus.SignedIn);

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -169,93 +169,93 @@ export class App {
   public breadcrumbs = computed<Breadcrumb[]>(() => {
     const baseBreadcrumbs: Breadcrumb[] = [
       { label: 'I Liq Chuan', shortLabel: 'ILC', url: 'https://iliqchuan.com' },
-      { label: 'Members Portal App', shortLabel: 'App', url: '#/' },
+      { label: 'Members Portal App', shortLabel: 'App', url: '/' },
     ];
     const view = this.currentView();
     if (view !== Views.Home && view) {
       if (view === Views.OrderView) {
-        baseBreadcrumbs.push({ label: 'Orders', url: '#/orders' });
+        baseBreadcrumbs.push({ label: 'Orders', url: '/orders' });
       } else if (view === Views.MembersAreaPost) {
-        baseBreadcrumbs.push({ label: 'Members Area', url: '#/members-area' });
+        baseBreadcrumbs.push({ label: 'Members Area', url: '/members-area' });
       } else if (view === Views.InstructorsAreaPost) {
-        baseBreadcrumbs.push({ label: 'Instructors Area', url: '#/instructors-area' });
+        baseBreadcrumbs.push({ label: 'Instructors Area', url: '/instructors-area' });
       } else if (view === Views.ManageMemberView) {
-        baseBreadcrumbs.push({ label: 'Manage Members', url: '#/members' });
+        baseBreadcrumbs.push({ label: 'Manage Members', url: '/members' });
       } else if (view === Views.SchoolMemberView) {
         const schoolId = this.routingService.signals[Views.SchoolMemberView].pathVars.schoolId();
-        baseBreadcrumbs.push({ label: `School ${schoolId} Members`, url: `#/school/${schoolId}/members` });
+        baseBreadcrumbs.push({ label: `School ${schoolId} Members`, url: `/school/${schoolId}/members` });
       } else if (view === Views.InstructorStudents || view === Views.InstructorStudentView) {
         const instructorId = view === Views.InstructorStudents
           ? this.routingService.signals[Views.InstructorStudents].pathVars.instructorId()
           : this.routingService.signals[Views.InstructorStudentView].pathVars.instructorId();
         const instructor = this.dataService.instructors.get(instructorId);
         if (!instructor) {
-          baseBreadcrumbs.push({ label: `Instructor Not Found (${instructorId})`, url: `#/instructor/${instructorId}/students` });
+          baseBreadcrumbs.push({ label: `Instructor Not Found (${instructorId})`, url: `/instructor/${instructorId}/students` });
           return baseBreadcrumbs;
         }
-        baseBreadcrumbs.push({ label: `Manage Members`, url: `#/members` });
-        baseBreadcrumbs.push({ label: `${instructor.name} [${instructorId}]`, url: `#/members/${instructor.memberId}` });
-        baseBreadcrumbs.push({ label: `Students of ${instructor.name} [${instructorId}]`, url: `#/instructor/${instructorId}/students` });
+        baseBreadcrumbs.push({ label: `Manage Members`, url: `/members` });
+        baseBreadcrumbs.push({ label: `${instructor.name} [${instructorId}]`, url: `/members/${instructor.memberId}` });
+        baseBreadcrumbs.push({ label: `Students of ${instructor.name} [${instructorId}]`, url: `/instructor/${instructorId}/students` });
         if (view === Views.InstructorStudentView) {
           const studentId = this.routingService.signals[Views.InstructorStudentView].pathVars.memberId();
           const student = this.dataService.getMember(studentId);
           if (!student) {
-            baseBreadcrumbs.push({ label: `Student Not Found (${studentId})`, url: `#/instructor/${instructorId}/students` });
+            baseBreadcrumbs.push({ label: `Student Not Found (${studentId})`, url: `/instructor/${instructorId}/students` });
             return baseBreadcrumbs;
           }
-          baseBreadcrumbs.push({ label: `${student.name} (${studentId})`, url: `#/instructor/${instructorId}/students` });
+          baseBreadcrumbs.push({ label: `${student.name} (${studentId})`, url: `/instructor/${instructorId}/students` });
         }
         return baseBreadcrumbs;
       } else if (view === Views.MyStudentView) {
-        baseBreadcrumbs.push({ label: 'My Students', url: '#/my-students' });
+        baseBreadcrumbs.push({ label: 'My Students', url: '/my-students' });
       } else if (view === Views.NewMember) {
         const basePath = this.routingService.signals[Views.NewMember].urlParams.basePath();
         if (basePath === 'members') {
-          baseBreadcrumbs.push({ label: 'Manage Members', url: '#/members' });
+          baseBreadcrumbs.push({ label: 'Manage Members', url: '/members' });
         } else if (basePath?.startsWith('school/')) {
-          baseBreadcrumbs.push({ label: 'School Members', url: `#/${basePath}` });
+          baseBreadcrumbs.push({ label: 'School Members', url: `/${basePath}` });
         } else if (basePath?.startsWith('instructor/')) {
-          baseBreadcrumbs.push({ label: 'Students', url: `#/${basePath}` });
+          baseBreadcrumbs.push({ label: 'Students', url: `/${basePath}` });
         } else if (basePath === 'my-students') {
-          baseBreadcrumbs.push({ label: 'My Students', url: '#/my-students' });
+          baseBreadcrumbs.push({ label: 'My Students', url: '/my-students' });
         }
       } else if (view === Views.ClassCalendarView) {
-        baseBreadcrumbs.push({ label: 'Find an Instructor', url: '#/find-an-instructor' });
+        baseBreadcrumbs.push({ label: 'Find an Instructor', url: '/find-an-instructor' });
       } else if (view === Views.SchoolCalendarView) {
-        baseBreadcrumbs.push({ label: 'Find a School', url: '#/find-school' });
+        baseBreadcrumbs.push({ label: 'Find a School', url: '/find-school' });
       } else if (view === Views.InstructorView) {
-        baseBreadcrumbs.push({ label: 'Find an Instructor', url: '#/find-an-instructor' });
+        baseBreadcrumbs.push({ label: 'Find an Instructor', url: '/find-an-instructor' });
       } else if (view === Views.SchoolView) {
-        baseBreadcrumbs.push({ label: 'Find a School', url: '#/find-school' });
+        baseBreadcrumbs.push({ label: 'Find a School', url: '/find-school' });
       } else if (view === Views.EventsCalendar) {
         // No parent breadcrumb needed for events
       } else if (view === Views.EventView) {
-        baseBreadcrumbs.push({ label: 'Events', url: '#/events' });
+        baseBreadcrumbs.push({ label: 'Events', url: '/events' });
       } else if (view === Views.MyEventView) {
-        baseBreadcrumbs.push({ label: 'My Events', url: '#/my-events' });
+        baseBreadcrumbs.push({ label: 'My Events', url: '/my-events' });
       } else if (view === Views.ManageEventView) {
-        baseBreadcrumbs.push({ label: 'Manage Events', url: '#/manage-events' });
+        baseBreadcrumbs.push({ label: 'Manage Events', url: '/manage-events' });
       } else if (view === Views.EventEdit || view === Views.ManageEventEdit) {
-        baseBreadcrumbs.push({ label: 'Manage Events', url: '#/manage-events' });
+        baseBreadcrumbs.push({ label: 'Manage Events', url: '/manage-events' });
       } else if (view === Views.MyEventEdit) {
-        baseBreadcrumbs.push({ label: 'My Events', url: '#/my-events' });
+        baseBreadcrumbs.push({ label: 'My Events', url: '/my-events' });
       } else if (view === Views.ProposeEvent) {
-        baseBreadcrumbs.push({ label: 'Events', url: '#/events' });
+        baseBreadcrumbs.push({ label: 'Events', url: '/events' });
       } else if (view === Views.ManageEvents) {
         // No parent breadcrumb needed for manage events
       } else if (view === Views.ManageSchoolEdit) {
-        baseBreadcrumbs.push({ label: 'Manage Schools', url: '#/schools' });
+        baseBreadcrumbs.push({ label: 'Manage Schools', url: '/schools' });
       } else if (view === Views.MySchoolEdit) {
-        baseBreadcrumbs.push({ label: 'My Schools', url: '#/my-schools' });
+        baseBreadcrumbs.push({ label: 'My Schools', url: '/my-schools' });
       } else if (view === Views.GradingView) {
         // The parent is "My Gradings" when this was opened from there (any tab,
         // tagged via the `from` param) or it's the viewer's own grading;
         // otherwise (an admin browsing the global list) it's "Manage Gradings".
         // Mirrors the back link in grading-view.
         if (this.gradingViewIsOwn() || this.gradingViewFromMyGradings()) {
-          baseBreadcrumbs.push({ label: 'My Gradings', url: '#/my-gradings' });
+          baseBreadcrumbs.push({ label: 'My Gradings', url: '/my-gradings' });
         } else {
-          baseBreadcrumbs.push({ label: 'Manage Gradings', url: '#/gradings' });
+          baseBreadcrumbs.push({ label: 'Manage Gradings', url: '/gradings' });
         }
       }
       const isEventView = view === Views.EventView || view === Views.MyEventView || view === Views.ManageEventView;

--- a/src/app/download-resource/download-resource.ts
+++ b/src/app/download-resource/download-resource.ts
@@ -2,7 +2,7 @@
  *
  * Standalone page for downloading a resource file. This provides stable,
  * shareable URLs in the form:
- *   #/resources/{accessLevel}/{fileName}
+ *   /resources/{accessLevel}/{fileName}
  *
  * The page checks the user's authentication and access tier, then calls
  * the getResourceDownloadUrl Cloud Function to obtain a signed download

--- a/src/app/events-calendar/event-item/event-item.ts
+++ b/src/app/events-calendar/event-item/event-item.ts
@@ -51,7 +51,7 @@ export class EventItemComponent {
     if (prefix) {
       return `${prefix}${encodeURIComponent(id)}`;
     }
-    return `#/instructors/${encodeURIComponent(id)}`;
+    return `/instructors/${encodeURIComponent(id)}`;
   });
 
   // Resolve the event owner (contact) to a display label.
@@ -77,7 +77,7 @@ export class EventItemComponent {
     if (prefix) {
       return `${prefix}${encodeURIComponent(owner.instructorId)}`;
     }
-    return `#/instructors/${encodeURIComponent(owner.instructorId)}`;
+    return `/instructors/${encodeURIComponent(owner.instructorId)}`;
   });
 
   readonly expandMoreName = 'expand_more' as const;

--- a/src/app/events-calendar/event-list/event-list.ts
+++ b/src/app/events-calendar/event-list/event-list.ts
@@ -161,7 +161,7 @@ export class EventListComponent implements OnDestroy {
   });
 
   // Link that clears the active filter (returns to the full events list).
-  protected clearFilterHref = '#/events';
+  protected clearFilterHref = '/events';
 
   // This signal is bound to the search input field and updates on every keystroke.
   // It is seeded from the URL `q` param (if present) or `initialQuery` (for the
@@ -190,7 +190,7 @@ export class EventListComponent implements OnDestroy {
 
   // Optional prefix for event detail links. When empty (default), the
   // component uses hash-based routes relative to the current page
-  // (e.g. '#/events/'). When set (e.g. 'https://app.iliqchuan.com/#/events/'),
+  // (e.g. '/events/'). When set (e.g. 'https://app.iliqchuan.com/events/'),
   // links point to an external domain — useful for the standalone WC.
   eventLinkPrefix = input<string>('');
 
@@ -204,7 +204,7 @@ export class EventListComponent implements OnDestroy {
   protected resolvedEventLinkPrefix = computed(() => {
     const explicit = this.eventLinkPrefix();
     if (explicit) return explicit;
-    return this.collectionPath() === 'events' ? '#/events/' : '#/my-events/';
+    return this.collectionPath() === 'events' ? '/events/' : '/my-events/';
   });
   // Determines if the current list is for the user's own events (non-public).
   protected isMyEvents = computed(() => this.collectionPath() !== 'events');

--- a/src/app/events-calendar/event-view/event-view.ts
+++ b/src/app/events-calendar/event-view/event-view.ts
@@ -60,7 +60,7 @@ export class EventViewComponent implements OnInit {
     const ev = this.event();
     const id = ev?.leadingInstructorId;
     if (!id) return '';
-    return `#/instructors/${encodeURIComponent(id)}`;
+    return `/instructors/${encodeURIComponent(id)}`;
   });
 
 

--- a/src/app/events-viewer/events-viewer.ts
+++ b/src/app/events-viewer/events-viewer.ts
@@ -7,7 +7,7 @@
  *
  * Attributes:
  *   event-link-prefix – Controls where event detail links point.
- *     When set (e.g. "https://app.iliqchuan.com/#/events/"), clicks
+ *     When set (e.g. "https://app.iliqchuan.com/events/"), clicks
  *     navigate to the main app. When empty, links are relative hash routes.
  *   initial-query – Optional initial search query to pre-populate the
  *     search field (e.g. "Seminar").
@@ -32,13 +32,13 @@ import { EventListComponent } from '../events-calendar/event-list/event-list';
 })
 export class EventsViewerComponent {
   // Base URL prefix for event detail links. Passed through to EventListComponent.
-  // Example: "https://app.iliqchuan.com/#/events/"
-  eventLinkPrefix = input<string>('https://app.iliqchuan.com/#/events/');
+  // Example: "https://app.iliqchuan.com/events/"
+  eventLinkPrefix = input<string>('https://app.iliqchuan.com/events/');
 
   // Base URL prefix for instructor profile links. Defaults to the main
   // app's Find an Instructor page so clicks navigate correctly from any host.
   instructorLinkPrefix = input<string>(
-    'https://app.iliqchuan.com/#/instructors/',
+    'https://app.iliqchuan.com/instructors/',
   );
 
   // Optional initial search query to pre-populate the search field.

--- a/src/app/find-school/find-school.html
+++ b/src/app/find-school/find-school.html
@@ -15,12 +15,12 @@
         @if (school.schoolId) {
           <span class="school-id-chip">{{ school.schoolId }}</span>
         }
-        <h3><a class="school-name-link" [href]="'#/school-profile/' + school.schoolId">{{ school.schoolName }}</a></h3>
+        <h3><a class="school-name-link" [href]="'/school-profile/' + school.schoolId">{{ school.schoolName }}</a></h3>
         <div class="school-header-details">
           @if (dataManager.instructors.get(school.ownerInstructorId); as owner) {
             <div class="header-detail">
               <app-icon name="person"></app-icon>
-              <a class="subtle-button" [href]="'#/instructors/' + school.ownerInstructorId">{{ owner.name }}</a>
+              <a class="subtle-button" [href]="'/instructors/' + school.ownerInstructorId">{{ owner.name }}</a>
             </div>
           }
           <div class="header-detail">
@@ -41,7 +41,7 @@
         @if (school.schoolClassGoogleCalendarId) {
         <div class="detail-row">
           <app-icon name="calendar_today"></app-icon>
-          <a class="subtle-button" [href]="'#/calendar/school/' + school.schoolId">Class Calendar</a>
+          <a class="subtle-button" [href]="'/calendar/school/' + school.schoolId">Class Calendar</a>
         </div>
         }
       </div>

--- a/src/app/grading-edit/grading-edit.html
+++ b/src/app/grading-edit/grading-edit.html
@@ -21,7 +21,7 @@
         @if (userIsAdmin()) {
           <input type="text" id="orderId" [formField]="form.orderId" />
           @if (e.orderId) {
-            <a class="icon-only-button" [href]="'#/order-view/' + e.orderId">
+            <a class="icon-only-button" [href]="'/order-view/' + e.orderId">
               <app-icon name="visibility"></app-icon>
             </a>
           }

--- a/src/app/grading-progress/grading-progress.html
+++ b/src/app/grading-progress/grading-progress.html
@@ -151,7 +151,7 @@
               <a
                 class="subtle-button"
                 [href]="
-                  '#/instructors/' + inst.instructorId
+                  '/instructors/' + inst.instructorId
                 "
                 style="
                   display: inline-flex;
@@ -210,7 +210,7 @@
                 <a
                   class="subtle-button"
                   [href]="
-                    '#/instructors/' + inst.instructorId
+                    '/instructors/' + inst.instructorId
                   "
                   style="
                     display: inline-flex;
@@ -487,7 +487,7 @@
                 <a
                   class="subtle-button"
                   [href]="
-                    '#/instructors/' + inst.instructorId
+                    '/instructors/' + inst.instructorId
                   "
                   style="
                     display: inline-flex;
@@ -575,7 +575,7 @@
               @if (gradingInstructor(); as inst) {
                 <a
                   class="instructor-link"
-                  [href]="'#/instructors/' + inst.instructorId"
+                  [href]="'/instructors/' + inst.instructorId"
                   ><app-icon name="person" class="person-icon"></app-icon>{{ inst.name }} [{{ inst.instructorId }}]</a
                 >
               } @else {
@@ -594,7 +594,7 @@
                   @if (manager.data) {
                     <a
                       class="instructor-link"
-                      [href]="'#/instructors/' + manager.data.instructorId"
+                      [href]="'/instructors/' + manager.data.instructorId"
                       ><app-icon name="person" class="person-icon"></app-icon>{{ manager.data.name }} [{{ manager.data.instructorId }}]</a
                     >
                   } @else {
@@ -870,7 +870,7 @@
               @if (gradingInstructor(); as inst) {
                 <a
                   class="instructor-link"
-                  [href]="'#/instructors/' + inst.instructorId"
+                  [href]="'/instructors/' + inst.instructorId"
                   ><app-icon name="person" class="person-icon"></app-icon>{{ inst.name }} [{{ inst.instructorId }}]</a
                 >
               } @else {
@@ -889,7 +889,7 @@
                   @if (manager.data) {
                     <a
                       class="instructor-link"
-                      [href]="'#/instructors/' + manager.data.instructorId"
+                      [href]="'/instructors/' + manager.data.instructorId"
                       ><app-icon name="person" class="person-icon"></app-icon>{{ manager.data.name }} [{{ manager.data.instructorId }}]</a
                     >
                   } @else {
@@ -1054,7 +1054,7 @@
           <span class="detail-label">Grading Instructor</span>
           <span class="detail-value">
             @if (gradingInstructor(); as inst) {
-              <a class="instructor-link" [href]="'#/instructors/' + inst.instructorId"
+              <a class="instructor-link" [href]="'/instructors/' + inst.instructorId"
                 ><app-icon name="person" class="person-icon"></app-icon>{{ inst.name }} [{{ inst.instructorId }}]</a>
             } @else {
               <strong>{{ gradingInstructorLabel() }}</strong>
@@ -1092,7 +1092,7 @@
             <span class="detail-value">
               @for (manager of completedManagers; track manager.id; let last = $last) {
                 @if (manager.data) {
-                  <a class="instructor-link" [href]="'#/instructors/' + manager.data.instructorId"
+                  <a class="instructor-link" [href]="'/instructors/' + manager.data.instructorId"
                     ><app-icon name="person" class="person-icon"></app-icon>{{ manager.data.name }} [{{ manager.data.instructorId }}]</a>
                 } @else {
                   <strong>{{ manager.id }}</strong>

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -45,6 +45,6 @@
   @if (isLoggedIn()) {
     <app-profile-menu></app-profile-menu>
   } @else if (isPublicPage()) {
-    <a class="nav-sign-in-link" [href]="'#/login?returnUrl=' + encodeCurrentUrl()">Sign In</a>
+    <a class="nav-sign-in-link" [href]="'/login?returnUrl=' + encodeCurrentUrl()">Sign In</a>
   }
 </div>

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -34,16 +34,13 @@ export class HeaderComponent {
   isPublicPage = input<boolean>(false);
   menuOpen = model<boolean>(false);
 
-  // Encodes the current hash-based URL (path + query params) for use as
-  // a returnUrl parameter on the login page.
+  // Encodes the current URL (path + query params, without the leading slash)
+  // for use as a returnUrl parameter on the login page.
   encodeCurrentUrl(): string {
-    let hash = window.location.hash;
-    if (hash.startsWith('#')) {
-      hash = hash.substring(1);
+    let path = window.location.pathname + window.location.search;
+    if (path.startsWith('/')) {
+      path = path.substring(1);
     }
-    if (hash.startsWith('/')) {
-      hash = hash.substring(1);
-    }
-    return encodeURIComponent(hash);
+    return encodeURIComponent(path);
   }
 }

--- a/src/app/instructor-card/instructor-card.html
+++ b/src/app/instructor-card/instructor-card.html
@@ -67,7 +67,7 @@
       </div>
     }
     @if (i.publicClassGoogleCalendarId) {
-      <a class="subtle-button" [href]="'#/calendar/instructor/' + i.instructorId">
+      <a class="subtle-button" [href]="'/calendar/instructor/' + i.instructorId">
         <app-icon name="calendar_today" width="14px" height="14px"></app-icon>
         Class Calendar
       </a>

--- a/src/app/instructor-card/instructor-card.spec.ts
+++ b/src/app/instructor-card/instructor-card.spec.ts
@@ -34,6 +34,6 @@ describe('InstructorCardComponent', () => {
 
   it('builds the profile href from the instructor id', () => {
     setInstructor({});
-    expect(component.profileHref()).toBe('#/instructors/I-101');
+    expect(component.profileHref()).toBe('/instructors/I-101');
   });
 });

--- a/src/app/instructor-card/instructor-card.ts
+++ b/src/app/instructor-card/instructor-card.ts
@@ -18,7 +18,7 @@ export class InstructorCardComponent {
   instructor = input.required<InstructorPublicData>();
 
   // Link to the instructor's dedicated public profile page (hash route).
-  profileHref = computed(() => `#/instructors/${this.instructor().instructorId}`);
+  profileHref = computed(() => `/instructors/${this.instructor().instructorId}`);
 
   ensureUrl(url: string | undefined): string {
     if (!url) {

--- a/src/app/instructor-selector/instructor-selector.html
+++ b/src/app/instructor-selector/instructor-selector.html
@@ -14,7 +14,7 @@
       <span>{{ inst.name }}</span>
       <a
         class="icon-only-button"
-        [href]="'#/instructors/' + inst.instructorId"
+        [href]="'/instructors/' + inst.instructorId"
       >
         <app-icon name="visibility"></app-icon>
       </a>

--- a/src/app/instructor-view/instructor-view.html
+++ b/src/app/instructor-view/instructor-view.html
@@ -71,7 +71,7 @@
         <a class="contact-link" [href]="'tel:' + i.publicPhone">{{ i.publicPhone }}</a>
       }
       @if (i.publicClassGoogleCalendarId) {
-        <a class="contact-link" [href]="'#/calendar/instructor/' + i.instructorId">
+        <a class="contact-link" [href]="'/calendar/instructor/' + i.instructorId">
           <app-icon name="calendar_today" width="16px" height="16px" /> Class Calendar
         </a>
       }

--- a/src/app/instructor-view/instructor-view.ts
+++ b/src/app/instructor-view/instructor-view.ts
@@ -71,7 +71,7 @@ export class InstructorViewComponent implements OnInit {
   allEventsHref = computed(() => {
     const i = this.instructor();
     if (!i) return '';
-    return `#/events?instructorId=${encodeURIComponent(i.instructorId)}`;
+    return `/events?instructorId=${encodeURIComponent(i.instructorId)}`;
   });
 
   // A short location summary line (region/city, county/state, country).

--- a/src/app/manage-events/manage-events.ts
+++ b/src/app/manage-events/manage-events.ts
@@ -314,12 +314,12 @@ export class ManageEventsComponent implements OnDestroy {
 
   editLink(event: IlcEvent): string {
     const id = event.docId || event.sourceId || '';
-    return `#/events/${id}/edit`;
+    return `/events/${id}/edit`;
   }
 
   viewLink(event: IlcEvent): string {
     const id = event.docId || event.sourceId || '';
-    return `#/manage-events/${id}`;
+    return `/manage-events/${id}`;
   }
 
   // Resolve the event owner to a "Name (MemberId)" chip label.

--- a/src/app/member-details/member-details.html
+++ b/src/app/member-details/member-details.html
@@ -32,8 +32,8 @@
         class="subtle-button"
         [href]="
           isOwnProfile()
-            ? '#/my-students'
-            : '#/instructor/' + e.instructorId + '/students'
+            ? '/my-students'
+            : '/instructor/' + e.instructorId + '/students'
         "
       >
         <app-icon name="salut" /> Students</a
@@ -105,7 +105,7 @@
                   track dup.docId;
                   let last = $last
                 ) {
-                  <a class="inline-link-button" href="#/members/{{ dup.docId }}"
+                  <a class="inline-link-button" href="/members/{{ dup.docId }}"
                     >{{ dup.name }} ({{ dup.memberId }})</a
                   >
                   @if (!last) {
@@ -538,8 +538,8 @@
               class="subtle-button"
               [href]="
                 isOwnProfile()
-                  ? '#/my-students'
-                  : '#/instructor/' + e.instructorId + '/students'
+                  ? '/my-students'
+                  : '/instructor/' + e.instructorId + '/students'
               "
             >
               <app-icon name="salut" /> View Students</a

--- a/src/app/member-list/member-list.ts
+++ b/src/app/member-list/member-list.ts
@@ -379,7 +379,7 @@ export class MemberListComponent {
       const hasDups = this.duplicateMemberIdEntries().some(m => m.memberId === member.memberId);
       const isMissing = !member.memberId;
       const idToRoute = (hasDups || isMissing) ? member.docId : member.memberId;
-      return `#/${base}/${idToRoute}`;
+      return `/${base}/${idToRoute}`;
     } else {
       console.warn('memberLink called but no basePath was provided to member-list component.');
       return null;

--- a/src/app/member-selector/member-selector.html
+++ b/src/app/member-selector/member-selector.html
@@ -14,7 +14,7 @@
       <span>{{ m.name }}</span>
       <a
         class="icon-only-button"
-        [href]="'#/members/' + (m.memberId || m.docId)"
+        [href]="'/members/' + (m.memberId || m.docId)"
       >
         <app-icon name="visibility"></app-icon>
       </a>

--- a/src/app/notification.service.spec.ts
+++ b/src/app/notification.service.spec.ts
@@ -227,7 +227,7 @@ describe('NotificationService', () => {
       expect(where).toHaveBeenCalledWith('id', '==', 'src-123');
       expect(result.resolved).toBe(false);
       expect(result.markdown).toBe(
-        'New Members post: [New Title](#/members-area/post/new-title)',
+        'New Members post: [New Title](/members-area/post/new-title)',
       );
     });
 
@@ -318,7 +318,7 @@ describe('NotificationService', () => {
 
       expect(updates).toHaveLength(1);
       expect(updates[0].patch['markdown']).toBe(
-        'New Members post: [New Title](#/members-area/post/new-title)',
+        'New Members post: [New Title](/members-area/post/new-title)',
       );
     });
 

--- a/src/app/notification.service.ts
+++ b/src/app/notification.service.ts
@@ -670,7 +670,7 @@ export class NotificationService implements OnDestroy {
     feed: { collection: string; label: string; route: string },
     post: CachedBlogPost,
   ): { markdown: string; data: NotificationBlogPostData } {
-    const link = `#/${feed.route}/${post.urlId}`;
+    const link = `/${feed.route}/${post.urlId}`;
     const publishedIso = new Date(post.publishOn || 0).toISOString();
     return {
       markdown: `New ${feed.label} post: [${post.title || 'Untitled'}](${link})`,
@@ -765,7 +765,7 @@ export class NotificationService implements OnDestroy {
       }
       const event = { ...initEvent(), ...(snap.data() as IlcEvent), docId: snap.id };
       const title = event.title || 'Untitled event';
-      const link = `#/manage-events/${event.docId}`;
+      const link = `/manage-events/${event.docId}`;
       if (event.status !== EventStatus.Proposed) {
         return {
           markdown: `Event [${title}](${link}) — ${eventStatusLabel(event.status).toLowerCase()}`,
@@ -784,7 +784,7 @@ export class NotificationService implements OnDestroy {
   // The markdown for a pending-event-approval notification, shared by the create
   // and reconcile passes.
   private pendingEventMarkdown(eventDocId: string, title: string): string {
-    return `Event awaiting approval: [${title}](#/manage-events/${eventDocId})`;
+    return `Event awaiting approval: [${title}](/manage-events/${eventDocId})`;
   }
 
   // ---------------------------------------------------------------------------
@@ -878,7 +878,7 @@ export class NotificationService implements OnDestroy {
       const status = order.ilcAppOrderStatus as OrderStatus;
       if (!NotificationService.ORDER_ATTENTION_STATUSES.includes(status)) {
         return {
-          markdown: `Order [#${this.orderRef(order)}](#/order-view/${order.docId}) — now resolved (${status})`,
+          markdown: `Order [#${this.orderRef(order)}](/order-view/${order.docId}) — now resolved (${status})`,
           data: this.orderIssueFields(order).data,
           resolved: true,
         };
@@ -899,7 +899,7 @@ export class NotificationService implements OnDestroy {
     const issues = order.ilcAppOrderIssues || [];
     const issuesSuffix = issues.length > 0 ? ` — ${issues.join('; ')}` : '';
     return {
-      markdown: `Order [#${orderRef}](#/order-view/${order.docId}) ${verb}${issuesSuffix}`,
+      markdown: `Order [#${orderRef}](/order-view/${order.docId}) ${verb}${issuesSuffix}`,
       data: { orderDocId: order.docId, orderRef, status, issues },
     };
   }
@@ -1016,7 +1016,7 @@ export class NotificationService implements OnDestroy {
   // The markdown for an unpaid-grading TODO notification, shared by the create and
   // reconcile passes. `forSelf` is true when the recipient is the student.
   private unpaidGradingMarkdown(g: Grading, forSelf: boolean): string {
-    const link = `#/gradings/${g.docId}`;
+    const link = `/gradings/${g.docId}`;
     return forSelf
       ? `⚠️ Your grading for **${g.level}** is complete but **not yet paid**. ` +
           `Please arrange payment so it can be finalised. [Open the grading](${link}).`

--- a/src/app/notifications-view/notifications-view.html
+++ b/src/app/notifications-view/notifications-view.html
@@ -25,7 +25,7 @@
           Mark all read
         </button>
       }
-      <a class="subtle-button" href="#/settings/notifications">
+      <a class="subtle-button" href="/settings/notifications">
         <app-icon name="settings" width="18px" height="18px"></app-icon>
         Notification Settings
       </a>

--- a/src/app/order-view/sheet-order-view/sheet-order-view.html
+++ b/src/app/order-view/sheet-order-view/sheet-order-view.html
@@ -11,7 +11,7 @@
     <div class="value">
       {{ order().externalId }}
       @if (order().externalId) {
-        <a class="icon-only-button" [href]="'#/members/' + order().externalId" title="View member profile">
+        <a class="icon-only-button" [href]="'/members/' + order().externalId" title="View member profile">
           <app-icon name="visibility"></app-icon>
         </a>
       }

--- a/src/app/order-view/squarespace-order-view/squarespace-order-view.html
+++ b/src/app/order-view/squarespace-order-view/squarespace-order-view.html
@@ -186,7 +186,7 @@
                     <td class="custom-value">
                       {{ custom.value }}
                       @if (custom.label?.toLowerCase()?.includes('member id') && custom.value?.trim()) {
-                        <a class="icon-only-button" [href]="'#/members/' + $any(custom.value).trim()" title="View member profile">
+                        <a class="icon-only-button" [href]="'/members/' + $any(custom.value).trim()" title="View member profile">
                           <app-icon name="visibility"></app-icon>
                         </a>
                       }
@@ -239,7 +239,7 @@
                 <div class="inferred-member-saved">
                   <app-icon name="info"></app-icon>
                   Saved: {{ item.ilcAppMemberIdInferred }}
-                  <a class="icon-only-button" [href]="'#/members/' + item.ilcAppMemberIdInferred" title="View member profile">
+                  <a class="icon-only-button" [href]="'/members/' + item.ilcAppMemberIdInferred" title="View member profile">
                     <app-icon name="visibility"></app-icon>
                   </a>
                 </div>

--- a/src/app/order-view/squarespace-order-view/squarespace-order-view.spec.ts
+++ b/src/app/order-view/squarespace-order-view/squarespace-order-view.spec.ts
@@ -124,7 +124,7 @@ describe('SquarespaceOrderView', () => {
     expect(preview!.entityFound).toBe(true);
     expect(preview!.entityName).toBe('Jane Doe');
     expect(preview!.entityKind).toBe('member');
-    expect(preview!.entityProfileLink).toBe('#/members/US123');
+    expect(preview!.entityProfileLink).toBe('/members/US123');
     // Preview dates based on order date 2026-03-01, 12 months.
     expect(preview!.renewalDate).toBe('2026-03-01');
     expect(preview!.expiryDate).toBe('2027-03-01');

--- a/src/app/order-view/squarespace-order-view/squarespace-order-view.ts
+++ b/src/app/order-view/squarespace-order-view/squarespace-order-view.ts
@@ -18,7 +18,7 @@ export interface ExpiryPreview {
   entityName: string; // The member name or school name, empty if not found.
   entityFound: boolean; // True if the entity was found in the database.
   entityKind: 'member' | 'school'; // What kind of entity this targets.
-  entityProfileLink: string; // Link to profile e.g. '#/members/US123', empty if N/A.
+  entityProfileLink: string; // Link to profile e.g. '/members/US123', empty if N/A.
   originalEntityId?: string;
   isOverridden?: boolean;
 }
@@ -177,7 +177,7 @@ export class SquarespaceOrderView {
           if (member) {
             entityName = member.name;
             entityFound = true;
-            entityProfileLink = '#/members/' + entityId;
+            entityProfileLink = '/members/' + entityId;
             // Read the current expiry for the relevant subscription type.
             if (config.label === 'Membership' || config.label === 'Life Membership') {
               currentExpiry = member.currentMembershipExpires || '';

--- a/src/app/profile-menu/profile-menu.html
+++ b/src/app/profile-menu/profile-menu.html
@@ -40,12 +40,12 @@
             </div>
           </div>
         }
-        <a href="#/notifications" class="menu-link" (click)="menuOpen.set(false)">
+        <a href="/notifications" class="menu-link" (click)="menuOpen.set(false)">
           <app-icon name="bullet_list" width="20px" height="20px"></app-icon>
           Notifications
         </a>
 
-        <a href="#/settings/notifications" class="menu-link" (click)="menuOpen.set(false)">
+        <a href="/settings/notifications" class="menu-link" (click)="menuOpen.set(false)">
           <app-icon name="info" width="20px" height="20px"></app-icon>
           Notification Settings
         </a>

--- a/src/app/routing.service.spec.ts
+++ b/src/app/routing.service.spec.ts
@@ -17,6 +17,17 @@ class TestRouterComponent {
   routingService = inject(RoutingService);
 }
 
+// The router binds to the HTML5 History API. Read the current location as the
+// app sees it (path + query, no origin), and simulate an external URL change
+// (e.g. back/forward or a typed URL) with replaceState + a popstate event.
+function currentUrl(): string {
+  return window.location.pathname + window.location.search;
+}
+function setUrl(url: string): void {
+  window.history.replaceState(null, '', url);
+  window.dispatchEvent(new PopStateEvent('popstate'));
+}
+
 describe('RoutingService', () => {
   let service: RoutingService<AppPathPatterns>;
   let fixture: ComponentFixture<TestRouterComponent>;
@@ -44,8 +55,8 @@ describe('RoutingService', () => {
   }
 
   beforeEach(() => {
-    // Reset window hash before each test
-    window.location.hash = '#/';
+    // Reset the URL to the root path before each test.
+    window.history.replaceState(null, '', '/');
   });
 
   it('should be created', async () => {
@@ -59,7 +70,7 @@ describe('RoutingService', () => {
     service.matchedPatternId.set(Views.SchoolMembers);
     service.signals[Views.SchoolMembers].pathVars['schoolId'].set('S1');
     await fixture.whenStable();
-    expect(window.location.hash).toBe(`#/school/S1/members`);
+    expect(currentUrl()).toBe(`/school/S1/members`);
   });
 
   it('should update the URL when a url param signal changes', async () => {
@@ -68,14 +79,13 @@ describe('RoutingService', () => {
     service.matchedPatternId.set(Views.ManageMembers);
     service.signals[Views.ManageMembers].urlParams['jumpTo'].set('456');
     await fixture.whenStable();
-    expect(window.location.hash).toBe(`#/members?jumpTo=456`);
+    expect(currentUrl()).toBe(`/members?jumpTo=456`);
   });
 
   it('should update signals from the URL', async () => {
     await configureTestBed(testConfig);
 
-    window.location.hash = `#members?jumpTo=789&q=`;
-    window.dispatchEvent(new HashChangeEvent('hashchange'));
+    setUrl(`/members?jumpTo=789&q=`);
     await fixture.whenStable();
     expect(service.signals[Views.ManageMembers].urlParams['jumpTo']()).toBe(
       '789',
@@ -91,14 +101,13 @@ describe('RoutingService', () => {
     service.matchedPatternId.set(Views.ManageMembers);
     // All URL params are at default values
     await fixture.whenStable();
-    expect(window.location.hash).toBe('#/members');
+    expect(currentUrl()).toBe('/members');
   });
 
   it('should update path var signals from the URL', async () => {
     await configureTestBed(testConfig);
 
-    window.location.hash = '#/school/S42/members';
-    window.dispatchEvent(new HashChangeEvent('hashchange'));
+    setUrl('/school/S42/members');
     await fixture.whenStable();
     expect(service.matchedPatternId()).toBe(Views.SchoolMembers);
     expect(service.signals[Views.SchoolMembers].pathVars['schoolId']()).toBe('S42');
@@ -107,8 +116,7 @@ describe('RoutingService', () => {
   it('should set matchedPatternId to null for unmatched URLs', async () => {
     await configureTestBed(testConfig);
 
-    window.location.hash = '#/this/path/does/not/exist';
-    window.dispatchEvent(new HashChangeEvent('hashchange'));
+    setUrl('/this/path/does/not/exist');
     await fixture.whenStable();
     expect(service.matchedPatternId()).toBeNull();
   });
@@ -117,10 +125,8 @@ describe('RoutingService', () => {
     await configureTestBed(testConfig);
 
     service.navigateTo('members?q=test');
-    // In jsdom, setting window.location.hash doesn't auto-fire hashchange
-    window.dispatchEvent(new HashChangeEvent('hashchange'));
     await fixture.whenStable();
-    expect(window.location.hash).toBe('#/members?q=test');
+    expect(currentUrl()).toBe('/members?q=test');
     expect(service.matchedPatternId()).toBe(Views.ManageMembers);
     expect(service.signals[Views.ManageMembers].urlParams['q']()).toBe('test');
   });
@@ -129,9 +135,8 @@ describe('RoutingService', () => {
     await configureTestBed(testConfig);
 
     service.navigateToParts(['school', 'S7', 'members']);
-    window.dispatchEvent(new HashChangeEvent('hashchange'));
     await fixture.whenStable();
-    expect(window.location.hash).toBe('#/school/S7/members');
+    expect(currentUrl()).toBe('/school/S7/members');
     expect(service.matchedPatternId()).toBe(Views.SchoolMembers);
     expect(service.signals[Views.SchoolMembers].pathVars['schoolId']()).toBe('S7');
   });
@@ -142,7 +147,7 @@ describe('RoutingService', () => {
     service.matchedPatternId.set(Views.ManageMembers);
     service.signals[Views.ManageMembers].urlParams['q'].set('hello');
     await fixture.whenStable();
-    expect(window.location.hash).toBe('#/members?q=hello');
+    expect(currentUrl()).toBe('/members?q=hello');
 
     service.signals[Views.ManageMembers].urlParams['q'].set('');
     // The signal should immediately reflect the cleared value
@@ -159,12 +164,12 @@ describe('RoutingService', () => {
     // 'asc' differs from the default 'desc', so it will appear in the URL
     service.signals[Views.ManageMembers].urlParams['sortDir'].set('asc');
     await fixture.whenStable();
-    const hash = window.location.hash;
+    const url = currentUrl();
     // All non-default params should be present
-    expect(hash).toContain('q=search');
-    expect(hash).toContain('jumpTo=M42');
-    expect(hash).toContain('sortBy=name');
-    expect(hash).toContain('sortDir=asc');
+    expect(url).toContain('q=search');
+    expect(url).toContain('jumpTo=M42');
+    expect(url).toContain('sortBy=name');
+    expect(url).toContain('sortDir=asc');
   });
 
   it('should encode special characters in path vars', async () => {
@@ -173,14 +178,13 @@ describe('RoutingService', () => {
     service.matchedPatternId.set(Views.ManageMemberView);
     service.signals[Views.ManageMemberView].pathVars['memberId'].set('Row 1561');
     await fixture.whenStable();
-    expect(window.location.hash).toBe('#/members/Row%201561');
+    expect(currentUrl()).toBe('/members/Row%201561');
   });
 
   it('should decode special characters in path vars from URL', async () => {
     await configureTestBed(testConfig);
 
-    window.location.hash = '#/members/Row%201561';
-    window.dispatchEvent(new HashChangeEvent('hashchange'));
+    setUrl('/members/Row%201561');
     await fixture.whenStable();
     expect(service.matchedPatternId()).toBe(Views.ManageMemberView);
     expect(service.signals[Views.ManageMemberView].pathVars['memberId']()).toBe('Row 1561');
@@ -195,8 +199,7 @@ describe('RoutingService', () => {
     await fixture.whenStable();
 
     // Navigate to same route without the param
-    window.location.hash = '#/members';
-    window.dispatchEvent(new HashChangeEvent('hashchange'));
+    setUrl('/members');
     await fixture.whenStable();
     expect(service.signals[Views.ManageMembers].urlParams['q']()).toBe('');
     // sortBy resets to its configured default, not empty string
@@ -216,8 +219,7 @@ describe('RoutingService', () => {
     await fixture.whenStable();
 
     // Navigate away to a member detail
-    window.location.hash = '#/members/M1';
-    window.dispatchEvent(new HashChangeEvent('hashchange'));
+    setUrl('/members/M1');
     await fixture.whenStable();
     expect(service.matchedPatternId()).toBe(Views.ManageMemberView);
 
@@ -241,8 +243,7 @@ describe('RoutingService', () => {
     await fixture.whenStable();
 
     // Navigate away
-    window.location.hash = '#/members/M1';
-    window.dispatchEvent(new HashChangeEvent('hashchange'));
+    setUrl('/members/M1');
     await fixture.whenStable();
 
     // Explicit q=new-search should NOT be overwritten by the old signal value
@@ -259,8 +260,7 @@ describe('RoutingService', () => {
     // sortBy left at default ('lastUpdated'), should not appear in URL
     await fixture.whenStable();
 
-    window.location.hash = '#/members/M1';
-    window.dispatchEvent(new HashChangeEvent('hashchange'));
+    setUrl('/members/M1');
     await fixture.whenStable();
 
     const resolved = service.resolveUrlWithParams('/members');
@@ -278,19 +278,19 @@ describe('RoutingService', () => {
 
   // ── hrefWithParams ──
 
-  it('hrefWithParams should return an href with # prefix and preserved params', async () => {
+  it('hrefWithParams should return an absolute path href with preserved params', async () => {
     await configureTestBed(testConfig);
 
     service.matchedPatternId.set(Views.ManageMembers);
     service.signals[Views.ManageMembers].urlParams['q'].set('test');
     await fixture.whenStable();
 
-    window.location.hash = '#/members/M1';
-    window.dispatchEvent(new HashChangeEvent('hashchange'));
+    setUrl('/members/M1');
     await fixture.whenStable();
 
     const href = service.hrefWithParams('/members');
-    expect(href).toMatch(/^#\//);
+    expect(href).toMatch(/^\//);
+    expect(href).not.toMatch(/^#/);
     expect(href).toContain('q=test');
   });
 
@@ -305,18 +305,16 @@ describe('RoutingService', () => {
     await fixture.whenStable();
 
     // Navigate away
-    window.location.hash = '#/members/M1';
-    window.dispatchEvent(new HashChangeEvent('hashchange'));
+    setUrl('/members/M1');
     await fixture.whenStable();
 
     // Navigate back without clearUrlParams (default = false)
     service.navigateTo('/members?jumpTo=M1');
-    window.dispatchEvent(new HashChangeEvent('hashchange'));
     await fixture.whenStable();
 
-    expect(window.location.hash).toContain('jumpTo=M1');
-    expect(window.location.hash).toContain('q=kept');
-    expect(window.location.hash).toContain('tag=active');
+    expect(currentUrl()).toContain('jumpTo=M1');
+    expect(currentUrl()).toContain('q=kept');
+    expect(currentUrl()).toContain('tag=active');
   });
 
   it('navigateTo with clearUrlParams should not preserve params', async () => {
@@ -327,17 +325,15 @@ describe('RoutingService', () => {
     await fixture.whenStable();
 
     // Navigate away
-    window.location.hash = '#/members/M1';
-    window.dispatchEvent(new HashChangeEvent('hashchange'));
+    setUrl('/members/M1');
     await fixture.whenStable();
 
     // Navigate back WITH clearUrlParams = true
     service.navigateTo('/members?jumpTo=M1', { clearUrlParams: true });
-    window.dispatchEvent(new HashChangeEvent('hashchange'));
     await fixture.whenStable();
 
-    expect(window.location.hash).toContain('jumpTo=M1');
-    expect(window.location.hash).not.toContain('q=should-be-gone');
+    expect(currentUrl()).toContain('jumpTo=M1');
+    expect(currentUrl()).not.toContain('q=should-be-gone');
   });
 
   it('navigateToParts should preserve params by default', async () => {
@@ -348,44 +344,42 @@ describe('RoutingService', () => {
     await fixture.whenStable();
 
     // Navigate away
-    window.location.hash = '#/members/M1';
-    window.dispatchEvent(new HashChangeEvent('hashchange'));
+    setUrl('/members/M1');
     await fixture.whenStable();
 
     // Navigate back
     service.navigateToParts(['/members']);
-    window.dispatchEvent(new HashChangeEvent('hashchange'));
     await fixture.whenStable();
 
-    expect(window.location.hash).toContain('sortBy=name');
+    expect(currentUrl()).toContain('sortBy=name');
   });
 
   // ── hrefForView ──
 
   it('hrefForView should return href for view without path vars', async () => {
     await configureTestBed(testConfig);
-    
+
     const href = service.hrefForView(Views.ManageMembers);
-    expect(href).toBe('#/members');
+    expect(href).toBe('/members');
   });
 
   it('hrefForView should return href for view with path vars', async () => {
     await configureTestBed(testConfig);
-    
+
     const href = service.hrefForView(Views.SchoolMembers, { schoolId: 'S123' });
-    expect(href).toBe('#/school/S123/members');
+    expect(href).toBe('/school/S123/members');
   });
 
   it('hrefForView should encode path variables', async () => {
     await configureTestBed(testConfig);
-    
+
     const href = service.hrefForView(Views.ManageMemberView, { memberId: 'John Doe' });
-    expect(href).toBe('#/members/John%20Doe');
+    expect(href).toBe('/members/John%20Doe');
   });
 
   it('hrefForView should throw if required path variable is missing', async () => {
     await configureTestBed(testConfig);
-    
+
     expect(() => {
       // Cast to any to bypass TypeScript safety checks for testing the runtime error
       (service as any).hrefForView(Views.SchoolMembers);

--- a/src/app/routing.service.ts
+++ b/src/app/routing.service.ts
@@ -16,9 +16,9 @@ Key Principles:
    seamlessly with Angular's `computed` and `effect` primitives and Zoneless Change Detection.
 
 4. Two-Way Synchronization: The service guarantees a bidirectional binding between the browser's
-   URL (using the hash fragment) and the internal Signal state. Mutating a routing Signal
-   automatically updates the browser URL, and navigation events instantly reflect back into the
-   Signals.
+   URL (using the HTML5 History API — path + query string) and the internal Signal state. Mutating
+   a routing Signal automatically updates the browser URL, and navigation events instantly reflect
+   back into the Signals.
 
 CRITICAL — Explicit Type Annotation Required:
 
@@ -73,7 +73,7 @@ export class ProfileComponent {
   }
 
   navigate(id: string) {
-    this.router.navigateToParts(['user', id]); // Updates hash, reflecting back into signals
+    this.router.navigateToParts(['user', id]); // Pushes a history entry, reflecting back into signals
   }
 }
 */
@@ -111,8 +111,8 @@ export type RoutingConfig<P extends PathPatterns> = {
   providedIn: 'root',
 })
 export class RoutingService<T extends PathPatterns> {
-  private urlHashPath: WritableSignal<string>;
-  private urlHashParams: WritableSignal<string>;
+  private currentPath: WritableSignal<string>;
+  private currentQuery: WritableSignal<string>;
   public matchedPatternId: WritableSignal<keyof T | null> = signal(null);
   public signals: {
     [pathId in keyof T]: PatternSignals<
@@ -129,8 +129,8 @@ export class RoutingService<T extends PathPatterns> {
   });
 
   constructor(@Inject(ROUTING_CONFIG) private config: RoutingConfig<T>) {
-    this.urlHashPath = signal('');
-    this.urlHashParams = signal('');
+    this.currentPath = signal('');
+    this.currentQuery = signal('');
 
     this.signals = {} as {
       [pathId in keyof T]: PatternSignals<
@@ -154,24 +154,42 @@ export class RoutingService<T extends PathPatterns> {
     // validatePaths(this.paths, this.pathParamSignals);
     // }
 
-    window.addEventListener('hashchange', () => this.handleUrlChange());
+    // Respond to back/forward navigation.
+    window.addEventListener('popstate', () => this.handleUrlChange());
+
+    // Seed the signals from the initial URL.
     this.handleUrlChange();
 
+    // Sync signal state back into the URL. This fires when a component mutates a
+    // URL-param signal (e.g. a search box); we use replaceState so those in-page
+    // updates don't spam the history stack. Genuine page navigations go through
+    // navigateTo() which pushes a new history entry.
     effect(() => {
+      // Only take over the URL when the current location actually matches one of
+      // our routes. This keeps the router inert when embedded as a web component
+      // on a host page whose path we don't own (so we never rewrite it).
+      if (this.matchedPatternId() === null) {
+        return;
+      }
       const path = this.constructPath();
       const query = this.constructQuery();
       const pathWithSlash = path.startsWith('/') ? path : `/${path}`;
-      const newHash = `${pathWithSlash}${query}`;
-      if (window.location.hash.substring(1) !== newHash) {
-        window.location.hash = newHash;
+      const newUrl = `${pathWithSlash}${query}`;
+      if (this.currentUrlPart() !== newUrl) {
+        window.history.replaceState(null, '', newUrl);
       }
     });
+  }
+
+  /** The current path + query as an absolute URL string, e.g. `/members?q=x`. */
+  private currentUrlPart(): string {
+    return `${window.location.pathname}${window.location.search}`;
   }
 
   private constructPath(): string {
     const patternId = this.matchedPatternId();
     if (!patternId) {
-      return this.urlHashPath();
+      return this.currentPath();
     }
     const parts = this.config.validPathPatterns[patternId].pathParts;
     const substParts = parts.map((part) => {
@@ -191,7 +209,7 @@ export class RoutingService<T extends PathPatterns> {
   private constructQuery(): string {
     const patternId = this.matchedPatternId();
     if (!patternId) {
-      return this.urlHashParams();
+      return this.currentQuery();
     }
     const patternSignals = this.signals[patternId];
     const defaults = patternSignals.urlParamDefaults;
@@ -215,11 +233,13 @@ export class RoutingService<T extends PathPatterns> {
   private previousPatternId: keyof T | null = null;
 
   private handleUrlChange() {
-    let hashlessUrlPart = window.location.hash.substring(1);
-    if (hashlessUrlPart.startsWith('/')) {
-      hashlessUrlPart = hashlessUrlPart.substring(1);
+    let path = window.location.pathname;
+    if (path.startsWith('/')) {
+      path = path.substring(1);
     }
-    const match = matchUrl(hashlessUrlPart, this.config.validPathPatterns);
+    // matchUrl expects the query string appended to the path (it splits on '?').
+    const urlPart = `${path}${window.location.search}`;
+    const match = matchUrl(urlPart, this.config.validPathPatterns);
     if (match) {
       const patternChanged = this.previousPatternId !== match.patternId;
       this.previousPatternId = match.patternId;
@@ -245,11 +265,11 @@ export class RoutingService<T extends PathPatterns> {
   navigateTo(pathAndParams: string, options?: { clearUrlParams?: boolean }) {
     const clearUrlParams = options?.clearUrlParams ?? false;
     const resolved = clearUrlParams ? pathAndParams : this.resolveUrlWithParams(pathAndParams);
-    if (resolved.startsWith('/')) {
-      window.location.hash = `#${resolved}`;
-    } else {
-      window.location.hash = `#/${resolved}`;
-    }
+    const url = resolved.startsWith('/') ? resolved : `/${resolved}`;
+    // pushState creates a new history entry but does not emit a popstate event,
+    // so we manually re-derive the signal state from the new URL.
+    window.history.pushState(null, '', url);
+    this.handleUrlChange();
   }
 
   /**
@@ -304,14 +324,14 @@ export class RoutingService<T extends PathPatterns> {
   }
 
   /**
-   * Generate an href string (with leading #) for an <a> link, preserving the
+   * Generate an absolute-path href string for an <a> link, preserving the
    * current URL param signal values for the target route pattern.
    *
    * Usage in templates: `<a [href]="routingService.hrefWithParams('/members')">`
    */
   hrefWithParams(basePath: string): string {
     const resolved = this.resolveUrlWithParams(basePath);
-    return `#${resolved.startsWith('/') ? resolved : '/' + resolved}`;
+    return resolved.startsWith('/') ? resolved : `/${resolved}`;
   }
 
   /**

--- a/src/app/school-edit/school-edit.html
+++ b/src/app/school-edit/school-edit.html
@@ -45,7 +45,7 @@
         @if (owner(); as o) {
           <div class="header-detail">
             <app-icon name="person"></app-icon>
-            <a class="subtle-button" [href]="'#/members/' + o.docId">{{ o.name }}</a>
+            <a class="subtle-button" [href]="'/members/' + o.docId">{{ o.name }}</a>
             @if (isOwnerLicenseExpired() !== ExpiryStatus.Valid) {
               <span class="identifier-chip" [class.expired-recent]="isOwnerLicenseExpired() === ExpiryStatus.Recent" [class.expired-old]="isOwnerLicenseExpired() === ExpiryStatus.Expired">
                 @if (isOwnerLicenseExpired() === ExpiryStatus.Recent) {
@@ -67,7 +67,7 @@
     <form (submit)="saveSchool($event)">
       <div class="form-section">
         @if (userIsAdmin() || userIsSchoolManager()) {
-          <a class="subtle-button" href="#/school/{{ s.schoolId }}/members" (click)="gotoMembers(); $event.preventDefault()">
+          <a class="subtle-button" href="/school/{{ s.schoolId }}/members" (click)="gotoMembers(); $event.preventDefault()">
             <app-icon name="salut" /> Students</a>
         }
         <h3>School Details</h3>

--- a/src/app/school-edit/school-edit.ts
+++ b/src/app/school-edit/school-edit.ts
@@ -397,9 +397,9 @@ export class SchoolEditComponent {
   backUrl = computed(() => {
     const match = this.routingService.matchedPatternId();
     if (match === Views.MySchoolEdit) {
-      return '#/my-schools';
+      return '/my-schools';
     }
-    return '#/schools';
+    return '/schools';
   });
 
   backLabel = computed(() => {

--- a/src/app/school-list/school-list.html
+++ b/src/app/school-list/school-list.html
@@ -93,7 +93,7 @@
                     <a
                       class="subtle-button"
                       [href]="
-                        '#/instructors/' +
+                        '/instructors/' +
                         school.ownerInstructorId
                       "
                       (click)="$event.stopPropagation()"
@@ -127,7 +127,7 @@
                 <app-icon name="calendar_today"></app-icon>
                 <a
                   class="subtle-button"
-                  [href]="'#/calendar/school/' + school.schoolId"
+                  [href]="'/calendar/school/' + school.schoolId"
                   (click)="$event.stopPropagation()"
                   >Class Calendar</a
                 >

--- a/src/app/school-list/school-list.spec.ts
+++ b/src/app/school-list/school-list.spec.ts
@@ -108,6 +108,6 @@ describe('SchoolListComponent', () => {
     school.docId = 'test-doc-id';
     school.schoolId = 'SCH-123';
     const link = component.editLink(school);
-    expect(link).toBe('#/schools/test-doc-id/edit');
+    expect(link).toBe('/schools/test-doc-id/edit');
   });
 });

--- a/src/app/school-list/school-list.ts
+++ b/src/app/school-list/school-list.ts
@@ -82,9 +82,9 @@ export class SchoolListComponent {
   editLink(school: School): string {
     const id = school.docId || school.schoolId;
     if (this.isMySchools()) {
-      return `#/my-schools/${encodeURIComponent(id)}/edit`;
+      return `/my-schools/${encodeURIComponent(id)}/edit`;
     }
-    return `#/schools/${encodeURIComponent(id)}/edit`;
+    return `/schools/${encodeURIComponent(id)}/edit`;
   }
 
 

--- a/src/app/school-view/school-view.html
+++ b/src/app/school-view/school-view.html
@@ -52,7 +52,7 @@
         </a>
       }
       @if (s.schoolClassGoogleCalendarId) {
-        <a class="contact-link" [href]="'#/calendar/school/' + s.schoolId">
+        <a class="contact-link" [href]="'/calendar/school/' + s.schoolId">
           <app-icon name="calendar_today" width="16px" height="16px" /> Class Calendar
         </a>
       }

--- a/src/app/school-view/school-view.spec.ts
+++ b/src/app/school-view/school-view.spec.ts
@@ -121,6 +121,6 @@ describe('SchoolViewComponent', () => {
     expect(component.upcomingEvents().length).toBe(1);
     expect(component.pastEvents().length).toBe(1);
     expect(component.pastEventsTotal()).toBe(7);
-    expect(component.allEventsHref()).toBe('#/events?schoolId=SCH-1');
+    expect(component.allEventsHref()).toBe('/events?schoolId=SCH-1');
   });
 });

--- a/src/app/school-view/school-view.ts
+++ b/src/app/school-view/school-view.ts
@@ -67,7 +67,7 @@ export class SchoolViewComponent implements OnInit {
   allEventsHref = computed(() => {
     const s = this.school();
     if (!s) return '';
-    return `#/events?schoolId=${encodeURIComponent(s.schoolId)}`;
+    return `/events?schoolId=${encodeURIComponent(s.schoolId)}`;
   });
 
   eventHref(ev: IlcEvent): string {

--- a/src/app/settings/notification-settings/notification-settings.component.html
+++ b/src/app/settings/notification-settings/notification-settings.component.html
@@ -8,7 +8,7 @@
         locally so you can personalize alerts on your phone, tablet, or desktop
         independently.
       </p>
-      <a href="#/notifications" class="view-notifications-link">
+      <a href="/notifications" class="view-notifications-link">
         <app-icon name="bullet_list" width="18px" height="18px"></app-icon>
         View all notifications
       </a>

--- a/src/app/settings/resources/resources.html
+++ b/src/app/settings/resources/resources.html
@@ -107,7 +107,7 @@
             <td class="file-info-cell">
               <div class="file-name-row">
                 <a class="inline-link-button file-name"
-                   [href]="'#/resources/' + resource.accessLevel + '/' + resource.name"
+                   [href]="'/resources/' + resource.accessLevel + '/' + resource.name"
                    [title]="'Download ' + resource.name"
                 >{{ resource.name }}</a>
                 @if (downloadingId() === resource.fullPath) {

--- a/src/app/settings/resources/resources.ts
+++ b/src/app/settings/resources/resources.ts
@@ -235,9 +235,9 @@ export class ResourcesComponent implements OnInit {
     }
   }
 
-  // Copies the stable download URL (#/resources/{level}/{name}) to the clipboard.
+  // Copies the stable download URL (/resources/{level}/{name}) to the clipboard.
   async copyDownloadLink(resource: ResourceFile) {
-    const url = `${window.location.origin}${window.location.pathname}#/resources/${resource.accessLevel}/${resource.name}`;
+    const url = `${window.location.origin}/resources/${resource.accessLevel}/${resource.name}`;
     try {
       await navigator.clipboard.writeText(url);
       this.statusMessage.set(`Copied download link for "${resource.name}" to clipboard.`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,5 +2,15 @@ import { bootstrapApplication } from '@angular/platform-browser';
 import { appConfig } from './app/app.config';
 import { App } from './app/app';
 
+// Legacy-link compatibility: the app used to use hash-based routing
+// (e.g. https://app.iliqchuan.com/#/events/E1). Now that we use path-based
+// routing, rewrite any incoming `#/...` URL to its path equivalent before the
+// app boots, so previously-shared links and bookmarks still resolve.
+const hash = window.location.hash;
+if (hash.startsWith('#/')) {
+  const target = hash.substring(1); // drop the leading '#', keep the leading '/'
+  window.history.replaceState(null, '', target);
+}
+
 bootstrapApplication(App, appConfig)
   .catch((err) => console.error(err));


### PR DESCRIPTION
## What & why

Shared links to public **event**, **instructor**, and **school** pages now unfurl with a rich preview (image, title, summary) on Facebook, WhatsApp, X, Slack, etc.

The blocker: social crawlers don't run JavaScript and don't send the URL fragment (`#…`) to the server. With the app's previous **hash-based routing** (`#/events/:id`), the server only ever saw `/`, so it could never expose per-item metadata to crawlers.

## Approach

1. **Hash → path routing.** The custom signal-based `RoutingService` now uses the HTML5 History API (`pushState`/`replaceState`/`popstate`) instead of `window.location.hash`. All ~100 in-app `#/…` links become `/…`. A tiny bootstrap shim in `main.ts` rewrites any incoming legacy `#/…` URL to its path equivalent, so previously-shared links and bookmarks keep working.

2. **`socialPreview` Cloud Function.** Firebase Hosting rewrites the three public detail routes (`/events/*`, `/instructors/*`, `/school-profile/*`) to a function that fetches the document, injects Open Graph / Twitter Card meta tags into the SPA shell, and returns it — humans still get the full app, crawlers get the preview. A `**` → `/index.html` rewrite serves the SPA for all other deep links (required now that routing is path-based).

### Why not full Angular SSR?
`@angular/ssr` is built around the Angular Router to decide which URLs are server-renderable. This app deliberately uses a bespoke signal-based router with no Angular Router / `<router-outlet>`, so full app SSR would mean adopting the Angular Router (risking conflicts with the custom router) plus per-template server-DOM fixes. A targeted per-route meta-injection function is simpler, lower-risk, and fits the existing `firebase deploy` pipeline — no custom server or App Hosting needed.

## Tests
- `RoutingService` spec rewritten for the History API (26 tests).
- New unit tests for the function's `toPlainSummary` + `injectMeta` helpers (9 tests).
- Updated specs that asserted old `#/` links.
- Full suites green: **app 389 passed**, **functions 222 passed**.

## Verification
- `pnpm build` + `pnpm build:functions` succeed.
- Hosting emulator: path-based deep links (`/members`, `/my-students/M1`) serve the SPA shell (200 + `<app-root>`).
- End-to-end preview rendering (function fetches live index.html + Firestore) is best verified post-deploy with the Facebook Sharing Debugger / X Card Validator, since the function fetches the deployed hosting `index.html`.

## Deploy notes
- `deploy:hosting` alone is no longer sufficient for previews — the `socialPreview` function must be deployed too (`pnpm deploy` / `deploy:functions`). The detail-route rewrites depend on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)