### PR TITLE
Grading progress: fix silent save failures + rework date/event/notes UX

### DIFF
--- a/src/app/data-manager.service.ts
+++ b/src/app/data-manager.service.ts
@@ -1140,6 +1140,21 @@ export class DataManagerService {
     }
   }
 
+  /**
+   * Optimistically apply a saved grading to whichever local cache currently
+   * holds it, so a reactive view reflects the change immediately. The main
+   * `gradings` set (admins) updates live from its own snapshot, but the
+   * per-instructor `myGradingsAssessed` mirror only refreshes once the
+   * `onGradingUpdated` Cloud Function re-syncs it — so without this patch a
+   * grading manager's view would appear unchanged after saving. The next real
+   * snapshot reconciles any difference.
+   */
+  applyLocalGradingUpdate(grading: Grading): void {
+    for (const set of [this.gradings, this.myGradings, this.myGradingsAssessed]) {
+      if (set.get(grading.docId)) set.upsert(grading);
+    }
+  }
+
   async deleteGrading(id: string): Promise<void> {
     return deleteDoc(doc(this.db, 'gradings', id));
   }

--- a/src/app/grading-event-input/grading-event-input.ts
+++ b/src/app/grading-event-input/grading-event-input.ts
@@ -51,13 +51,15 @@ export class GradingEventInputComponent {
   // Whether the grading was at a listed workshop/event. When checked, the event
   // search is shown so an event can be linked; otherwise only the date is
   // recorded (no event name/link). Seeded from the incoming data — a linked
-  // event means it WAS at a listed event — then user-controlled via the checkbox
-  // and preserved across re-renders.
-  atListedEvent = linkedSignal<{ docId: string }, boolean>({
-    source: () => ({ docId: this.gradingEventDocId() }),
+  // event OR pre-existing free-text event info means it WAS at a listed event —
+  // then user-controlled via the checkbox and preserved across re-renders.
+  // Seeding checked for legacy free-text-without-link surfaces the search and
+  // the "isn't a linked ILC event" warning, so the user can link it or untick.
+  atListedEvent = linkedSignal<{ docId: string; event: string }, boolean>({
+    source: () => ({ docId: this.gradingEventDocId(), event: this.gradingEvent() }),
     computation: (src, prev) => {
       if (prev) return prev.value;
-      return !!src.docId;
+      return !!src.docId || src.event.trim() !== '';
     },
   });
 

--- a/src/app/grading-progress/grading-progress.html
+++ b/src/app/grading-progress/grading-progress.html
@@ -327,7 +327,7 @@
               ></textarea>
             </div>
 
-            <label class="align-top">Event (optional)</label>
+            <label class="align-first-row">Event</label>
             <div class="field">
               <app-grading-event-input
                 [gradingEvent]="editGradingEvent()"
@@ -356,7 +356,7 @@
               }
               <button
                 (click)="saveRequestFields()"
-                [disabled]="isSaving() || !editInstructorId() || requestBlockedByUnpaid() || eventInputInvalid()"
+                [disabled]="isSaving() || !editInstructorId() || requestBlockedByUnpaid() || eventBlocksSave()"
               >
                 Submit Request
               </button>
@@ -383,7 +383,7 @@
           <div class="action-buttons">
             <button
               (click)="acceptAndGradeMyself()"
-              [disabled]="isSaving() || !isNextGrading() || eventInputInvalid()"
+              [disabled]="isSaving() || !isNextGrading() || eventBlocksSave()"
             >
               Change to Accept
             </button>
@@ -403,7 +403,7 @@
 
           <!-- Instructor can optionally set event/date before accepting -->
           <div class="inline-form">
-            <label class="align-top">Event (optional)</label>
+            <label class="align-first-row">Event</label>
             <div class="field">
               <app-grading-event-input
                 [gradingEvent]="editGradingEvent()"
@@ -421,7 +421,7 @@
               <button
                 class="subtle-button"
                 (click)="saveEdits()"
-                [disabled]="isSaving() || eventInputInvalid()"
+                [disabled]="isSaving() || eventBlocksSave()"
               >
                 Save changes
               </button>
@@ -438,7 +438,7 @@
           <div class="action-buttons">
             <button
               (click)="acceptAndGradeMyself()"
-              [disabled]="isSaving() || isDirty() || !isNextGrading() || eventInputInvalid()"
+              [disabled]="isSaving() || isDirty() || !isNextGrading() || eventBlocksSave()"
               [title]="isDirty() ? 'Save or discard your changes first' : ''"
             >
               Accept
@@ -667,43 +667,23 @@
         </p>
 
         <div class="inline-form">
-          <label>Notes for the student (feedback)</label>
+          <!-- Unified date + event widget: the grading date is always shown on
+               top, with a "held at a listed workshop/event" checkbox below that
+               reveals the event search. A grading always needs a date, so we warn
+               and (via the buttons) block recording a result until it's set. -->
+          <label class="align-first-row">Event</label>
           <div class="field">
-            <textarea
-              [value]="editResultNotes()"
-              (input)="editResultNotes.set($any($event.target).value)"
-              placeholder="Feedback or comments for the student..."
-              rows="3"
-            ></textarea>
-          </div>
-
-          <label class="align-top">Event</label>
-          <div class="field">
-            @if (isEditingEvent()) {
-              <app-grading-event-input
-                [gradingEvent]="editGradingEvent()"
-                [gradingEventDate]="editGradingEventDate()"
-                [gradingEventDocId]="editGradingEventDocId()"
-                (gradingEventChange)="onEventInputChange($event)"
-              ></app-grading-event-input>
-              <div class="detail-edit-actions">
-                <button class="subtle-button" (click)="saveEventDetails()" [disabled]="eventInputInvalid()">Save</button>
-                <button class="subtle-button" (click)="cancelEventEdit()">Cancel</button>
-              </div>
-            } @else if (g.gradingEvent || g.gradingEventDate) {
-              @if (g.gradingEventDate) {
-                <span class="detail-value">{{ g.gradingEventDate }}</span>
-              }
-              <span class="detail-value">
-                @if (eventLink()) {
-                  <a class="event-link" [href]="eventLink()"><app-icon name="event" class="event-icon"></app-icon>{{ eventLinkLabel() }}</a>
-                } @else if (g.gradingEvent) {
-                  {{ g.gradingEvent }}
-                }
-                <button class="icon-only-button detail-edit-btn" (click)="isEditingEvent.set(true)" title="Edit event details"><app-icon name="edit"></app-icon></button>
-              </span>
-            } @else {
-              <button class="subtle-button detail-edit-btn" (click)="isEditingEvent.set(true)"><app-icon name="edit"></app-icon> Set event details</button>
+            <app-grading-event-input
+              [gradingEvent]="editGradingEvent()"
+              [gradingEventDate]="editGradingEventDate()"
+              [gradingEventDocId]="editGradingEventDocId()"
+              (gradingEventChange)="onEventInputChange($event)"
+            ></app-grading-event-input>
+            @if (gradingDateMissing()) {
+              <p class="field-warning">
+                <app-icon name="error" width="16" height="16" fill="#b06000"></app-icon>
+                A grading date is required before you can record a result.
+              </p>
             }
           </div>
 
@@ -781,6 +761,16 @@
             />
           </div>
 
+          <label>Notes for the student (feedback)</label>
+          <div class="field">
+            <textarea
+              [value]="editResultNotes()"
+              (input)="editResultNotes.set($any($event.target).value)"
+              placeholder="Feedback or comments for the student..."
+              rows="3"
+            ></textarea>
+          </div>
+
           <label class="align-top">Internal notes</label>
           <div class="field">
             <textarea
@@ -823,16 +813,16 @@
           <button
             class="pass-button"
             (click)="markResult(GradingStatus.Passed)"
-            [disabled]="isSaving() || isDirty() || eventInputInvalid()"
-            [title]="isDirty() ? 'Save or discard your changes first' : ''"
+            [disabled]="isSaving() || isDirty() || eventBlocksSave() || gradingDateMissing()"
+            [title]="isDirty() ? 'Save or discard your changes first' : (gradingDateMissing() ? 'Set the grading date first' : '')"
           >
             Mark as Passed
           </button>
           <button
             class="not-pass-button"
             (click)="markResult(GradingStatus.NotPassed)"
-            [disabled]="isSaving() || isDirty() || eventInputInvalid()"
-            [title]="isDirty() ? 'Save or discard your changes first' : ''"
+            [disabled]="isSaving() || isDirty() || eventBlocksSave() || gradingDateMissing()"
+            [title]="isDirty() ? 'Save or discard your changes first' : (gradingDateMissing() ? 'Set the grading date first' : '')"
           >
             Mark as Not Passed
           </button>
@@ -1005,33 +995,6 @@
           }
         }
       </p>
-      @if (isEditingResultNotes()) {
-        <div class="detail-inline-edit result-notes-edit">
-          <label>Notes for the student</label>
-          <textarea
-            [value]="editResultNotes()"
-            (input)="editResultNotes.set($any($event.target).value)"
-            rows="3"
-            placeholder="Feedback or comments for the student..."
-          ></textarea>
-          <div class="detail-edit-actions">
-            <button class="subtle-button" (click)="saveResultNotes()">Save</button>
-            <button class="subtle-button" (click)="cancelResultNotesEdit()">Cancel</button>
-          </div>
-        </div>
-      } @else if (g.resultNotes) {
-        <p class="detail-note result-detail">
-          <strong>Grading Instructor's notes:</strong> {{ g.resultNotes }}
-          @if (canEditGradingDetails()) {
-            <button class="icon-only-button detail-edit-btn" (click)="isEditingResultNotes.set(true)" title="Edit notes for the student"><app-icon name="edit"></app-icon></button>
-          }
-        </p>
-      } @else if (canEditGradingDetails()) {
-        <p class="detail-note">
-          <button class="subtle-button detail-edit-btn" (click)="isEditingResultNotes.set(true)"><app-icon name="edit"></app-icon> Add notes for the student</button>
-        </p>
-      }
-
       <div class="details-grid">
 
         <!-- Event / date -->
@@ -1051,36 +1014,23 @@
             </div>
           </div>
         } @else {
-          @if (g.gradingEventDate) {
-            <span class="detail-label">Date</span>
-            <span class="detail-value">
-              {{ g.gradingEventDate }}
-              @if (canEditEvent()) {
-                <button class="icon-only-button detail-edit-btn" (click)="isEditingEvent.set(true)" title="Edit event details"><app-icon name="edit"></app-icon></button>
-              }
-            </span>
-          }
-          @if (g.gradingEvent) {
-            <span class="detail-label">Event</span>
-            <span class="detail-value">
+          <!-- Single "Event" row: the grading date first ("Date of grading:"),
+               then the linked/free-text event if any — matching the inline event
+               widget's ordering used in the earlier stages. -->
+          <span class="detail-label">Event</span>
+          <span class="detail-value">
+            <span>Date of grading: {{ g.gradingEventDate || '—' }}</span>
+            @if (g.gradingEvent) {
               @if (eventLink()) {
                 <a class="event-link" [href]="eventLink()"><app-icon name="event" class="event-icon"></app-icon>{{ eventLinkLabel() }}</a>
               } @else {
-                {{ g.gradingEvent }}
+                <span>{{ g.gradingEvent }}</span>
               }
-              @if (canEditEvent()) {
-                <button class="icon-only-button detail-edit-btn" (click)="isEditingEvent.set(true)" title="Edit event details"><app-icon name="edit"></app-icon></button>
-              }
-            </span>
-          }
-          @if (canEditEvent() && !g.gradingEventDate && !g.gradingEvent) {
-            <span class="detail-label"></span>
-            <span class="detail-value">
-              <button class="subtle-button detail-edit-btn" (click)="isEditingEvent.set(true)">
-                <app-icon name="edit"></app-icon> Set event details
-              </button>
-            </span>
-          }
+            }
+            @if (canEditEvent()) {
+              <button class="icon-only-button detail-edit-btn" (click)="isEditingEvent.set(true)" title="Edit event details"><app-icon name="edit"></app-icon></button>
+            }
+          </span>
         }
 
         <!-- Grading instructor -->
