### PR TITLE
fix(notifications): repair dead links in in-app notifications

### DIFF
--- a/functions/src/data-model.ts
+++ b/functions/src/data-model.ts
@@ -1829,8 +1829,12 @@ export interface EmailTemplates {
 export function initEmailTemplates(): EmailTemplates {
   return {
     membershipActivatedSubject: membershipActivatedSubject(),
-    membershipActivatedBody: membershipActivatedBody(),
+    membershipActivatedBody: membershipActivatedBody({ appBase: '{appBase}' }),
     instructorLicenseActivatedSubject: instructorLicenseActivatedSubject(),
-    instructorLicenseActivatedBody: instructorLicenseActivatedBody({ instructorId: '{instructorId}' }),
+    instructorLicenseActivatedBody: instructorLicenseActivatedBody({
+      instructorId: '{instructorId}',
+      appBase: '{appBase}',
+      instructorSopUrl: '{instructorSopUrl}',
+    }),
   };
 }

--- a/functions/src/email-templates.ts
+++ b/functions/src/email-templates.ts
@@ -1,9 +1,16 @@
 // Email template functions using TypeScript template literals.
 
+// Links in email must be absolute, so every body that links back into the app
+// takes the app's origin as a parameter rather than hardcoding a host. The
+// caller supplies the real values from environment.links (sendTemplateEmail);
+// initEmailTemplates passes the `{token}` form instead, so the editable
+// template defaults shown in Settings keep the placeholders visible.
 export interface MembershipEmailParams {
   name?: string;
   memberId?: string;
   email?: string;
+  // App origin with no trailing slash, e.g. 'https://app.iliqchuan.com'.
+  appBase?: string;
 }
 
 export interface InstructorEmailParams {
@@ -11,6 +18,10 @@ export interface InstructorEmailParams {
   memberId?: string;
   instructorId?: string;
   email?: string;
+  // App origin with no trailing slash, e.g. 'https://app.iliqchuan.com'.
+  appBase?: string;
+  // Absolute URL of the Instructors Area post holding the instructor SOP.
+  instructorSopUrl?: string;
 }
 
 // Subject for membership activation email.
@@ -20,9 +31,10 @@ export function membershipActivatedSubject(params?: MembershipEmailParams): stri
 
 // Body for membership activation email.
 export function membershipActivatedBody(params?: MembershipEmailParams): string {
+  const appBase = params?.appBase || '';
   return `Welcome to the I Liq Chuan family! Your membership is now active.
 
-You can now access the [Active Members Area](https://members.iliqchuan.com/#/members-area) to read the blog, view classes, and more.`;
+You can now access the [Active Members Area](${appBase}/members-area) to read the blog, view classes, and more.`;
 }
 
 // Subject for instructor license activation email.
@@ -33,7 +45,9 @@ export function instructorLicenseActivatedSubject(params?: InstructorEmailParams
 // Body for instructor license activation email.
 export function instructorLicenseActivatedBody(params?: InstructorEmailParams): string {
   const instructorId = params?.instructorId || '';
+  const appBase = params?.appBase || '';
+  const sopUrl = params?.instructorSopUrl || '';
   return `Congratulations on getting your Instructor ID **${instructorId}**!
 
-Please [update your public instructor profile](https://members.iliqchuan.com/#/myProfile) with a bio, photos, and links, and make sure to review the [Instructor Standard Operating Procedures (SOP)](https://members.iliqchuan.com/#/instructors-area/post/sop) in the Instructors Area.`;
+Please [update your public instructor profile](${appBase}/myProfile) with a bio, photos, and links, and make sure to review the [Instructor Standard Operating Procedures (SOP)](${sopUrl}) in the Instructors Area.`;
 }

--- a/functions/src/environment/environment.template.ts
+++ b/functions/src/environment/environment.template.ts
@@ -31,6 +31,12 @@ export const environment: FunctionsEnvironment = {
   // the private key is provided via the VAPID_PRIVATE_KEY secret. Empty disables push.
   vapidPublicKey: '',
   pushContactEmail: 'mailto:admin@example.com',
+  // Where the links in notifications and emails point. `appBase` is only needed
+  // to make email links absolute; in-app links use the paths on their own.
+  links: {
+    appBase: 'https://app.iliqchuan.com',
+    instructorSopPath: '/instructors-area/post/instructor-packet',
+  },
   // Outbound email address configuration. If `from` is empty, email notifications are disabled.
   email: {
     from: '', // e.g. 'admin@iliqchuan.com'

--- a/functions/src/environment/environment.types.ts
+++ b/functions/src/environment/environment.types.ts
@@ -50,6 +50,19 @@ export interface FunctionsEnvironment {
   vapidPublicKey: string;
   // Contact mailto: URI included in Web Push VAPID headers per Web Push specification
   pushContactEmail: string;
+  // Public URLs used when linking a member back into the app from a
+  // notification or an outbound email.
+  links: {
+    // Origin the members app is served from, with no trailing slash
+    // (e.g. 'https://app.iliqchuan.com'). Email links must be absolute, so they
+    // are built from this; in-app notification links stay root-relative so they
+    // also work on localhost and preview deploys.
+    appBase: string;
+    // Root-relative path of the Instructors Area post holding the instructor
+    // SOP. Configured here because the post's urlId is content, and can change
+    // without a code change.
+    instructorSopPath: string;
+  };
   // Outbound email notification settings
   email: {
     // Default 'From' email sender address (e.g. 'info@iliqchuan.com').

--- a/functions/src/on-grading-update.ts
+++ b/functions/src/on-grading-update.ts
@@ -359,7 +359,7 @@ async function notifyEventManagers(
   event: EventManagers,
   eventDocId: string,
 ): Promise<void> {
-  const gradingHref = `#/gradings/${gradingDocId}`;
+  const gradingHref = `/gradings/${gradingDocId}`;
   for (const memberDocId of memberDocIds) {
     if (memberDocId === grading.studentMemberDocId) continue;
     const msg = added
@@ -432,7 +432,7 @@ export const onGradingCreated = onDocumentCreated(
     // yet actionable by the student) or has no linked student.
     if (grading.studentMemberDocId && grading.status !== GradingStatus.RequiresReview) {
       const awaitingInstructor = grading.status === GradingStatus.AwaitingRequest;
-      const gradingHref = `#/gradings/${gradingDocId}`;
+      const gradingHref = `/gradings/${gradingDocId}`;
       const msg = awaitingInstructor
         ? `🥋 Your grading for **${grading.level}** is ready! Next step: choose the instructor who will grade you. ` +
           `[Open your grading](${gradingHref}) to select your instructor and send your request.`
@@ -485,7 +485,7 @@ export const onGradingCreated = onDocumentCreated(
           grading.statusChangedByMemberDocId,
         );
         if (sifu) {
-          const gradingHref = `#/gradings/${gradingDocId}`;
+          const gradingHref = `/gradings/${gradingDocId}`;
           const instructorName = await getMemberName(
             await findInstructorMemberDocId(grading.gradingInstructorId),
             'another instructor',
@@ -762,7 +762,7 @@ export const onGradingUpdated = onDocumentUpdated(
 
     // Notify the student when their grading result is recorded.
     if (grading.studentMemberDocId) {
-      const gradingHref = `#/gradings/${gradingDocId}`;
+      const gradingHref = `/gradings/${gradingDocId}`;
       if (
         grading.status === GradingStatus.Passed &&
         previous.status !== GradingStatus.Passed
@@ -907,7 +907,7 @@ export const onGradingUpdated = onDocumentUpdated(
         grading.acceptedByMemberDocId,
       );
       if (sifu) {
-        const gradingHref = `#/gradings/${gradingDocId}`;
+        const gradingHref = `/gradings/${gradingDocId}`;
         const acceptorName = grading.acceptedByName || 'a grading manager';
         await createNotification(sifu.sifuMemberDocId, {
           markdown:
@@ -1014,7 +1014,7 @@ export const onGradingUpdated = onDocumentUpdated(
           grading.statusChangedByMemberDocId,
         );
         if (sifu) {
-          const gradingHref = `#/gradings/${gradingDocId}`;
+          const gradingHref = `/gradings/${gradingDocId}`;
           const instructorName = await getMemberName(
             await findInstructorMemberDocId(grading.gradingInstructorId),
             'another instructor',

--- a/functions/src/on-member-update.spec.ts
+++ b/functions/src/on-member-update.spec.ts
@@ -172,6 +172,7 @@ describe('on-member-update triggers logic', () => {
       const setCall = mockSet.mock.calls[0][0] as MemberNotification;
       expect(setCall.kind).toBe(NotificationKind.MembershipActivated);
       expect(setCall.markdown).toContain('Welcome to the I Liq Chuan family');
+      expect(setCall.markdown).toContain('](/members-area)');
 
       // Verify email was enqueued
       expect(mockAdd).toHaveBeenCalled();
@@ -179,6 +180,7 @@ describe('on-member-update triggers logic', () => {
       expect(addCall.to).toEqual(['member-email@example.com']);
       expect(addCall.message.subject).toBe('Welcome to the I Liq Chuan Family!');
       expect(addCall.message.html).toContain('Welcome to the I Liq Chuan family');
+      expect(addCall.message.html).toContain(`${environment.links.appBase}/members-area`);
     });
 
     it('should use custom templates from Firestore system/email-templates document if present', async () => {
@@ -295,6 +297,12 @@ describe('on-member-update triggers logic', () => {
       expect(setCall.kind).toBe(NotificationKind.InstructorLicenseActivated);
       expect(setCall.markdown).toContain('Congratulations on getting your Instructor ID');
       expect(setCall.data.instructorId).toBe('INST-777');
+      // Regression: in-app links must be root-relative paths. A legacy `#/...`
+      // href only resolves on a full page load (see the rewrite in main.ts), so
+      // clicking one inside the running app does nothing at all.
+      expect(setCall.markdown).not.toContain('](#/');
+      expect(setCall.markdown).toContain('](/myProfile)');
+      expect(setCall.markdown).toContain(`](${environment.links.instructorSopPath})`);
 
       // Verify email was enqueued
       expect(mockAdd).toHaveBeenCalled();
@@ -303,6 +311,11 @@ describe('on-member-update triggers logic', () => {
       expect(addCall.message.subject).toBe('Congratulations on your Instructor License!');
       expect(addCall.message.html).toContain('Congratulations on getting your Instructor ID');
       expect(addCall.message.html).toContain('INST-777');
+      // Email links have no app to resolve against, so they must be absolute.
+      expect(addCall.message.html).toContain(`${environment.links.appBase}/myProfile`);
+      expect(addCall.message.html).toContain(
+        `${environment.links.appBase}${environment.links.instructorSopPath}`,
+      );
     });
 
     it('should do nothing if instructorId remains unchanged or empty', async () => {

--- a/functions/src/on-member-update.ts
+++ b/functions/src/on-member-update.ts
@@ -358,7 +358,7 @@ export async function handleMembershipActivation(
 
     await createMemberNotification(db, member.docId, {
       kind: NotificationKind.MembershipActivated,
-      markdown: `Welcome to the I Liq Chuan family! Your membership is now active. You can now access the [Active Members Area](#/members-area) to read the blog, view classes, and more.`,
+      markdown: `Welcome to the I Liq Chuan family! Your membership is now active. You can now access the [Active Members Area](/members-area) to read the blog, view classes, and more.`,
       createdAt: new Date().toISOString(),
       dismissed: false,
       data: {}
@@ -369,6 +369,7 @@ export async function handleMembershipActivation(
         name: member.name || '',
         memberId: member.memberId || '',
         email: (member.emails || [])[0] || '',
+        appBase: environment.links.appBase,
       });
     } catch (error) {
       logger.error(`Failed to enqueue welcome email for member ${member.docId}:`, error);
@@ -388,7 +389,7 @@ export async function handleInstructorActivation(
 
     await createMemberNotification(db, member.docId, {
       kind: NotificationKind.InstructorLicenseActivated,
-      markdown: `Congratulations on getting your Instructor ID **${member.instructorId}**! Please [update your public instructor profile](#/myProfile) with a bio, photos, and links, and make sure to review the [Instructor Standard Operating Procedures (SOP)](#/instructors-area/post/sop) in the Instructors Area.`,
+      markdown: `Congratulations on getting your Instructor ID **${member.instructorId}**! Please [update your public instructor profile](/myProfile) with a bio, photos, and links, and make sure to review the [Instructor Standard Operating Procedures (SOP)](${environment.links.instructorSopPath}) in the Instructors Area.`,
       createdAt: new Date().toISOString(),
       dismissed: false,
       data: {
@@ -402,6 +403,8 @@ export async function handleInstructorActivation(
         memberId: member.memberId || '',
         instructorId: member.instructorId || '',
         email: (member.emails || [])[0] || '',
+        appBase: environment.links.appBase,
+        instructorSopUrl: `${environment.links.appBase}${environment.links.instructorSopPath}`,
       });
     } catch (error) {
       logger.error(`Failed to enqueue welcome email for instructor ${member.docId}:`, error);

--- a/src/app/settings/email-templates/email-templates.ts
+++ b/src/app/settings/email-templates/email-templates.ts
@@ -25,12 +25,15 @@ export class EmailTemplatesComponent {
     { token: '{name}' },
     { token: '{memberId}' },
     { token: '{email}' },
+    { token: '{appBase}' },
   ];
   readonly instructorChips: EditorChip[] = [
     { token: '{name}' },
     { token: '{memberId}' },
     { token: '{instructorId}' },
     { token: '{email}' },
+    { token: '{appBase}' },
+    { token: '{instructorSopUrl}' },
   ];
 
   // The email renderer only understands a subset of Markdown, so the body


### PR DESCRIPTION
## The bug

Reported against the instructor-activation notification: the links do nothing when clicked.

Notification markdown used legacy hash hrefs (`#/myProfile`). [`main.ts`](https://github.com/iislucas/ilc-members-manager/blob/main/src/main.ts#L9) rewrites `#/…` → `/…` for compatibility with old shared links, but **only once, at boot**. Clicking such a link inside the already-running SPA just sets the fragment — no navigation, no re-boot. Notification links render as plain anchors (`markdown-viewer` does not intercept them), so a root-relative `/myProfile` navigates correctly.

## Scope

The reported notification was one instance of a systemic bug. Every server-generated notification link was affected:

| Where | Was | Now |
| --- | --- | --- |
| Instructor activation | `#/myProfile`, `#/instructors-area/post/sop` | `/myProfile`, configurable SOP path |
| Membership activation | `#/members-area` | `/members-area` |
| Grading notifications (×6) | `#/gradings/{id}` | `/gradings/{id}` |

The grading ones were masked by the separate "View grading" button, which builds its href through `routingService` and worked.

## Two independent bugs found along the way

**1. The SOP link pointed at a post that does not exist.** No doc in `instructors-post` has `urlId: 'sop'`, so that link would have 404'd even with the `#` removed. It now points at `instructor-packet` ("Instructor Packet"). Because which post holds the SOP is *content*, the path is now configuration (`environment.links.instructorSopPath`) rather than a literal in a template string.

**2. The activation emails linked to `members.iliqchuan.com`, which does not exist.** Now `app.iliqchuan.com`, via config.

## Design note

`email-templates.ts` is reachable from the Angular build (`data-model.ts` → `initEmailTemplates`), and `functions/src/environment/environment.ts` is gitignored — so importing the environment there would break a fresh clone. Instead the bodies take `appBase` / `instructorSopUrl` as parameters: `sendTemplateEmail` passes the real values, `initEmailTemplates` passes the `{token}` form, matching how `{instructorId}` already works. The new tokens are exposed as editor chips in Settings.

## ⚠️ Deploy note

`FunctionsEnvironment` gains a required `links` block. `functions/src/environment/environment.ts` is gitignored, so **every deploy environment needs this added or it will not typecheck**:

```ts
links: {
  appBase: 'https://app.iliqchuan.com',
  instructorSopPath: '/instructors-area/post/instructor-packet',
},
```

## Verification

- `functions`: 250/250 tests pass, clean `tsc --noEmit`.
- client: 426/426 tests pass.
- Rendered the real notification markdown through the same `marked` the viewer uses → `href="/myProfile"`, `href="/instructors-area/post/instructor-packet"`.
- `curl`'d prod: `/myProfile`, `/instructors-area/post/instructor-packet`, `/members-area` all return 200.
- Added regression assertions that the markdown contains no `](#/` and that email links are absolute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)