### PR TITLE
fix(grading): make event autocomplete search find all listed events

### DIFF
--- a/src/app/data-manager.service.ts
+++ b/src/app/data-manager.service.ts
@@ -600,7 +600,14 @@ export class DataManagerService {
 
       try {
         const snap = await getDocs(q);
-        return snap.docs.map(d => ({ ...initEvent(), ...d.data(), docId: d.id } as IlcEvent));
+        let results = snap.docs.map(d => ({ ...initEvent(), ...d.data(), docId: d.id } as IlcEvent));
+        // Apply the status filter client-side: adding `where('status', '==', …)`
+        // to the date-range query would require a composite index, so filter the
+        // fetched page instead.
+        if (status) {
+          results = results.filter((e) => e.status === status);
+        }
+        return results;
       } catch (error) {
         console.error('Error searching events by date bounds:', error);
         return [];

--- a/src/app/grading-event-input/grading-event-input.ts
+++ b/src/app/grading-event-input/grading-event-input.ts
@@ -1,4 +1,4 @@
-import { Component, effect, inject, input, linkedSignal, computed, output } from '@angular/core';
+import { Component, effect, inject, input, linkedSignal, computed, output, signal } from '@angular/core';
 import { IlcEvent } from '../../../functions/src/data-model';
 import { DataManagerService, EventSearchCriteriaDateRange } from '../data-manager.service';
 import { SearchableSet } from '../searchable-set';
@@ -6,19 +6,6 @@ import { RoutingService } from '../routing.service';
 import { AppPathPatterns, Views } from '../app.config';
 import { AutocompleteComponent } from '../autocomplete/autocomplete';
 import { IconComponent } from '../icons/icon.component';
-
-function oneMonthAgo(): string {
-  const d = new Date();
-  d.setMonth(d.getMonth() - 1);
-  return d.toISOString().substring(0, 10);
-}
-
-// Shift a YYYY-MM-DD date string by a number of days, returning YYYY-MM-DD.
-function shiftDays(dateStr: string, days: number): string {
-  const d = new Date(dateStr + 'T00:00:00');
-  d.setDate(d.getDate() + days);
-  return d.toISOString().substring(0, 10);
-}
 
 export interface GradingEventDetails {
   gradingEvent: string;
@@ -63,19 +50,14 @@ export class GradingEventInputComponent {
     },
   });
 
-  // Event search. When the grading already has a date, default the search to a
-  // fortnight either side of it so the matching event is easy to find; otherwise
-  // fall back to the last month onwards. These stay user-editable via the date
-  // inputs (re-seeded only if the grading date itself changes).
+  // Event search. The autocomplete filters this preloaded set locally, so it can
+  // only find events that were loaded — a narrow default range silently hides
+  // the event the user is searching for. Default to loading all listed events
+  // (matching the grading list's event filter); the date inputs below let the
+  // user narrow the range when there are too many to scroll.
   eventsSet = new SearchableSet<'docId', IlcEvent>(['title', 'location', 'start'], 'docId');
-  eventRangeFrom = linkedSignal(() => {
-    const date = this.gradingEventDate();
-    return date ? shiftDays(date, -15) : oneMonthAgo();
-  });
-  eventRangeTo = linkedSignal(() => {
-    const date = this.gradingEventDate();
-    return date ? shiftDays(date, 15) : '';
-  });
+  eventRangeFrom = signal<string>('');
+  eventRangeTo = signal<string>('');
 
   _loadEvents = effect(() => {
     const criteria: EventSearchCriteriaDateRange = {


### PR DESCRIPTION
## Problem

In the grading progress component, ticking **"This grading was at a listed workshop/event"** revealed the **"Grading happened at event"** search box, but typing in it returned no results — the autocomplete appeared to do nothing.

## Root cause

The event autocomplete filters a **preloaded** event set locally; it does not re-query as you type. That set was loaded with a restrictive default date window:

- No grading date → only events from **one month ago onward**
- Grading date set → only events **±15 days** around it

Any workshop outside that window simply wasn't in the set, so there was nothing for the search to match. The proven-working event filter in `grading-list` instead loads *all* events, which is why its search is reliable.

Separately, `searchEvents` applied `statusFilter` in its `term` branch but **silently ignored it in the `date` branch**, so `statusFilter: 'listed'` had no effect.

## Fix

- **`grading-event-input.ts`** — default the event date range to empty so **all listed events load** and the autocomplete always has the full set to search. The date inputs still work for optional narrowing. Removed the now-unused `oneMonthAgo`/`shiftDays` helpers.
- **`data-manager.service.ts`** — honor `statusFilter` in the date-range branch by filtering the fetched page client-side (a `where('status', '==', …)` clause there would require a composite index).

## Testing

- `tsc` typecheck passes.
- Worth a manual check against real data: open a grading, tick "This grading was at a listed workshop/event", and confirm typing a workshop name now returns matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)