@@ -1123,13 +1073,11 @@
               @for (mgr of editGradingManagerIds(); track $index; let last = $last) {
                 <div class="manager-row">
                   <app-instructor-selector [value]="mgr" (valueChange)="updateGradingManagerId($index, $event)"></app-instructor-selector>
-                  <button type="button" class="icon-only-button" (click)="removeGradingManager($index)"><app-icon name="close" width="16" height="16"></app-icon></button>
+                  <button type="button" class="icon-only-button" (click)="removeManagerInEditor($index)"><app-icon name="close" width="16" height="16"></app-icon></button>
                   @if (last) {
                     <button type="button" class="icon-only-button" (click)="addGradingManager()"><app-icon name="add" width="16" height="16"></app-icon></button>
                   }
                 </div>
-              } @empty {
-                <button type="button" class="icon-only-button" (click)="addGradingManager()"><app-icon name="add" width="16" height="16"></app-icon></button>
               }
               <div class="detail-edit-actions">
                 <button class="subtle-button" (click)="saveManagers()">Save</button>
@@ -1152,13 +1100,13 @@
                 @if (!last) { , }
               }
               @if (canEditGradingDetails()) {
-                <button class="icon-only-button detail-edit-btn" (click)="isEditingManagers.set(true)" title="Edit grading managers"><app-icon name="edit"></app-icon></button>
+                <button class="icon-only-button detail-edit-btn" (click)="openManagersEditor()" title="Edit grading managers"><app-icon name="edit"></app-icon></button>
               }
             </span>
           } @else if (canEditGradingDetails()) {
-            <span class="detail-label"></span>
+            <span class="detail-label is-empty">Managers</span>
             <span class="detail-value">
-              <button class="subtle-button detail-edit-btn" (click)="isEditingManagers.set(true)">
+              <button class="subtle-button detail-edit-btn" (click)="openManagersEditor()">
                 <app-icon name="edit"></app-icon> Add grading managers
               </button>
             </span>
@@ -1218,45 +1166,81 @@
           </span>
         }
 
