### PR TITLE
fix(social-preview): fallback og:image + date/location for events

### DIFF
--- a/functions/src/social-preview.spec.ts
+++ b/functions/src/social-preview.spec.ts
@@ -1,6 +1,69 @@
 /* social-preview.spec.ts — tests for the social preview helpers. */
 import { describe, it, expect } from 'vitest';
-import { toPlainSummary, injectMeta, Preview } from './social-preview';
+import {
+  toPlainSummary,
+  injectMeta,
+  formatEventDate,
+  buildEventPreview,
+  Preview,
+} from './social-preview';
+
+describe('buildEventPreview', () => {
+  const host = 'app.iliqchuan.com';
+
+  it('prepends date · location to the description', () => {
+    const p = buildEventPreview(
+      {
+        title: 'Master Hsin Chin',
+        start: '2026-08-15',
+        end: '2026-08-17',
+        location: 'Poland, Narewka',
+        descriptionMarkdown: 'A **weekend** of training.',
+      },
+      host,
+    );
+    expect(p.description).toBe(
+      'Aug 15, 2026 – Aug 17, 2026 · Poland, Narewka — A weekend of training.',
+    );
+  });
+
+  it('shows just the facts when there is no marketing copy', () => {
+    const p = buildEventPreview({ start: '2026-08-15', location: 'Poland' }, host);
+    expect(p.description).toBe('Aug 15, 2026 · Poland');
+  });
+
+  it('falls back to the static logo image when the event has no hero image', () => {
+    const p = buildEventPreview({ title: 'E', start: '2026-08-15' }, host);
+    expect(p.image).toBe('https://app.iliqchuan.com/icons/icon-512x512.png');
+  });
+
+  it('prefers the event hero image over the fallback', () => {
+    const p = buildEventPreview(
+      { title: 'E', heroImageLargeUrl: 'https://cdn/x.jpg' },
+      host,
+    );
+    expect(p.image).toBe('https://cdn/x.jpg');
+  });
+});
+
+describe('formatEventDate', () => {
+  it('formats a single bare date in UTC (no TZ drift)', () => {
+    expect(formatEventDate('2026-08-15')).toBe('Aug 15, 2026');
+  });
+
+  it('formats a date range when start and end differ', () => {
+    expect(formatEventDate('2026-08-15', '2026-08-17')).toBe('Aug 15, 2026 – Aug 17, 2026');
+  });
+
+  it('collapses a same-day range to a single date', () => {
+    expect(formatEventDate('2026-08-15T09:00:00Z', '2026-08-15T17:00:00Z')).toBe('Aug 15, 2026');
+  });
+
+  it('returns empty string for missing or invalid input', () => {
+    expect(formatEventDate('')).toBe('');
+    expect(formatEventDate('not-a-date')).toBe('');
+  });
+});
 
 describe('toPlainSummary', () => {
   it('strips markdown and collapses whitespace', () => {

--- a/functions/src/social-preview.ts
+++ b/functions/src/social-preview.ts
@@ -18,6 +18,12 @@ import * as admin from 'firebase-admin';
 
 const SITE_NAME = 'I Liq Chuan Members Portal';
 
+// Fallback preview image for items that have no image of their own. Social
+// crawlers (notably WhatsApp) refuse to render any link preview card without an
+// og:image, so we point at a static logo. Must be a raster format — WhatsApp,
+// Facebook and X all ignore SVG og:images — hence the PNG rather than ilc.svg.
+const DEFAULT_IMAGE_PATH = '/icons/icon-512x512.png';
+
 export interface Preview {
   title: string;
   description: string;
@@ -75,6 +81,31 @@ export function toPlainSummary(text: string, maxLen = 200): string {
   return s;
 }
 
+/**
+ * Format an event's date (or date range) as a short human-readable string, e.g.
+ * "Aug 15, 2026" or "Aug 15 – 17, 2026". `start`/`end` may be ISO date-times or
+ * bare YYYY-MM-DD; we format in UTC so a bare date doesn't drift a day by TZ.
+ */
+export function formatEventDate(start: string, end?: string): string {
+  if (!start) return '';
+  const s = new Date(start);
+  if (isNaN(s.getTime())) return '';
+  const opts: Intl.DateTimeFormatOptions = {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  };
+  const startStr = s.toLocaleDateString('en-US', opts);
+  if (end) {
+    const e = new Date(end);
+    if (!isNaN(e.getTime()) && e.toISOString().slice(0, 10) !== s.toISOString().slice(0, 10)) {
+      return `${startStr} – ${e.toLocaleDateString('en-US', opts)}`;
+    }
+  }
+  return startStr;
+}
+
 /** Fetch the first document in `collection` where `field` == `value`. */
 async function firstWhere(
   collection: string,
@@ -90,23 +121,46 @@ async function firstWhere(
   return snap.empty ? null : snap.docs[0].data();
 }
 
+/** Absolute URL for the static fallback image; crawlers reject relative ones. */
+export function fallbackImageUrl(host: string): string {
+  return `https://${host}${DEFAULT_IMAGE_PATH}`;
+}
+
+/** Build an event preview from its Firestore data (pure; no I/O). */
+export function buildEventPreview(
+  data: admin.firestore.DocumentData,
+  host: string,
+): Preview {
+  // Lead the description with the date · location facts, so the preview shows
+  // the key details even when the marketing copy buries them (or is empty).
+  const facts = [formatEventDate(data.start, data.end), data.location]
+    .filter(Boolean)
+    .join(' · ');
+  const summary = toPlainSummary(data.descriptionMarkdown || data.description || '');
+  const description = facts ? (summary ? `${facts} — ${summary}` : facts) : summary;
+  return {
+    title: data.title ?? 'Event',
+    description,
+    image: data.heroImageLargeUrl || data.heroImageUrl || fallbackImageUrl(host),
+  };
+}
+
 /** Resolve a request path to a preview, or null if it's not a known detail page. */
-async function loadPreview(path: string): Promise<Preview | null> {
+async function loadPreview(path: string, host: string): Promise<Preview | null> {
   const parts = path.split('/').filter(Boolean);
   const route = parts[0];
   const id = decodeURIComponent(parts[1] ?? '');
   if (!id) return null;
+
+  // Absolute URL for the static fallback image; crawlers reject relative ones.
+  const fallbackImage = fallbackImageUrl(host);
 
   if (route === 'events') {
     const db = admin.firestore();
     const byId = await db.collection('events').doc(id).get();
     const data = byId.exists ? byId.data() : await firstWhere('events', 'sourceId', id);
     if (!data) return null;
-    return {
-      title: data.title ?? 'Event',
-      description: toPlainSummary(data.descriptionMarkdown || data.description || ''),
-      image: data.heroImageLargeUrl || data.heroImageUrl || undefined,
-    };
+    return buildEventPreview(data, host);
   }
 
   if (route === 'instructors') {
@@ -117,7 +171,7 @@ async function loadPreview(path: string): Promise<Preview | null> {
     return {
       title: `${data.name ?? id} — I Liq Chuan Instructor`,
       description: bio || (location ? `I Liq Chuan instructor in ${location}.` : ''),
-      image: data.publicCoverImageUrl || data.publicProfileImageUrl || undefined,
+      image: data.publicCoverImageUrl || data.publicProfileImageUrl || fallbackImage,
     };
   }
 
@@ -129,7 +183,7 @@ async function loadPreview(path: string): Promise<Preview | null> {
     return {
       title: `${data.schoolName || id} — I Liq Chuan School`,
       description: bio || (location ? `I Liq Chuan school in ${location}.` : ''),
-      image: data.publicCoverImageUrl || data.publicProfileImageUrl || undefined,
+      image: data.publicCoverImageUrl || data.publicProfileImageUrl || fallbackImage,
     };
   }
 
@@ -190,7 +244,7 @@ export const socialPreview = onRequest(async (request, response) => {
   }
 
   try {
-    const preview = await loadPreview(path);
+    const preview = await loadPreview(path, host);
     if (preview) {
       html = injectMeta(html, preview, canonicalUrl);
     }


### PR DESCRIPTION
## Problem

Sharing an event link with no hero image (e.g. `/events/0VM1DmaQDWwKclN3GVTI`) produced **no WhatsApp preview at all** — just a bare URL.

Diagnosis: the social-preview function was working correctly (title, `og:description`, `og:url` and Twitter tags all injected), but the event had no image so **no `og:image` was emitted**. WhatsApp — unlike Facebook, X, Slack and Telegram — refuses to render *any* preview card without an `og:image`.

## Changes

- **Fallback `og:image`**: events, instructors and schools with no image of their own now fall back to the static `icons/icon-512x512.png` (absolute URL). A **PNG is used deliberately** — WhatsApp, Facebook and X all ignore SVG `og:image`s, so `ilc.svg` would have left the preview blank.
- **Date · location in the event description**: previews now lead with e.g. `Aug 15, 2026 – Aug 17, 2026 · Poland, Narewka — <marketing text>`, formatted in UTC so bare `YYYY-MM-DD` dates don't drift by a day. Falls back gracefully to just the facts when there's no marketing copy.
- Extracted the event-preview assembly into a pure `buildEventPreview()` and added `formatEventDate()` — both unit-tested (no emulator needed).

## Testing

- `pnpm exec vitest run src/social-preview.spec.ts` — 17 passing (new coverage for `formatEventDate` and `buildEventPreview`).
- `pnpm exec tsc --noEmit` — clean.

## Notes

- Needs deploy to go live.
- WhatsApp caches aggressively; a previously-shared link may show the old empty result for a while (appending a query param to the URL forces a re-scrape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)