### PR TITLE
Include customer and items in admin order-issue notifications

### DIFF
--- a/src/app/notification.service.spec.ts
+++ b/src/app/notification.service.spec.ts
@@ -339,4 +339,51 @@ describe('NotificationService', () => {
       expect(commit).not.toHaveBeenCalled();
     });
   });
+
+  describe('orderIssueFields', () => {
+    const fields = (order: unknown) => (service as any).orderIssueFields(order);
+
+    it('includes who placed a Squarespace order and what it was for', () => {
+      const order = {
+        docId: 'o1',
+        ilcAppOrderKind: 'https://api.squarespace.com/1.0/commerce/orders',
+        ilcAppOrderStatus: 'needs-manual-processing',
+        orderNumber: '1234',
+        customerEmail: 'jane@example.com',
+        billingAddress: { firstName: 'Jane', lastName: 'Doe' },
+        lineItems: [{ productName: 'Annual Membership' }, { productName: 'Video Library' }],
+      };
+      expect(fields(order).markdown).toBe(
+        'Order [#1234](/order-view/o1) (from Jane Doe for Annual Membership, Video Library) needs manual processing',
+      );
+    });
+
+    it('uses customerName/description for Stripe orders and appends issues', () => {
+      const order = {
+        docId: 'o2',
+        ilcAppOrderKind: 'stripe',
+        ilcAppOrderStatus: 'error',
+        stripeObjectId: 'cs_123',
+        customerName: 'John Smith',
+        lineItems: [{ description: 'Grading Fee' }],
+        ilcAppOrderIssues: ['no matching member'],
+      };
+      expect(fields(order).markdown).toBe(
+        'Order [#cs_123](/order-view/o2) (from John Smith for Grading Fee) failed with an error — no matching member',
+      );
+    });
+
+    it('falls back to email and omits the details clause when nothing is known', () => {
+      const order = {
+        docId: 'o3',
+        ilcAppOrderKind: 'stripe',
+        ilcAppOrderStatus: 'error',
+        stripeObjectId: 'cs_9',
+        lineItems: [],
+      };
+      expect(fields(order).markdown).toBe(
+        'Order [#cs_9](/order-view/o3) failed with an error',
+      );
+    });
+  });
 });

--- a/src/app/notification.service.spec.ts
+++ b/src/app/notification.service.spec.ts
@@ -373,6 +373,25 @@ describe('NotificationService', () => {
       );
     });
 
+    it('shows a sensible summary for a physical-product order, using SKU as fallback', () => {
+      const order = {
+        docId: 'o4',
+        ilcAppOrderKind: 'https://api.squarespace.com/1.0/commerce/orders',
+        ilcAppOrderStatus: 'needs-manual-processing',
+        orderNumber: '5678',
+        billingAddress: { firstName: 'Sam', lastName: 'Lee' },
+        // A physical book (as displayed "1x BOOK : System Guide - 3rd Edition")
+        // plus a second item that only carries a SKU.
+        lineItems: [
+          { productName: 'BOOK : System Guide - 3rd Edition', sku: 'PRINT-3SGUIDE' },
+          { sku: 'PRINT-POSTER' },
+        ],
+      };
+      expect(fields(order).markdown).toBe(
+        'Order [#5678](/order-view/o4) (from Sam Lee for BOOK : System Guide - 3rd Edition, PRINT-POSTER) needs manual processing',
+      );
+    });
+
     it('falls back to email and omits the details clause when nothing is known', () => {
       const order = {
         docId: 'o3',

--- a/src/app/notification.service.ts
+++ b/src/app/notification.service.ts
@@ -803,6 +803,37 @@ export class NotificationService implements OnDestroy {
     return order.referenceNumber || order.docId;
   }
 
+  // Who placed the order: a name where available, falling back to the email.
+  // Empty string when neither is known.
+  private orderCustomer(order: Order): string {
+    if (order.ilcAppOrderKind === 'https://api.squarespace.com/1.0/commerce/orders') {
+      const name = [order.billingAddress?.firstName, order.billingAddress?.lastName]
+        .filter(Boolean)
+        .join(' ')
+        .trim();
+      return name || order.customerEmail || '';
+    }
+    if (order.ilcAppOrderKind === 'stripe') {
+      return (order.customerName || order.customerEmail || '').trim();
+    }
+    const name = [order.firstName, order.lastName].filter(Boolean).join(' ').trim();
+    return name || order.email || '';
+  }
+
+  // Short human-readable summary of what was purchased (line-item product names
+  // or descriptions). Empty string when the order carries no itemised lines.
+  private orderItemsSummary(order: Order): string {
+    let names: string[] = [];
+    if (order.ilcAppOrderKind === 'https://api.squarespace.com/1.0/commerce/orders') {
+      names = (order.lineItems || []).map((li) => (li.productName || li.sku || '').trim());
+    } else if (order.ilcAppOrderKind === 'stripe') {
+      names = (order.lineItems || []).map((li) => (li.description || '').trim());
+    } else {
+      names = [order.paidFor, order.orderType].map((s) => (s || '').trim());
+    }
+    return names.filter(Boolean).join(', ');
+  }
+
   // Surfaces orders that failed automatic processing (ilcAppOrderStatus 'error'
   // or 'needs-manual-processing') as notifications in this admin's feed, most
   // recent first. Idempotent and modelled on the pending-event catch-up: it
@@ -901,8 +932,17 @@ export class NotificationService implements OnDestroy {
     const verb = status === 'error' ? 'failed with an error' : 'needs manual processing';
     const issues = order.ilcAppOrderIssues || [];
     const issuesSuffix = issues.length > 0 ? ` — ${issues.join('; ')}` : '';
+    // Basic context so the admin can tell what the order is at a glance: who
+    // placed it and what it was for.
+    const customer = this.orderCustomer(order);
+    const items = this.orderItemsSummary(order);
+    const details = [
+      customer ? `from ${customer}` : '',
+      items ? `for ${items}` : '',
+    ].filter(Boolean).join(' ');
+    const detailsSuffix = details ? ` (${details})` : '';
     return {
-      markdown: `Order [#${orderRef}](/order-view/${order.docId}) ${verb}${issuesSuffix}`,
+      markdown: `Order [#${orderRef}](/order-view/${order.docId})${detailsSuffix} ${verb}${issuesSuffix}`,
       data: { orderDocId: order.docId, orderRef, status, issues },
     };
   }


### PR DESCRIPTION
## What

Admin `OrderNeedsAttention` notifications previously read only the order reference and status, e.g.:

> Order #1234 needs manual processing

They now include **who placed the order** and **what it was for**:

> Order #1234 (from Jane Doe for Annual Membership, Video Library) needs manual processing

## How

Two helpers in `notification.service.ts`, handling all three order kinds:

- `orderCustomer()` — name from `billingAddress` (Squarespace), `customerName` (Stripe), or `firstName/lastName` (Sheets import), falling back to the customer email.
- `orderItemsSummary()` — joins line-item names (Squarespace `productName`, Stripe `description`, or Sheets `paidFor`/`orderType`).

The details clause is omitted entirely when nothing is known, so the message degrades gracefully. Because `orderIssueFields` is shared by the create and reconcile passes, the richer text applies to both newly-surfaced and refreshed notifications. The in-app push-alert text is derived from the same markdown, so it benefits automatically.

## Testing

- Typecheck passes.
- Added 3 focused tests for `orderIssueFields` (Squarespace, Stripe + issues, empty-details fallback); all 11 spec tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)