-        <!-- Note from the student (their request note), under the other info.
-             Skipped entirely when empty. -->
+        <!-- Notes for the student (instructor feedback), under Payment and above
+             the internal notes. Shown as a normal detail row (label + value),
+             with a full-width editor when editing — consistent with the other
+             rows. -->
+        @if (isEditingResultNotes()) {
+          <div class="detail-edit-span">
+            <div class="detail-inline-edit result-notes-edit">
+              <label>Notes for the student</label>
+              <textarea
+                [value]="editResultNotes()"
+                (input)="editResultNotes.set($any($event.target).value)"
+                rows="3"
+                placeholder="Feedback or comments for the student..."
+              ></textarea>
+              <div class="detail-edit-actions">
+                <button class="subtle-button" (click)="saveResultNotes()">Save</button>
+                <button class="subtle-button" (click)="cancelResultNotesEdit()">Cancel</button>
+              </div>
+            </div>
+          </div>
+        } @else if (g.resultNotes) {
+          <span class="detail-label">Notes for student</span>
+          <span class="detail-value">
+            {{ g.resultNotes }}
+            @if (canEditGradingDetails()) {
+              <button class="icon-only-button detail-edit-btn" (click)="isEditingResultNotes.set(true)" title="Edit notes for the student"><app-icon name="edit"></app-icon></button>
+            }
+          </span>
+        } @else if (canEditGradingDetails()) {
+          <span class="detail-label is-empty">Notes for student</span>
+          <span class="detail-value">
+            <button class="subtle-button detail-edit-btn" (click)="isEditingResultNotes.set(true)"><app-icon name="edit"></app-icon> Add notes for the student</button>
+          </span>
+        }
+
+        <!-- Note from the student (their request note). Skipped when empty. -->
         @if (g.studentNotes) {
-          <p class="detail-note student-note-row">
-            <strong>Note from student:</strong> {{ g.studentNotes }}
-          </p>
+          <span class="detail-label">Note from student</span>
+          <span class="detail-value">{{ g.studentNotes }}</span>
+        }
+
+        <!-- Internal administrative notes — only for managers/instructors/admins;
+             never shown to the student. Same row style as the notes above. -->
+        @if (canEditGradingDetails()) {
+          @if (isEditingInternalNotes()) {
+            <div class="detail-edit-span">
+              <div class="detail-inline-edit result-notes-edit">
+                <label>Internal notes (not visible to the student)</label>
+                <textarea
+                  [value]="editInternalNotes()"
+                  (input)="editInternalNotes.set($any($event.target).value)"
+                  rows="3"
+                  placeholder="Notes for admins / grading managers only..."
+                ></textarea>
+                <div class="detail-edit-actions">
+                  <button class="subtle-button" (click)="saveInternalNotes()">Save</button>
+                  <button class="subtle-button" (click)="cancelInternalNotesEdit()">Cancel</button>
+                </div>
+              </div>
+            </div>
+          } @else if (g.notes) {
+            <span class="detail-label">Internal notes</span>
+            <span class="detail-value">
+              {{ g.notes }}
+              <button class="icon-only-button detail-edit-btn" (click)="isEditingInternalNotes.set(true)" title="Edit internal notes"><app-icon name="edit"></app-icon></button>
+            </span>
+          } @else {
+            <span class="detail-label is-empty">Internal notes</span>
+            <span class="detail-value">
+              <button class="subtle-button detail-edit-btn" (click)="isEditingInternalNotes.set(true)"><app-icon name="edit"></app-icon> Add internal notes</button>
+            </span>
+          }
         }
 
       </div>
