### PR TITLE
chore(build): allow `extend` CommonJS dep to silence build warning

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -30,7 +30,7 @@
               "src/privacy.html"
             ],
             "styles": ["src/styles.scss"],
-            "allowedCommonJsDependencies": ["papaparse", "fast-deep-equal"]
+            "allowedCommonJsDependencies": ["papaparse", "fast-deep-equal", "extend"]
           },
           "configurations": {
             "production": {


### PR DESCRIPTION
## Summary

Silences the recurring esbuild warning seen on every build/deploy:

```
Module 'extend' used by 'unified@11.0.5/lib/index.js' is not ESM
CommonJS or AMD dependencies can cause optimization bailouts.
```

`extend` is a small (~44 KB) **transitive CommonJS** dependency pulled in by the milkdown markdown editor (`@milkdown/core` → `remark` → `unified` → `extend`). We don't import it directly and can't remove it without dropping milkdown.

Adds `extend` to `allowedCommonJsDependencies` on the main `ilc-members-manager` build target — the [Angular-recommended](https://angular.dev/tools/cli/build#configuring-commonjs-dependencies) way to acknowledge a known/acceptable CommonJS dep. No behavior or bundle change; it just stops the noise so genuinely new CommonJS warnings stay visible.

The web-component targets are untouched (they don't bundle milkdown/unified); `markdown-editor-wc` already allowlists its milkdown deps.

## Testing
- `pnpm run build` completes with the `extend` warning gone and no new warnings/errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)