### PR TITLE
Invert grading event checkbox + origin-aware "Back to My Gradings"

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -126,7 +126,7 @@ export const initPathPatterns = {
   [Views.InstructorsArea]: pathPattern`instructors-area`,
   [Views.InstructorsAreaCategory]: pathPattern`instructors-area/category/${pv('category')}`,
   [Views.ManageGradings]: addUrlParams(pathPattern`gradings`, ['tab', 'event']),
-  [Views.GradingView]: pathPattern`gradings/${pv('gradingId')}`,
+  [Views.GradingView]: addUrlParams(pathPattern`gradings/${pv('gradingId')}`, ['from']),
   [Views.MemberGradings]: addUrlParams(pathPattern`my-gradings`, ['tab', 'event']),
   [Views.Settings]: addUrlParams(pathPattern`settings`, ['tab']),
   [Views.NotificationSettings]: pathPattern`settings/notifications`,

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -161,6 +161,11 @@ export class App {
     const profiles = this.firebaseService.user()?.memberProfiles ?? [];
     return profiles.some((p) => p.docId === grading.studentMemberDocId);
   });
+  // True when the grading detail was opened from the member-facing "My Gradings"
+  // page (any tab), tagged via the `from` URL param on the link.
+  public gradingViewFromMyGradings = computed(
+    () => this.routingService.signals[Views.GradingView].urlParams.from() === 'my-gradings',
+  );
   public breadcrumbs = computed<Breadcrumb[]>(() => {
     const baseBreadcrumbs: Breadcrumb[] = [
       { label: 'I Liq Chuan', shortLabel: 'ILC', url: 'https://iliqchuan.com' },
@@ -243,10 +248,11 @@ export class App {
       } else if (view === Views.MySchoolEdit) {
         baseBreadcrumbs.push({ label: 'My Schools', url: '#/my-schools' });
       } else if (view === Views.GradingView) {
-        // When viewing your own grading, the parent is "My Gradings"; otherwise
-        // (an admin viewing someone else's) it's "Manage Gradings". Mirrors the
-        // back link in grading-view.
-        if (this.gradingViewIsOwn()) {
+        // The parent is "My Gradings" when this was opened from there (any tab,
+        // tagged via the `from` param) or it's the viewer's own grading;
+        // otherwise (an admin browsing the global list) it's "Manage Gradings".
+        // Mirrors the back link in grading-view.
+        if (this.gradingViewIsOwn() || this.gradingViewFromMyGradings()) {
           baseBreadcrumbs.push({ label: 'My Gradings', url: '#/my-gradings' });
         } else {
           baseBreadcrumbs.push({ label: 'Manage Gradings', url: '#/gradings' });

--- a/src/app/grading-edit/grading-edit.ts
+++ b/src/app/grading-edit/grading-edit.ts
@@ -371,7 +371,7 @@ export class GradingEditComponent {
       this.asyncError.set(
         new Error(
           'The event isn\'t linked to a listed ILC event. Search and select it, ' +
-            'or tick "Grading was not at a listed workshop/event".',
+            'or untick "This grading was at a listed workshop/event".',
         ),
       );
       return;

--- a/src/app/grading-event-input/grading-event-input.html
+++ b/src/app/grading-event-input/grading-event-input.html
@@ -10,19 +10,20 @@
     />
   </div>
 
-  <!-- Single checkbox: was the grading at a listed workshop/event, or not? -->
+  <!-- Single checkbox: was the grading at a listed workshop/event? When ticked,
+       the event search below is shown. -->
   <div class="event-not-listed-row">
     <label class="checkbox-label">
       <input
         type="checkbox"
-        [checked]="notListed()"
-        (change)="setNotListed($any($event.target).checked)"
+        [checked]="atListedEvent()"
+        (change)="setAtListedEvent($any($event.target).checked)"
       />
-      Grading was not at a listed workshop/event
+      This grading was at a listed workshop/event
     </label>
   </div>
 
-  @if (!notListed()) {
+  @if (atListedEvent()) {
     <!-- ILC event search -->
     <div class="event-search-section">
       <label class="small-label">Grading happened at event:</label>
@@ -67,8 +68,8 @@
           <app-icon name="error" width="16" height="16" fill="#b06000"></app-icon>
           <span>
             “<strong>{{ editEvent() }}</strong>” isn't a linked ILC event. Search
-            and select the event above, or tick
-            <strong>“Grading was not at a listed workshop/event”</strong>.
+            and select the event above, or untick
+            <strong>“This grading was at a listed workshop/event”</strong>.
           </span>
         </p>
       }

--- a/src/app/grading-event-input/grading-event-input.ts
+++ b/src/app/grading-event-input/grading-event-input.ts
@@ -48,15 +48,16 @@ export class GradingEventInputComponent {
   editDate = linkedSignal(() => this.gradingEventDate());
   editDocId = linkedSignal(() => this.gradingEventDocId());
 
-  // Whether the grading was NOT at a listed workshop/event. When checked, only
-  // the date is recorded (no event name/link). Seeded from the incoming data —
-  // a linked event means it WAS at a listed event — then user-controlled via the
-  // checkbox and preserved across re-renders.
-  notListed = linkedSignal<{ docId: string }, boolean>({
+  // Whether the grading was at a listed workshop/event. When checked, the event
+  // search is shown so an event can be linked; otherwise only the date is
+  // recorded (no event name/link). Seeded from the incoming data — a linked
+  // event means it WAS at a listed event — then user-controlled via the checkbox
+  // and preserved across re-renders.
+  atListedEvent = linkedSignal<{ docId: string }, boolean>({
     source: () => ({ docId: this.gradingEventDocId() }),
     computation: (src, prev) => {
       if (prev) return prev.value;
-      return false;
+      return !!src.docId;
     },
   });
 
@@ -111,7 +112,7 @@ export class GradingEventInputComponent {
   // invalid, ambiguous state: the grading must either link a real event or be
   // marked as not-at-a-listed-event (date only). Parents disable saving while so.
   isUnlinkedText = computed(
-    () => !this.notListed() && !this.editDocId() && this.editEvent().trim() !== '',
+    () => this.atListedEvent() && !this.editDocId() && this.editEvent().trim() !== '',
   );
 
   linkedEventHref = computed(() => {
@@ -120,12 +121,12 @@ export class GradingEventInputComponent {
     return this.routingService.hrefForView(Views.EventView, { eventId: docId });
   });
 
-  // Toggle "not at a listed event". When checked, the grading is date-only:
-  // clear any event name/link and keep just the date. When unchecked, the event
-  // search reappears (the date is preserved either way).
-  setNotListed(checked: boolean) {
-    this.notListed.set(checked);
-    if (checked) {
+  // Toggle "at a listed event". When checked, the event search appears so an
+  // event can be linked. When unchecked, the grading is date-only: clear any
+  // event name/link and keep just the date (the date is preserved either way).
+  setAtListedEvent(checked: boolean) {
+    this.atListedEvent.set(checked);
+    if (!checked) {
       this.editEvent.set('');
       this.editDocId.set('');
       this.emit();

--- a/src/app/grading-list/grading-list.ts
+++ b/src/app/grading-list/grading-list.ts
@@ -476,8 +476,17 @@ export class GradingListComponent {
   }
 
   gradingLink(grading: Grading): string {
-    return this.routingService.hrefForView(Views.GradingView, {
+    const href = this.routingService.hrefForView(Views.GradingView, {
       gradingId: grading.docId,
     });
+    // Gradings opened from the member-facing "My Gradings" page (any of its
+    // tabs — viewMode 'member' or 'instructor') should navigate back to My
+    // Gradings, so tag the link with its origin. The admin "Manage Gradings"
+    // list (viewMode 'all') is left untagged and goes back there.
+    if (this.viewMode() === 'member' || this.viewMode() === 'instructor') {
+      const sep = href.includes('?') ? '&' : '?';
+      return `${href}${sep}from=my-gradings`;
+    }
+    return href;
   }
 }

--- a/src/app/grading-row-header/grading-row-header.html
+++ b/src/app/grading-row-header/grading-row-header.html
@@ -6,7 +6,10 @@
       [class.passed]="g.status === GradingStatus.Passed"
       [class.not-passed]="g.status === GradingStatus.NotPassed"
       [class.in-review]="g.status === GradingStatus.RequiresReview"
-      [class.pending]="g.status === GradingStatus.AwaitingRequest || g.status === GradingStatus.AwaitingAcceptance || g.status === GradingStatus.AwaitingGrading || g.status === GradingStatus.Declined"
+      [class.pending]="g.status === GradingStatus.Declined"
+      [class.awaiting-selection]="g.status === GradingStatus.AwaitingRequest"
+      [class.awaiting-acceptance]="g.status === GradingStatus.AwaitingAcceptance"
+      [class.awaiting-grading]="g.status === GradingStatus.AwaitingGrading"
       >{{ getPrettyGradingStatus(g.status) }}</span
     >
   }

--- a/src/app/grading-row-header/grading-row-header.scss
+++ b/src/app/grading-row-header/grading-row-header.scss
@@ -20,9 +20,28 @@
   flex-shrink: 0;
   white-space: nowrap;
 
+  // Declined by the instructor; student needs to re-select.
   &.pending {
     background-color: #fff3cd;
     color: #856404;
+  }
+
+  // Purchased; waiting on the student to select an instructor.
+  &.awaiting-selection {
+    background-color: #fde2c4;
+    color: #8a4b00;
+  }
+
+  // Student has requested; waiting on the instructor to accept/decline.
+  &.awaiting-acceptance {
+    background-color: #cfe2ff;
+    color: #084298;
+  }
+
+  // Instructor accepted; waiting on grading & instructor notes.
+  &.awaiting-grading {
+    background-color: #e7dbf5;
+    color: #5a2a86;
   }
 
   &.passed {

--- a/src/app/grading-view/grading-view.ts
+++ b/src/app/grading-view/grading-view.ts
@@ -79,15 +79,27 @@ export class GradingViewComponent {
     return user.memberProfiles.some((p) => p.docId === g.studentMemberDocId);
   });
 
-  protected backHref = computed(() => {
-    if (this.userIsAdmin() && !this.isOwnGrading()) {
-      return this.routingService.hrefForView(Views.ManageGradings);
-    }
-    return this.routingService.hrefForView(Views.MemberGradings);
-  });
+  // True when the grading was opened from the member-facing "My Gradings" page
+  // (any of its tabs), tagged via the `from` URL param on the link.
+  protected cameFromMyGradings = computed(
+    () => this.routingService.signals[Views.GradingView].urlParams.from() === 'my-gradings',
+  );
+
+  // Return to "My Gradings" when the viewer opened this from there or it's their
+  // own grading; otherwise (an admin browsing the global list) to "Manage
+  // Gradings".
+  protected returnsToMyGradings = computed(
+    () => this.cameFromMyGradings() || this.isOwnGrading() || !this.userIsAdmin(),
+  );
+
+  protected backHref = computed(() =>
+    this.returnsToMyGradings()
+      ? this.routingService.hrefForView(Views.MemberGradings)
+      : this.routingService.hrefForView(Views.ManageGradings),
+  );
 
   protected backLabel = computed(() =>
-    this.isOwnGrading() ? 'Back to My Gradings' : 'Back to Gradings',
+    this.returnsToMyGradings() ? 'Back to My Gradings' : 'Back to Gradings',
   );
 
   // Emit the title when the grading is loaded.

--- a/src/app/member-gradings/member-gradings.ts
+++ b/src/app/member-gradings/member-gradings.ts
@@ -58,7 +58,7 @@ export class MemberGradingsComponent {
   openUnpaidGradingLink = computed(() => {
     const id = this.openUnpaidGradingId();
     if (!id) return '';
-    return this.routingService.hrefForView(Views.GradingView, { gradingId: id });
+    return this.gradingLinkFromMyGradings(id);
   });
 
   // Whether the member can request a brand-new grading: active member, has a
@@ -82,7 +82,7 @@ export class MemberGradingsComponent {
     this.requestError.set('');
     try {
       const gradingId = await this.dataService.requestGrading(u.member.docId);
-      this.routingService.navigateTo(`gradings/${gradingId}`);
+      this.routingService.navigateTo(`gradings/${gradingId}?from=my-gradings`);
     } catch (e: unknown) {
       this.requestError.set(
         e instanceof Error ? e.message : 'Could not request a grading. Please try again.',
@@ -150,10 +150,16 @@ export class MemberGradingsComponent {
   nextGradingLink = computed(() => {
     const gradingId = this.nextGradingPurchasedId();
     if (!gradingId) return '';
-    return this.routingService.hrefForView(Views.GradingView, {
-      gradingId,
-    });
+    return this.gradingLinkFromMyGradings(gradingId);
   });
+
+  // Build a link to a grading detail tagged with its origin so the detail page's
+  // back link / breadcrumb return here to "My Gradings".
+  private gradingLinkFromMyGradings(gradingId: string): string {
+    const href = this.routingService.hrefForView(Views.GradingView, { gradingId });
+    const sep = href.includes('?') ? '&' : '?';
+    return `${href}${sep}from=my-gradings`;
+  }
 
 
   setActiveTab(tab: GradingTab) {


### PR DESCRIPTION
## Summary

Two grading UX changes (plus a status-badge colour refresh), based off `main`.

### 1. Invert the "listed event" checkbox in the grading event input
- Replaced the negative **"Grading was not at a listed workshop/event"** checkbox with a positive **"This grading was at a listed workshop/event"**.
- The event search UI is shown only when the box is **ticked**.
- The box defaults to **checked when an event is already linked**, and **unchecked** otherwise (so with no event selected, the search UI stays hidden until the user opts in).
- Updated the validation/warning copy in `grading-event-input` and `grading-edit` to match.

### 2. "Back to My Gradings" from all three My Gradings tabs
When a grading is opened from the member-facing **My Gradings** page (any of *My Gradings*, *My Students' Gradings*, *Examined/Managed*), the detail page's back button and breadcrumb now return to **My Gradings** (labelled "Back to My Gradings") instead of falling through to "Manage Gradings".

Implemented by tagging those links with a `from=my-gradings` URL param, which the grading-view back link and the app breadcrumb both honour. Admin links from the global "Manage Gradings" list are left untagged and still return there.

### 3. Status badge colours
Distinct colours for the awaiting-selection / awaiting-acceptance / awaiting-grading states (previously all shared the "pending" style).

## Testing
- `tsc --noEmit -p tsconfig.app.json` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)