-
-      <!-- Internal administrative notes — under the details table; only for
-           grading managers/instructors/admins; never shown to the student. -->
-      @if (canEditGradingDetails()) {
-        @if (isEditingInternalNotes()) {
-          <div class="detail-inline-edit result-notes-edit">
-            <label>Internal notes (not visible to the student)</label>
-            <textarea
-              [value]="editInternalNotes()"
-              (input)="editInternalNotes.set($any($event.target).value)"
-              rows="3"
-              placeholder="Notes for admins / grading managers only..."
-            ></textarea>
-            <div class="detail-edit-actions">
-              <button class="subtle-button" (click)="saveInternalNotes()">Save</button>
-              <button class="subtle-button" (click)="cancelInternalNotesEdit()">Cancel</button>
-            </div>
-          </div>
-        } @else if (g.notes) {
-          <p class="detail-note internal-note">
-            <app-icon name="admin" width="14" height="14"></app-icon>
-            <strong>Internal notes (not visible to the student):</strong> {{ g.notes }}
-            <button class="icon-only-button detail-edit-btn" (click)="isEditingInternalNotes.set(true)" title="Edit internal notes"><app-icon name="edit"></app-icon></button>
-          </p>
-        } @else {
-          <p class="detail-note">
-            <button class="subtle-button detail-edit-btn" (click)="isEditingInternalNotes.set(true)"><app-icon name="edit"></app-icon> Add internal notes</button>
-          </p>
-        }
-      }
     </div>
   }
 </div>

--- a/src/app/grading-progress/grading-progress.scss
+++ b/src/app/grading-progress/grading-progress.scss
@@ -289,7 +289,7 @@
 .details-grid {
   display: grid;
   grid-template-columns: auto 1fr;
-  gap: 0.35em 1em;
+  gap: 10px 1em;
   margin-top: 0.6em;
   align-items: baseline;
   font-size: 0.9em;
@@ -300,6 +300,13 @@
   white-space: nowrap;
   font-weight: 500;
   color: v.$text-secondary;
+
+  // Greyed-out key for a row whose value is empty — only shown to
+  // managers/admins (view-only users skip the row entirely).
+  &.is-empty {
+    font-weight: 400;
+    opacity: 0.55;
+  }
 }
 
 .detail-value {
@@ -380,7 +387,7 @@
 .inline-form {
   display: grid;
   grid-template-columns: auto 1fr;
-  gap: 8px 16px;
+  gap: 10px 16px;
   align-items: center;
   margin: 0.8em 0;
 
@@ -394,6 +401,16 @@
   .align-top {
     align-self: start;
     padding-top: 8px;
+  }
+
+  // For a field whose first row is the event input's "Date of grading" line
+  // (label + date input, vertically centred). Align this label's baseline to
+  // that first line rather than the very top of the multi-row field. The offset
+  // matches the date input's top padding (0.3em) + border (1px) so the two
+  // baselines line up and it scales with the font size.
+  .align-first-row {
+    align-self: start;
+    padding-top: calc(0.3em + 1px);
   }
 
   .field {

--- a/src/app/grading-progress/grading-progress.spec.ts
+++ b/src/app/grading-progress/grading-progress.spec.ts
@@ -461,4 +461,133 @@ describe('GradingProgressComponent', () => {
     expect(resolved[0]).toEqual({ id: 'manager-1', data: { name: 'Manager One', instructorId: 'manager-1' } });
     expect(resolved[1]).toEqual({ id: 'manager-2', data: null });
   });
+
+  // Regression: a pre-existing unlinked event (free-text `gradingEvent` with no
+  // linked `gradingEventDocId`, e.g. legacy data) must not silently block saving
+  // other fields such as grading managers. See grading ccN4T2XAgtxQ2HQQJjOf.
+  describe('unlinked-event save guard', () => {
+    beforeEach(() => {
+      const adminMember = { ...initMember(), docId: 'doc-admin', instructorId: '213' };
+      mockFirebaseState.user.set({
+        member: adminMember, memberProfiles: [adminMember], isAdmin: true,
+        schoolsManaged: [], firebaseUser: {} as never,
+      });
+      componentRef.setInput('grading', {
+        ...initGrading(),
+        docId: 'g1',
+        studentMemberDocId: 'doc-student-1',
+        status: GradingStatus.AwaitingGrading,
+        gradingInstructorId: '222',
+        gradingManagerIds: ['213', '197'],
+        gradingEvent: 'Alberto Benedusi private lesson',
+        gradingEventDocId: '',
+      });
+      fixture.detectChanges();
+    });
+
+    it('does not block a save when the unlinked event is left untouched', () => {
+      // The event itself is invalid...
+      expect(component.eventInputInvalid()).toBe(true);
+      // ...but it isn't being changed, so it must not block other edits.
+      expect(component.eventBlocksSave()).toBe(false);
+
+      const emitted: Partial<Grading>[] = [];
+      component.gradingUpdated.subscribe((u) => emitted.push(u));
+      component.removeGradingManager(0); // remove self ('213')
+      component.saveEdits();
+
+      expect(emitted.length).toBe(1);
+      expect(emitted[0].gradingManagerIds).toEqual(['197']);
+    });
+
+    it('blocks the save when the event is edited into an unlinked state', () => {
+      component['editGradingEvent'].set('Some new unlinked event');
+      component['editGradingEventDocId'].set('');
+      expect(component.eventBlocksSave()).toBe(true);
+    });
+  });
+
+  // A grading always needs a date; the result buttons are gated on it.
+  describe('grading date requirement', () => {
+    beforeEach(() => {
+      const instr = { ...initMember(), docId: 'doc-instr', instructorId: '222' };
+      mockFirebaseState.user.set({
+        member: instr, memberProfiles: [instr], isAdmin: false,
+        schoolsManaged: [], firebaseUser: {} as never,
+      });
+      componentRef.setInput('grading', {
+        ...initGrading(),
+        docId: 'g1',
+        studentMemberDocId: 'doc-student-1',
+        status: GradingStatus.AwaitingGrading,
+        gradingInstructorId: '222',
+        gradingEvent: '',
+        gradingEventDate: '',
+        gradingEventDocId: '',
+      });
+      fixture.detectChanges();
+    });
+
+    it('flags a missing date and refuses to record a result', () => {
+      expect(component.gradingDateMissing()).toBe(true);
+      const emitted: Partial<Grading>[] = [];
+      component.gradingUpdated.subscribe((u) => emitted.push(u));
+      component.markResult(GradingStatus.Passed);
+      expect(emitted.length).toBe(0);
+    });
+
+    it('records the result once a date is set', () => {
+      component['editGradingEventDate'].set('2026-07-04');
+      expect(component.gradingDateMissing()).toBe(false);
+      const emitted: Partial<Grading>[] = [];
+      component.gradingUpdated.subscribe((u) => emitted.push(u));
+      component.markResult(GradingStatus.Passed);
+      expect(emitted.length).toBe(1);
+      expect(emitted[0].status).toBe(GradingStatus.Passed);
+      expect(emitted[0].gradingEventDate).toBe('2026-07-04');
+    });
+  });
+
+  describe('grading managers editor', () => {
+    function setGrading(managerIds: string[]) {
+      componentRef.setInput('grading', {
+        ...initGrading(),
+        docId: 'g1',
+        studentMemberDocId: 'doc-student-1',
+        status: GradingStatus.Passed,
+        gradingManagerIds: managerIds,
+      });
+      fixture.detectChanges();
+    }
+
+    it('opens with one empty row when there are no managers', () => {
+      setGrading([]);
+      component.openManagersEditor();
+      expect(component['isEditingManagers']()).toBe(true);
+      expect(component['editGradingManagerIds']()).toEqual(['']);
+    });
+
+    it('opens without adding a row when managers already exist', () => {
+      setGrading(['213']);
+      component.openManagersEditor();
+      expect(component['isEditingManagers']()).toBe(true);
+      expect(component['editGradingManagerIds']()).toEqual(['213']);
+    });
+
+    it('removing the sole added row closes the editor (add mode)', () => {
+      setGrading([]);
+      component.openManagersEditor();
+      component.removeManagerInEditor(0);
+      expect(component['isEditingManagers']()).toBe(false);
+      expect(component['editGradingManagerIds']()).toEqual([]);
+    });
+
+    it('keeps the editor open when clearing pre-existing managers', () => {
+      setGrading(['213']);
+      component.openManagersEditor();
+      component.removeManagerInEditor(0);
+      expect(component['isEditingManagers']()).toBe(true);
+      expect(component['editGradingManagerIds']()).toEqual([]);
+    });
+  });
 });

--- a/src/app/grading-progress/grading-progress.ts
+++ b/src/app/grading-progress/grading-progress.ts
@@ -406,6 +406,31 @@ export class GradingProgressComponent {
     () => this.editGradingEvent().trim() !== '' && !this.editGradingEventDocId(),
   );
 
+  // Whether the event fields have been changed from the saved grading.
+  private eventDirty = computed(() => {
+    const g = this.grading();
+    return (
+      this.editGradingEvent() !== g.gradingEvent ||
+      this.editGradingEventDate() !== g.gradingEventDate ||
+      this.editGradingEventDocId() !== g.gradingEventDocId
+    );
+  });
+
+  // Whether an invalid event should block a save. Only blocks when the user is
+  // actually setting/changing the event into the ambiguous "free text, not
+  // linked" state. A pre-existing unlinked event (legacy data from before event
+  // linking) that the user isn't touching must NOT block saving other fields
+  // such as grading managers — otherwise those edits silently fail. To fix the
+  // event itself, edit it: link a listed event, or untick "This grading was at a
+  // listed workshop/event".
+  eventBlocksSave = computed(() => this.eventDirty() && this.eventInputInvalid());
+
+  // Every grading needs a date, whether or not it happened at a listed event. A
+  // linked event supplies its own date; otherwise a manager/instructor must set
+  // one before a result can be recorded. When missing we warn and disable the
+  // grading result buttons.
+  gradingDateMissing = computed(() => !this.editGradingEventDate().trim());
+
   // Feedback shown next to the Save button after an explicit save.
   saveStatus = signal<'' | 'saving...' | 'saved'>('');
 
@@ -413,7 +438,7 @@ export class GradingProgressComponent {
   // explicitly. The component no longer auto-saves — the user must click Save (or
   // Discard) so changes are intentional and clearly visible.
   saveEdits() {
-    if (!this.isDirty() || this.eventInputInvalid()) return;
+    if (!this.isDirty() || this.eventBlocksSave()) return;
     this.saveStatus.set('saving...');
     this.gradingUpdated.emit({
       gradingEvent: this.editGradingEvent(),
@@ -524,6 +549,29 @@ export class GradingProgressComponent {
     this.isEditingManagers.set(false);
   }
 
+  // Open the grading-managers editor. When there are no managers yet, start with
+  // one empty input row rather than a lone "+" so the user can type straight
+  // away.
+  openManagersEditor() {
+    if (this.editGradingManagerIds().length === 0) {
+      this.editGradingManagerIds.set(['']);
+    }
+    this.isEditingManagers.set(true);
+  }
+
+  // Remove a manager row while editing. If this empties a list that had no saved
+  // managers to begin with (i.e. the user opened the editor to add one, then
+  // removed it), close the editor — same effect as Cancel.
+  removeManagerInEditor(index: number) {
+    this.removeGradingManager(index);
+    if (
+      this.editGradingManagerIds().length === 0 &&
+      gradingManagerIdsOf(this.grading()).length === 0
+    ) {
+      this.cancelManagerEdit();
+    }
+  }
+
   savePaymentDetails() {
     this.gradingUpdated.emit({
       paymentStatus: this.editPaymentStatus(),
@@ -624,7 +672,7 @@ export class GradingProgressComponent {
     // A grading can only be accepted when it's the student's next grading in the
     // progression (guarded here as well as in the template), and not while the
     // event input is in an invalid (unlinked free-text) state.
-    if (!this.isNextGrading() || this.eventInputInvalid()) return;
+    if (!this.isNextGrading() || this.eventBlocksSave()) return;
     this.isSaving.set(true);
     const today = new Date().toISOString().split('T')[0];
     const actor = this.currentActor();
@@ -646,11 +694,12 @@ export class GradingProgressComponent {
 
   // Step 3: Mark result
   markResult(status: GradingStatus.Passed | GradingStatus.NotPassed) {
-    if (this.eventInputInvalid()) return;
+    // A grading date is mandatory (guarded here as well as in the template).
+    if (this.eventBlocksSave() || this.gradingDateMissing()) return;
     this.isSaving.set(true);
     const update: Partial<Grading> = {
       status,
-      gradingEventDate: this.editGradingEventDate() || new Date().toISOString().split('T')[0],
+      gradingEventDate: this.editGradingEventDate(),
       resultNotes: this.editResultNotes(),
       gradingInstructorId: this.editInstructorId(),
       ...this.managerIdsUpdate(),

--- a/src/app/grading-view/grading-view.spec.ts
+++ b/src/app/grading-view/grading-view.spec.ts
@@ -75,10 +75,14 @@ describe('GradingViewComponent', () => {
 
     mockRoutingService = {
       hrefForView: () => '#/gradings',
+      navigateTo: () => {},
       signals: {
         gradingView: {
           pathVars: {
             gradingId: () => '123'
+          },
+          urlParams: {
+            from: () => ''
           }
         }
       }
@@ -113,5 +117,51 @@ describe('GradingViewComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('optimistically applies the saved grading to local caches', async () => {
+    const applied: Grading[] = [];
+    mockDataManagerService.applyLocalGradingUpdate = (g: Grading) => applied.push(g);
+    await component.onProgressAction({ resultNotes: 'Great work' });
+    expect(applied.length).toBe(1);
+    expect(applied[0].resultNotes).toBe('Great work');
+  });
+
+  // Build a fresh component after the mock grading + user are configured, since
+  // the mock's `gradings.get` isn't a signal and `grading()` memoizes on the
+  // value present at creation.
+  async function makeComponentFor(isAdmin: boolean): Promise<GradingViewComponent> {
+    mockDataManagerService.gradings = {
+      get: () => ({ ...initGrading(), docId: '123', gradingManagerIds: ['INSTR1'] }),
+      loading: () => false,
+    } as never;
+    const firebaseState = TestBed.inject(FirebaseStateService);
+    const member = { docId: 'doc-instr', instructorId: 'INSTR1' } as never;
+    firebaseState.user.set({
+      member, memberProfiles: [member], isAdmin, schoolsManaged: [], firebaseUser: {} as never,
+    });
+    const f = TestBed.createComponent(GradingViewComponent);
+    f.componentRef.setInput('gradingId', '123');
+    await f.whenStable();
+    return f.componentInstance;
+  }
+
+  it('redirects to My Gradings when a manager removes their own access', async () => {
+    const nav: string[] = [];
+    (mockRoutingService as { navigateTo: (p: string) => void }).navigateTo = (p) => nav.push(p);
+    mockDataManagerService.applyLocalGradingUpdate = () => {};
+    const c = await makeComponentFor(false);
+    // Save with themselves removed from the managers.
+    await c.onProgressAction({ gradingManagerIds: [] });
+    expect(nav).toContain('my-gradings');
+  });
+
+  it('does not redirect an admin who removes themselves', async () => {
+    const nav: string[] = [];
+    (mockRoutingService as { navigateTo: (p: string) => void }).navigateTo = (p) => nav.push(p);
+    mockDataManagerService.applyLocalGradingUpdate = () => {};
+    const c = await makeComponentFor(true);
+    await c.onProgressAction({ gradingManagerIds: [] });
+    expect(nav).not.toContain('my-gradings');
   });
 });

--- a/src/app/grading-view/grading-view.ts
+++ b/src/app/grading-view/grading-view.ts
@@ -9,7 +9,7 @@
  */
 
 import { Component, computed, inject, input, output, signal, effect, ChangeDetectionStrategy } from '@angular/core';
-import { Grading, GradingStatus } from '../../../functions/src/data-model';
+import { Grading, GradingStatus, gradingManagerIdsOf } from '../../../functions/src/data-model';
 import { GradingEditComponent } from '../grading-edit/grading-edit';
 import { GradingRowHeaderComponent } from '../grading-row-header/grading-row-header';
 import { GradingProgressComponent } from '../grading-progress/grading-progress';
@@ -167,10 +167,41 @@ export class GradingViewComponent {
     try {
       const merged: Grading = { ...g, ...update };
       await this.dataService.updateGrading(g.docId, merged, g);
+      // Reflect the save immediately. The visible grading may be backed by the
+      // per-instructor mirror (`myGradingsAssessed`), which only refreshes once
+      // the Cloud Function re-syncs it — so without this the page would appear
+      // unchanged after saving.
+      this.dataService.applyLocalGradingUpdate(merged);
+
+      // If this change revoked the current user's own access to the grading
+      // (e.g. a grading manager removed themselves), they can no longer see it —
+      // send them back to My Gradings rather than stranding them on a page that
+      // is about to become inaccessible.
+      if (this.hasAccess(g) && !this.hasAccess(merged)) {
+        this.routingService.navigateTo('my-gradings');
+      }
     } catch (e: unknown) {
       console.error('Error updating grading:', e);
       this.asyncError.set((e as Error).message);
     }
     this.isSaving.set(false);
+  }
+
+  // Whether the current (non-admin) user is associated with the grading as its
+  // student, primary grading instructor, or a grading manager — i.e. can still
+  // read it. Admins always retain access. Event/school-manager access is derived
+  // server-side and unaffected by editing the managers list, so it isn't checked
+  // here (we only redirect on a definite loss of the student/instructor roles).
+  private hasAccess(g: Grading): boolean {
+    const user = this.firebaseState.user();
+    if (!user) return false;
+    if (user.isAdmin) return true;
+    if (user.memberProfiles.some((p) => p.docId === g.studentMemberDocId)) return true;
+    const myInstructorId = user.member.instructorId;
+    if (!myInstructorId) return false;
+    return (
+      g.gradingInstructorId === myInstructorId ||
+      gradingManagerIdsOf(g).includes(myInstructorId)
+    );
   }
 }

--- a/src/app/searchable-set.ts
+++ b/src/app/searchable-set.ts
@@ -120,6 +120,25 @@ export class SearchableSet<
     this.state.update((state) => ({ ...state, entries, loading: false }));
   }
 
+  /**
+   * Insert or replace a single entry (matched by its id field), leaving all
+   * other entries untouched. Used for optimistic local updates so a reactive
+   * view reflects a write immediately, without waiting for the next snapshot
+   * (important when the entry is backed by a denormalized mirror that only
+   * refreshes via a Cloud Function).
+   */
+  upsert(entry: T) {
+    this.state.update((state) => {
+      const id = entry[this.idField];
+      const idx = state.entries.findIndex((e) => e[this.idField] === id);
+      const entries =
+        idx >= 0
+          ? [...state.entries.slice(0, idx), entry, ...state.entries.slice(idx + 1)]
+          : [...state.entries, entry];
+      return { ...state, entries };
+    });
+  }
+
   setError(error: string) {
     this.state.update((state) => ({ ...state, error, loading: false }));
   }


### PR DESCRIPTION
## Summary

A series of fixes and UX improvements to the grading progress component, prompted by a real grading (`ccN4T2XAgtxQ2HQQJjOf`) where removing a grading manager silently did nothing.

### Save reliability
- **Root cause fix:** a legacy *unlinked* event (free-text `gradingEvent` with no `gradingEventDocId`) made `eventInputInvalid` true, so `saveEdits()` bailed on its first line — silently blocking edits to unrelated fields (e.g. managers), for admins too. The event-invalid guard now only blocks a save when the user is actually **changing** the event (`eventBlocksSave = eventDirty && eventInputInvalid`).
- **Optimistic local update:** after a successful save, patch the backing cache so the change is reflected immediately even when the view is served from the per-instructor `myGradingsAssessed` mirror (which only refreshes via the `onGradingUpdated` Cloud Function).
- **Access-loss redirect:** if a change revokes the current user's own access (e.g. a manager removing themselves), navigate back to My Gradings instead of leaving them on a now-inaccessible page.

### Date + event
- The grading **date is always shown** (via the unified event widget) and is **required** before a result can be recorded, with a warning when missing.
- Legacy free-text events seed the "This grading was at a listed workshop/event" checkbox **checked**, so the search box and the "isn't a linked ILC event" warning are visible and fixable.

### Layout / consistency
- Unified **"Event"** labelling and the date-on-top widget across the request, accept, and grading stages; the "Event" label baseline is aligned to the "Date of grading" row.
- **Final stage:** a single "Event" row (Date of grading first, then the event); "Notes for the student" moved **under Payment and above Internal notes**; both notes render as normal right-column detail rows in a consistent style.
- Empty rows **grey out their key** for editors (view-only users skip the row); consistent, slightly larger (10px) row spacing across the editing and completed grids.
- The grading-managers editor **opens with one empty row**; removing the sole added row closes it like Cancel.

## Testing
- `pnpm run build` — clean (no template errors, no CommonJS warning).
- `pnpm exec vitest run` — **400 tests pass**, including new coverage for the unlinked-event guard, the date requirement, the manager-editor open/remove behavior, and the optimistic-update / access-loss redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)