### PR TITLE
feat(events): creator + a chosen subset of managers as public contacts

### DIFF
--- a/functions/src/data-model.ts
+++ b/functions/src/data-model.ts
@@ -1647,6 +1647,33 @@ export type EventDocument = {
   url: string;    // Download URL in Firebase Storage
 };
 
+// One publicly-listed contact for an event. Membership of `IlcEvent.contacts`
+// IS the "listed as a contact" flag: a contact must be the event's creator
+// (ownerDocId) or one of its managerDocIds, and onEventUpdated prunes entries
+// that are neither. The display fields are cached on the (publicly readable)
+// event because /members is not public, so a visitor cannot resolve a member
+// doc ID into a name. `contactEmail`/`contactUrl` are opt-in and typed by the
+// editor — a member's own emails are never copied here automatically.
+export type EventContact = {
+  memberDocId: string;
+  name: string;          // Cached member name / contact display name.
+  memberId: string;      // Cached human-readable memberId.
+  instructorId: string;  // Cached instructorId, or '' if not an instructor.
+  contactEmail: string;  // Optional public contact email.
+  contactUrl: string;    // Optional public contact link.
+};
+
+export function initEventContact(): EventContact {
+  return {
+    memberDocId: '',
+    name: '',
+    memberId: '',
+    instructorId: '',
+    contactEmail: '',
+    contactUrl: '',
+  };
+}
+
 // A single unified event type. All events live in /events/{docId}.
 // Calendar-synced events have kind='calendar-sourced' and status='listed'.
 // Member-proposed events have kind='firebase-sourced' and status='proposed'.
@@ -1669,12 +1696,14 @@ export type IlcEvent = {
   googleCalEventLink?: string;
   kind: EventSourceKind;  // used by sync pruning
   createdAt?: string;      // ISO date-time
-  // The event owner / main contact. `ownerDocId` is the member's Firestore doc ID
-  // and stays the authoritative membership field (used by firestore.rules, the
-  // /members/{docId}/events mirror, and notifications). The owner does NOT need to
-  // be an instructor; the fields below cache the owner's identity and an optional
-  // inline "mini-profile" contact so a non-instructor can be the contact without
-  // depending on an instructorId. '' throughout when there is no owner.
+  // The event creator (historically called the owner; the field names are kept).
+  // `ownerDocId` is the member's Firestore doc ID and stays the authoritative
+  // membership field (used by firestore.rules, the /members/{docId}/events
+  // mirror, and notifications). The creator does NOT need to be an instructor;
+  // the fields below cache their identity and an optional inline "mini-profile"
+  // contact so a non-instructor can be listed as a contact without depending on
+  // an instructorId. '' throughout when there is no creator. Who is shown
+  // publicly is `contacts` below, NOT this field.
   ownerDocId: string;
   ownerEmails: string[];
   ownerName: string;          // Cached member name / contact display name.
@@ -1690,6 +1719,10 @@ export type IlcEvent = {
   schoolDocId: string; // Firestore doc ID of the associated school, or ''.
   managerDocIds: string[];
   managerEmails: string[];
+  // The subset of the creator + managers that is listed publicly as a contact
+  // for the event, in display order. Empty means "nobody chosen" — the UI then
+  // falls back to the creator, and then to the leading instructor.
+  contacts: EventContact[];
   // Attached documents (max 10). Each entry has a display name and a
   // Firebase Storage download URL.
   documents: EventDocument[];
@@ -1723,13 +1756,14 @@ export function initEvent(): IlcEvent {
     schoolDocId: '',
     managerDocIds: [],
     managerEmails: [],
+    contacts: [],
     documents: [],
     updatedByEmail: '',
   };
 }
 
-// A normalised view of an event's owner / main contact for display. Callers must
-// NOT branch on the owner being an instructor: `instructorId` is only a hint for
+// A normalised view of an event's creator for display. Callers must
+// NOT branch on the creator being an instructor: `instructorId` is only a hint for
 // optionally linking to the public instructor profile page. `hasMiniProfile` is
 // independent — an instructor owner may also set an event-specific contact.
 export type EventOwnerContact = {
@@ -1769,6 +1803,41 @@ export function eventOwnerContact(event: {
     contactUrl,
     hasMiniProfile: contactEmail !== '' || contactUrl !== '',
   };
+}
+
+// The event fields `contactFromCreator` / `eventContacts` read. Every field is
+// optional so old event documents (and partial form models) can be passed in.
+export type EventContactFields = {
+  contacts?: EventContact[];
+  ownerDocId?: string;
+  ownerName?: string;
+  ownerMemberId?: string;
+  ownerInstructorId?: string;
+  ownerContactEmail?: string;
+  ownerContactUrl?: string;
+  ownerEmails?: string[];
+};
+
+// Build the contact entry for an event's creator from the cached owner* fields.
+// Returns null when the event has no creator.
+export function contactFromCreator(event: EventContactFields): EventContact | null {
+  const creator = eventOwnerContact(event);
+  if (!creator.hasOwner) return null;
+  const { hasOwner: _, hasMiniProfile: __, ...contact } = creator;
+  return contact;
+}
+
+// Resolve the contacts to list publicly for an event: the explicitly chosen
+// `contacts`, or — when nobody has been chosen — the creator, so events that
+// predate the contacts list still show someone. An empty result means the
+// caller should fall back to the leading instructor.
+export function eventContacts(event: EventContactFields): EventContact[] {
+  const listed = (event.contacts || []).filter((c) => c && c.memberDocId);
+  if (listed.length > 0) {
+    return listed.map((c) => ({ ...initEventContact(), ...c }));
+  }
+  const creator = contactFromCreator(event);
+  return creator ? [creator] : [];
 }
 
 // A single cached blog post with only the fields the UI needs.

--- a/functions/src/proposed-events.spec.ts
+++ b/functions/src/proposed-events.spec.ts
@@ -1,7 +1,7 @@
 /* proposed-events.spec.ts — tests for event proposal validation. */
 import { describe, it, expect } from 'vitest';
-import { validateProposal, buildManagerDocIds } from './proposed-events';
-import { Member, MembershipType } from './data-model';
+import { validateProposal, buildManagerDocIds, resolveEventContacts, sameContacts } from './proposed-events';
+import { EventContact, Member, MembershipType, initEventContact } from './data-model';
 
 describe('validateProposal', () => {
   const validMember: Member = {
@@ -68,5 +68,87 @@ describe('buildManagerDocIds', () => {
 
   it('removes empty entries and de-duplicates', () => {
     expect(buildManagerDocIds(['mgr-a', '', 'mgr-a', ''], 'member-1')).toEqual(['mgr-a', 'member-1']);
+  });
+});
+
+describe('resolveEventContacts', () => {
+  const members: Record<string, Partial<Member>> = {
+    'owner-1': { name: 'Owner One', memberId: 'MEM-1', instructorId: 'I-1' },
+    'mgr-a': { name: 'Manager A', memberId: 'MEM-2', instructorId: '' },
+  };
+  const loadMember = async (docId: string) => members[docId] as Member | undefined;
+
+  const contact = (memberDocId: string, over: Partial<EventContact> = {}): EventContact =>
+    ({ ...initEventContact(), memberDocId, ...over });
+
+  it('drops contacts who are neither the creator nor a manager', async () => {
+    const result = await resolveEventContacts(
+      [contact('owner-1'), contact('ex-mgr'), contact('mgr-a')],
+      'owner-1', ['mgr-a'], loadMember,
+    );
+    expect(result.map((c) => c.memberDocId)).toEqual(['owner-1', 'mgr-a']);
+  });
+
+  it('refreshes cached identifiers but keeps typed-in name and contact details', async () => {
+    const result = await resolveEventContacts(
+      [contact('owner-1', {
+        name: 'Ring the school',
+        memberId: 'STALE',
+        instructorId: 'STALE',
+        contactEmail: 'hi@example.com',
+        contactUrl: 'https://example.com',
+      })],
+      'owner-1', [], loadMember,
+    );
+    expect(result).toEqual([{
+      memberDocId: 'owner-1',
+      name: 'Ring the school',
+      memberId: 'MEM-1',
+      instructorId: 'I-1',
+      contactEmail: 'hi@example.com',
+      contactUrl: 'https://example.com',
+    }]);
+  });
+
+  it('fills a missing name from the member and de-duplicates', async () => {
+    const result = await resolveEventContacts(
+      [contact('mgr-a'), contact('mgr-a')], '', ['mgr-a'], loadMember,
+    );
+    expect(result).toEqual([{
+      memberDocId: 'mgr-a',
+      name: 'Manager A',
+      memberId: 'MEM-2',
+      instructorId: '',
+      contactEmail: '',
+      contactUrl: '',
+    }]);
+  });
+
+  it('keeps the cached fields when the member document is gone', async () => {
+    const result = await resolveEventContacts(
+      [contact('mgr-gone', { name: 'Gone', memberId: 'MEM-9', instructorId: 'I-9' })],
+      '', ['mgr-gone'], loadMember,
+    );
+    expect(result[0]).toMatchObject({ name: 'Gone', memberId: 'MEM-9', instructorId: 'I-9' });
+  });
+});
+
+describe('sameContacts', () => {
+  const a: EventContact = {
+    memberDocId: 'owner-1', name: 'Owner One', memberId: 'MEM-1',
+    instructorId: 'I-1', contactEmail: '', contactUrl: '',
+  };
+
+  it('ignores the key order Firestore returns fields in', () => {
+    const reordered = JSON.parse(JSON.stringify({
+      contactUrl: '', contactEmail: '', instructorId: 'I-1',
+      memberId: 'MEM-1', name: 'Owner One', memberDocId: 'owner-1',
+    })) as EventContact;
+    expect(sameContacts([a], [reordered])).toBe(true);
+  });
+
+  it('is sensitive to order and content', () => {
+    expect(sameContacts([a], [])).toBe(false);
+    expect(sameContacts([a], [{ ...a, name: 'Someone Else' }])).toBe(false);
   });
 });

--- a/functions/src/proposed-events.ts
+++ b/functions/src/proposed-events.ts
@@ -12,7 +12,7 @@ import { onCall, HttpsError, CallableRequest } from 'firebase-functions/v2/https
 import { onDocumentCreated, onDocumentUpdated, onDocumentDeleted } from 'firebase-functions/v2/firestore';
 import * as admin from 'firebase-admin';
 import * as logger from 'firebase-functions/logger';
-import { IlcEvent, EventStatus, EventSourceKind, Member, EventDocument, initEvent, NotificationKind } from './data-model';
+import { IlcEvent, EventStatus, EventSourceKind, Member, EventDocument, EventContact, initEvent, initEventContact, contactFromCreator, NotificationKind } from './data-model';
 import { getMemberByEmail, allowedOrigins, hasActiveMembership } from './common';
 import { createMemberNotification } from './notifications';
 import axios from 'axios';
@@ -106,6 +106,64 @@ export function buildManagerDocIds(
   );
 }
 
+/** Loads member documents on demand, caching each doc ID's result. */
+function memberLoader(db: admin.firestore.Firestore) {
+  const cache = new Map<string, Member | undefined>();
+  return async (docId: string): Promise<Member | undefined> => {
+    if (!docId) return undefined;
+    if (!cache.has(docId)) {
+      const snap = await db.collection('members').doc(docId).get();
+      cache.set(docId, snap.data() as Member | undefined);
+    }
+    return cache.get(docId);
+  };
+}
+
+/**
+ * The contacts to store on an event: every entry that still belongs to the
+ * organising team (the creator or a manager), de-duplicated and with its cached
+ * display fields refreshed from the member document. Membership of the list is
+ * the "listed publicly" flag, so the pruning here is what drops a removed
+ * manager from the public page. The editor owns the ordering and the opt-in
+ * contactEmail/contactUrl, so those are preserved exactly as typed.
+ */
+export async function resolveEventContacts(
+  contacts: EventContact[] | undefined,
+  ownerDocId: string,
+  managerDocIds: string[],
+  loadMember: (docId: string) => Promise<Member | undefined>,
+): Promise<EventContact[]> {
+  const allowed = new Set([ownerDocId, ...(managerDocIds || [])].filter(Boolean));
+  const resolved: EventContact[] = [];
+  const seen = new Set<string>();
+  for (const contact of contacts || []) {
+    const docId = contact?.memberDocId || '';
+    if (!docId || !allowed.has(docId) || seen.has(docId)) continue;
+    seen.add(docId);
+    const member = await loadMember(docId);
+    resolved.push({
+      ...initEventContact(),
+      ...contact,
+      // A typed-in display name wins; identifiers always follow the member doc
+      // so that e.g. losing an instructorId also drops the instructor link.
+      name: contact.name || member?.name || '',
+      memberId: member ? member.memberId || '' : contact.memberId || '',
+      instructorId: member ? member.instructorId || '' : contact.instructorId || '',
+    });
+  }
+  return resolved;
+}
+
+/** Order-sensitive but key-order-independent comparison of two contact lists. */
+export function sameContacts(a: EventContact[], b: EventContact[]): boolean {
+  const norm = (list: EventContact[]) =>
+    JSON.stringify(list.map((c) => {
+      const entry = c as unknown as Record<string, unknown>;
+      return Object.keys(entry).sort().map((k) => [k, entry[k]]);
+    }));
+  return norm(a) === norm(b);
+}
+
 export function validateProposal(member: Member, data: Record<string, unknown>): string | null {
   if (!member.memberId || member.memberId.trim() === '') {
     return 'Must have a valid Member ID to propose events.';
@@ -125,7 +183,7 @@ export function validateProposal(member: Member, data: Record<string, unknown>):
 // Submit a new event proposal — writes directly to /events with status='proposed'.
 export const submitProposedEvent = onCall(
   { cors: allowedOrigins },
-  async (request: CallableRequest<{ title: string; start: string; end: string; description?: string; location?: string; leadingInstructorId?: string; ownerDocId?: string; managerDocIds?: string[]; ownerContactName?: string; ownerContactEmail?: string; ownerContactUrl?: string }>) => {
+  async (request: CallableRequest<{ title: string; start: string; end: string; description?: string; location?: string; leadingInstructorId?: string; ownerDocId?: string; managerDocIds?: string[]; contactDocIds?: string[]; ownerContactName?: string; ownerContactEmail?: string; ownerContactUrl?: string }>) => {
     if (!request.auth || !request.auth.token.email) {
       throw new HttpsError('unauthenticated', 'Must be authenticated to propose events.');
     }
@@ -183,6 +241,25 @@ export const submitProposedEvent = onCall(
       }
     }
 
+    // Who is listed publicly as a contact. The creator is a contact by default;
+    // the form may also tick managers, whose display fields are resolved from
+    // their member documents (no email/link — those are typed in the editor).
+    const creatorContact = contactFromCreator({
+      ownerDocId, ownerName, ownerMemberId, ownerInstructorId, ownerContactEmail, ownerContactUrl,
+    });
+    const requestedContactDocIds = (data.contactDocIds || []).filter(Boolean);
+    const contacts = await resolveEventContacts(
+      requestedContactDocIds.length > 0
+        ? requestedContactDocIds.map((memberDocId) =>
+          memberDocId === ownerDocId && creatorContact
+            ? creatorContact
+            : { ...initEventContact(), memberDocId })
+        : creatorContact ? [creatorContact] : [],
+      ownerDocId,
+      managerDocIds,
+      memberLoader(db),
+    );
+
     const event: Omit<IlcEvent, 'docId'> = {
       ...initEvent(),
       title: data.title,
@@ -200,6 +277,7 @@ export const submitProposedEvent = onCall(
       ownerInstructorId,
       ownerContactEmail,
       ownerContactUrl,
+      contacts,
       leadingInstructorId: data.leadingInstructorId || '',
     };
 
@@ -278,15 +356,19 @@ export const onEventUpdated = onDocumentUpdated('/events/{docId}', async (event)
 
   // Resolve emails if missing or if owner/managers changed. Done after
   // mirroring (above) so a membership change is never lost.
-  const ownerDoc = await db.collection('members').doc(after.ownerDocId).get();
-  const ownerEmails = ownerDoc.data()?.emails || [];
+  const loadMember = memberLoader(db);
+  const ownerEmails = (await loadMember(after.ownerDocId))?.emails || [];
 
   const managerEmails: string[] = [];
   for (const id of (after.managerDocIds || [])) {
-    const mgrDoc = await db.collection('members').doc(id).get();
-    const emails = mgrDoc.data()?.emails || [];
-    managerEmails.push(...emails);
+    managerEmails.push(...((await loadMember(id))?.emails || []));
   }
+
+  // Drop contacts who are no longer on the organising team and refresh the
+  // display fields cached for the public event page.
+  const contacts = await resolveEventContacts(
+    after.contacts, after.ownerDocId, after.managerDocIds || [], loadMember,
+  );
 
   // Compare as order-independent multisets: the stored and freshly-derived
   // lists hold the same emails but their order depends on the member email
@@ -296,12 +378,18 @@ export const onEventUpdated = onDocumentUpdated('/events/{docId}', async (event)
     JSON.stringify([...a].sort()) === JSON.stringify([...b].sort());
   const ownerEmailsChanged = !sameEmails(ownerEmails, after.ownerEmails || []);
   const managerEmailsChanged = !sameEmails(managerEmails, after.managerEmails || []);
+  // Contacts are an ordered list, so compare position by position — but with
+  // each entry's keys sorted, since the field order Firestore returns need not
+  // match the order the objects are built in (a mismatch there would rewrite
+  // the document on every trigger, looping forever).
+  const contactsChanged = !sameContacts(contacts, after.contacts || []);
 
-  if (ownerEmailsChanged || managerEmailsChanged) {
-    logger.info(`Updating emails for event ${event.params.docId}.`);
+  if (ownerEmailsChanged || managerEmailsChanged || contactsChanged) {
+    logger.info(`Updating derived owner/manager/contact fields for event ${event.params.docId}.`);
     await event.data.after.ref.update({
       ownerEmails,
-      managerEmails
+      managerEmails,
+      contacts
     });
     return; // Let the follow-up trigger handle Google Calendar sync.
   }

--- a/scripts/backfill-event-contacts.ts
+++ b/scripts/backfill-event-contacts.ts
@@ -1,0 +1,159 @@
+/* backfill-event-contacts.ts
+ *
+ * One-off migration for the "creator + listed contacts" change to events.
+ *
+ * Background: an event's `ownerDocId` used to mean both "the creator" and "the
+ * public contact". It now only means the creator; who is listed publicly is the
+ * `contacts` array, whose members must be the creator or one of the managers
+ * (`managerDocIds`). This script brings old events into that shape:
+ *
+ *   - adds `ownerDocId` to `managerDocIds` if it isn't there (the creator was
+ *     always allowed to edit the event, so this only makes that explicit);
+ *   - adds the creator to `contacts` if the event has no entry for them, built
+ *     from the cached owner* fields, so the public page keeps showing exactly
+ *     who it showed before;
+ *   - mirrors the event into `members/{ownerDocId}/events/{eventId}` if adding
+ *     the creator as a manager made that mirror missing.
+ *
+ * Events without a creator are left alone.
+ *
+ * Idempotent: a second run makes no further writes.
+ *
+ * Usage (Application Default Credentials, like the other admin scripts):
+ *   # dry run — report what would change, write nothing:
+ *   pnpm --prefix functions exec ts-node -O '{"module":"commonjs"}' \
+ *     ../scripts/backfill-event-contacts.ts
+ *   # apply the changes:
+ *   pnpm --prefix functions exec ts-node -O '{"module":"commonjs"}' \
+ *     ../scripts/backfill-event-contacts.ts --commit
+ *   # target a different project (defaults to ilc-paris-class-tracker):
+ *   pnpm --prefix functions exec ts-node -O '{"module":"commonjs"}' \
+ *     ../scripts/backfill-event-contacts.ts --project=<project-id>
+ *   # against a running emulator (after `pnpm seed:emulator`):
+ *   FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 pnpm --prefix functions exec \
+ *     ts-node -O '{"module":"commonjs"}' \
+ *     ../scripts/backfill-event-contacts.ts --commit
+ *
+ * The local seed export in tmp/seed-data/ has already been migrated in place,
+ * so a fresh `pnpm seed:emulator` loads events in the new shape.
+ */
+
+import * as admin from 'firebase-admin';
+
+// Kept dependency-free (like reconcile-event-mirrors.ts) so it runs under
+// ts-node without the functions build; `creatorContact` below mirrors
+// `contactFromCreator` / `eventOwnerContact` in functions/src/data-model.ts.
+type EventContact = {
+  memberDocId: string;
+  name: string;
+  memberId: string;
+  instructorId: string;
+  contactEmail: string;
+  contactUrl: string;
+};
+
+const COMMIT = process.argv.includes('--commit');
+const DEFAULT_PROJECT = 'ilc-paris-class-tracker';
+const projectArg = process.argv.find((a) => a.startsWith('--project='));
+const PROJECT_ID = projectArg ? projectArg.split('=')[1] : DEFAULT_PROJECT;
+
+// Fields stripped from the per-member mirror copy (private; never shown there).
+const PRIVATE_FIELDS = ['ownerEmails', 'managerEmails'] as const;
+
+function mirrorData(canonical: Record<string, unknown>): Record<string, unknown> {
+  const copy = { ...canonical };
+  for (const f of PRIVATE_FIELDS) delete copy[f];
+  return copy;
+}
+
+// The contact entry for an event's creator: the cached owner* fields, topped up
+// from their member document. Events created before those fields existed have
+// none of them, and falling all the way back to an email would publish it as
+// the contact's display name.
+function creatorContact(
+  event: Record<string, unknown>,
+  member: Record<string, unknown> | undefined,
+): EventContact {
+  const str = (k: string) => (event[k] as string) || '';
+  const memberStr = (k: string) => (member?.[k] as string) || '';
+  const emails = (event['ownerEmails'] as string[]) || [];
+  const memberId = str('ownerMemberId') || memberStr('memberId');
+  return {
+    memberDocId: str('ownerDocId'),
+    name: str('ownerName') || memberStr('name') || memberId || emails[0] || '',
+    memberId,
+    instructorId: str('ownerInstructorId') || memberStr('instructorId'),
+    contactEmail: str('ownerContactEmail'),
+    contactUrl: str('ownerContactUrl'),
+  };
+}
+
+async function main() {
+  console.log(`Using project: ${PROJECT_ID}`);
+  console.log(COMMIT ? 'MODE: COMMIT (writes enabled)' : 'MODE: DRY RUN (no writes)');
+  admin.initializeApp({ projectId: PROJECT_ID });
+  const db = admin.firestore();
+
+  const eventsSnap = await db.collection('events').get();
+  console.log(`Loaded ${eventsSnap.size} events.`);
+
+  let managerAdds = 0;
+  let contactAdds = 0;
+  let mirrorAdds = 0;
+  let unchanged = 0;
+
+  for (const doc of eventsSnap.docs) {
+    const event = doc.data() as Record<string, unknown>;
+    const ownerDocId = (event['ownerDocId'] as string) || '';
+    if (!ownerDocId) {
+      unchanged++;
+      continue;
+    }
+
+    const managerDocIds = (event['managerDocIds'] as string[]) || [];
+    const contacts = (event['contacts'] as EventContact[]) || [];
+
+    const needsManager = !managerDocIds.includes(ownerDocId);
+    const needsContact = !contacts.some((c) => c && c.memberDocId === ownerDocId);
+    if (!needsManager && !needsContact) {
+      unchanged++;
+      continue;
+    }
+
+    const update: Record<string, unknown> = {};
+    if (needsManager) {
+      update['managerDocIds'] = [...managerDocIds, ownerDocId];
+      console.log(`ADD creator as manager: events/${doc.id} (${ownerDocId})`);
+      managerAdds++;
+    }
+    if (needsContact) {
+      // The onEventUpdated trigger refreshes the cached name/memberId/
+      // instructorId from the member document after this write.
+      const memberSnap = await db.collection('members').doc(ownerDocId).get();
+      const creator = creatorContact(event, memberSnap.data());
+      update['contacts'] = [...contacts, creator];
+      console.log(`ADD creator as contact: events/${doc.id} (${creator.name || ownerDocId})`);
+      contactAdds++;
+    }
+
+    if (COMMIT) await doc.ref.update(update);
+
+    // A creator who was not already a manager may have no mirror copy.
+    if (needsManager) {
+      const mirrorRef = db.collection('members').doc(ownerDocId)
+        .collection('events').doc(doc.id);
+      const mirrorSnap = await mirrorRef.get();
+      if (!mirrorSnap.exists) {
+        console.log(`CREATE missing mirror: members/${ownerDocId}/events/${doc.id}`);
+        if (COMMIT) await mirrorRef.set(mirrorData({ ...event, ...update }));
+        mirrorAdds++;
+      }
+    }
+  }
+
+  console.log(`\nDone. ${managerAdds} manager add(s), ${contactAdds} contact add(s), ` +
+    `${mirrorAdds} mirror create(s), ${unchanged} event(s) already correct.` +
+    (COMMIT ? '' : ' (dry run — re-run with --commit to apply)'));
+}
+
+main().then(() => process.exit(0)).catch((e) => { console.error(e); process.exit(1); });

--- a/src/app/event-edit/event-edit.html
+++ b/src/app/event-edit/event-edit.html
@@ -391,9 +391,9 @@
         <h3>Status & Metadata</h3>
 
         @if (ev) {
-        <label for="event-owner" class="align-top">Owner (contact)</label>
+        <label for="event-owner" class="align-top">Creator</label>
         <div class="rhs owner-editor">
-          <!-- Owner selector: a member search in non-instructor mode (admins only),
+          <!-- Creator selector: a member search in non-instructor mode (admins only),
                otherwise the shared instructor selector. -->
           @if (assignMemberAsOwner()) {
             @if (userIsAdmin()) {
@@ -418,13 +418,14 @@
                     }
                   </span>
                   <button type="button" class="subtle-button" (click)="clearOwner()">
-                    Clear owner
+                    Clear creator
                   </button>
                 }
               </div>
               @if (!eventFormModel().ownerDocId) {
                 <div class="note">
-                  No owner — the leading instructor will be shown as the contact.
+                  No creator — with no contacts listed, the leading instructor is
+                  shown as the contact.
                 </div>
               }
             }
@@ -437,7 +438,7 @@
               ></app-instructor-selector>
               @if (eventFormModel().ownerDocId) {
                 <button type="button" class="subtle-button" (click)="clearOwner()">
-                  Clear owner
+                  Clear creator
                 </button>
               }
             </div>
@@ -451,12 +452,24 @@
                 [checked]="assignMemberAsOwner()"
                 (change)="assignMemberAsOwner.set($any($event.target).checked)"
               />
-              List a non-instructor as the event owner &amp; contact
+              Allow a non-instructor to be the event creator
             </label>
           }
 
-          <!-- Mini-profile contact: only in "non-instructor owner" mode. -->
-          @if (assignMemberAsOwner()) {
+          <!-- Ticking this lists the creator publicly as a contact; the
+               mini-profile below is their optional public email/link. -->
+          @if (eventFormModel().ownerDocId) {
+            <label class="checkbox-row">
+              <input
+                type="checkbox"
+                [checked]="isListedContact(eventFormModel().ownerDocId)"
+                (change)="setContactListed(eventFormModel().ownerDocId, $any($event.target).checked)"
+              />
+              List the creator as a public contact for this event
+            </label>
+          }
+
+          @if (isListedContact(eventFormModel().ownerDocId)) {
             <div class="mini-profile">
               <label for="ownerContactName">Contact name</label>
               <input
@@ -486,7 +499,7 @@
           }
         </div>
 
-        <label>Managers</label>
+        <label class="align-top">Managers</label>
         <div class="rhs">
           @let managerIds = eventFormModel().managerDocIds;
           @for (managerId of managerIds; track $index; let last = $last) {
@@ -505,6 +518,36 @@
                 </button>
               }
             </div>
+            @if (managerId) {
+              <label class="checkbox-row manager-contact-row">
+                <input
+                  type="checkbox"
+                  [checked]="isListedContact(managerId)"
+                  (change)="setContactListed(managerId, $any($event.target).checked)"
+                />
+                List as a public contact
+              </label>
+              @if (contactFor(managerId); as contact) {
+                <div class="mini-profile manager-contact-profile">
+                  <label [for]="'contactEmail-' + $index">Contact email</label>
+                  <input
+                    [id]="'contactEmail-' + $index"
+                    type="email"
+                    [value]="contact.contactEmail"
+                    (input)="updateContactField(managerId, 'contactEmail', $event)"
+                    placeholder="them@example.com"
+                  />
+                  <label [for]="'contactUrl-' + $index">Contact link</label>
+                  <input
+                    [id]="'contactUrl-' + $index"
+                    type="url"
+                    [value]="contact.contactUrl"
+                    (input)="updateContactField(managerId, 'contactUrl', $event)"
+                    placeholder="https://…"
+                  />
+                </div>
+              }
+            }
           }
           @if (managerIds.length === 0) {
             <div>

--- a/src/app/event-edit/event-edit.scss
+++ b/src/app/event-edit/event-edit.scss
@@ -229,8 +229,8 @@
   gap: 4px;
 }
 
-// Owner / main-contact editor: stack the selector row, the mode toggle and (in
-// non-instructor mode) the mini-profile contact fields vertically.
+// Creator editor: stack the selector row, the toggles and (when the creator is
+// listed as a contact) the mini-profile contact fields vertically.
 .owner-editor {
   flex-direction: column;
   align-items: stretch;
@@ -256,43 +256,56 @@
     font-size: 0.85em;
   }
 
-  .checkbox-row {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    text-align: left;
+}
+
+// Shared by the creator editor and the manager rows: the "list as a public
+// contact" toggle, and the optional public email/link fields it reveals.
+.checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  text-align: left;
+  padding-left: 0;
+  cursor: pointer;
+  font-size: 0.95em;
+}
+
+.mini-profile {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 8px 12px;
+  align-items: center;
+  padding: 12px;
+  border: 1px solid v.$border-color-light;
+  border-radius: 6px;
+  background: v.$theme-bg-color;
+
+  label {
+    text-align: right;
     padding-left: 0;
-    cursor: pointer;
-    font-size: 0.95em;
+    font-size: 0.9em;
+    color: v.$text-secondary;
   }
 
-  .mini-profile {
-    display: grid;
-    grid-template-columns: auto 1fr;
-    gap: 8px 12px;
-    align-items: center;
-    padding: 12px;
-    border: 1px solid v.$border-color-light;
-    border-radius: 6px;
-    background: v.$theme-bg-color;
+  input {
+    width: 100%;
+  }
+
+  @media (max-width: 600px) {
+    grid-template-columns: 1fr;
 
     label {
-      text-align: right;
-      padding-left: 0;
-      font-size: 0.9em;
-      color: v.$text-secondary;
-    }
-
-    input {
-      width: 100%;
-    }
-
-    @media (max-width: 600px) {
-      grid-template-columns: 1fr;
-
-      label {
-        text-align: left;
-      }
+      text-align: left;
     }
   }
+}
+
+// Indent a manager's contact toggle and fields under the manager they belong to.
+.manager-contact-row,
+.manager-contact-profile {
+  margin-left: 1.5em;
+}
+
+.manager-contact-profile {
+  margin-bottom: 10px;
 }

--- a/src/app/event-edit/event-edit.spec.ts
+++ b/src/app/event-edit/event-edit.spec.ts
@@ -97,6 +97,7 @@ describe('EventEditComponent', () => {
       ownerContactEmail: '',
       ownerContactUrl: '',
       managerDocIds: [],
+      contacts: [],
       leadingInstructorId: '',
       schoolId: '',
       schoolDocId: '',
@@ -240,6 +241,19 @@ describe('EventEditComponent', () => {
     expect(component.eventFormModel().managerDocIds[0]).toBe('');
   });
 
+  it('should drop the contact listing when a manager row is cleared', () => {
+    component.eventFormModel.set({
+      ...component.eventFormModel(),
+      managerDocIds: ['manager-doc-id'],
+    });
+    component.setContactListed('manager-doc-id', true);
+
+    component.updateManagerDocId(0, 'Someone El');
+
+    expect(component.eventFormModel().managerDocIds[0]).toBe('');
+    expect(component.eventFormModel().contacts).toEqual([]);
+  });
+
   it('resolves a manager row for a non-admin (empty members cache)', async () => {
     // Only admins load the full `members` collection; on /my-events/{id}/edit
     // the viewer is usually an ordinary instructor with an empty members cache,
@@ -272,5 +286,113 @@ describe('EventEditComponent', () => {
     );
     expect(input.value).toBe('197');
     expect(fixture.nativeElement.textContent).toContain('Manager Name');
+  });
+
+  it('should list and unlist a manager as a public contact', () => {
+    (mockDataManagerService.members as any).setEntries([{
+      docId: 'manager-doc-id',
+      memberId: 'MEM-200',
+      instructorId: 'I-200',
+      name: 'Manager Name',
+    }]);
+    component.eventFormModel.set({
+      ...component.eventFormModel(),
+      managerDocIds: ['manager-doc-id'],
+    });
+
+    component.setContactListed('manager-doc-id', true);
+
+    expect(component.isListedContact('manager-doc-id')).toBe(true);
+    expect(component.contactFor('manager-doc-id')).toMatchObject({
+      memberDocId: 'manager-doc-id',
+      name: 'Manager Name',
+      memberId: 'MEM-200',
+      instructorId: 'I-200',
+    });
+
+    component.setContactListed('manager-doc-id', false);
+
+    expect(component.isListedContact('manager-doc-id')).toBe(false);
+    expect(component.eventFormModel().contacts).toEqual([]);
+  });
+
+  it('should drop a removed manager from the contacts', () => {
+    component.eventFormModel.set({
+      ...component.eventFormModel(),
+      managerDocIds: ['manager-doc-id'],
+    });
+    component.setContactListed('manager-doc-id', true);
+
+    component.removeManagerDocId(0);
+
+    expect(component.eventFormModel().managerDocIds).toEqual([]);
+    expect(component.eventFormModel().contacts).toEqual([]);
+  });
+
+  it('should hand the creator listing to a newly assigned creator', () => {
+    const mockInstructor = {
+      docId: 'instructor-member-doc-id',
+      instructorId: 'I-101',
+      memberId: 'MEM-101',
+      name: 'Instructor Name',
+    };
+    (mockDataManagerService.instructors as any).setEntries([mockInstructor]);
+    component.eventFormModel.set({
+      ...component.eventFormModel(),
+      ownerDocId: 'old-owner-doc-id',
+      ownerName: 'Old Owner',
+    });
+    component.setContactListed('old-owner-doc-id', true);
+
+    component.updateOwnerInstructor('I-101');
+
+    expect(component.eventFormModel().contacts).toEqual([{
+      memberDocId: 'instructor-member-doc-id',
+      name: 'Instructor Name',
+      memberId: 'MEM-101',
+      instructorId: 'I-101',
+      contactEmail: '',
+      contactUrl: '',
+    }]);
+  });
+
+  it('should save only creator/manager contacts, with the creator details', async () => {
+    component.event.set({
+      docId: 'test-doc-id',
+      title: 'Title',
+      ownerDocId: 'owner-id',
+    } as IlcEvent);
+    component.eventFormModel.set({
+      ...component.eventFormModel(),
+      title: 'Title',
+      start: '2026-04-13',
+      end: '2026-04-13',
+      ownerDocId: 'owner-id',
+      ownerName: 'Owner Name',
+      ownerMemberId: 'MEM-1',
+      ownerInstructorId: 'I-1',
+      ownerContactEmail: 'owner@example.com',
+      ownerContactUrl: 'https://example.com',
+      managerDocIds: ['manager-doc-id'],
+      contacts: [
+        { memberDocId: 'owner-id', name: 'stale', memberId: '', instructorId: '', contactEmail: '', contactUrl: '' },
+        { memberDocId: 'ex-manager-doc-id', name: 'Gone', memberId: '', instructorId: '', contactEmail: '', contactUrl: '' },
+      ],
+    });
+
+    await component.saveEvent({ preventDefault: vi.fn() } as unknown as Event);
+
+    expect(component.errorMessage()).toBe(null);
+    const saved = (updateDoc as any).mock.calls.at(-1)[1];
+    // Round-tripped through JSON: the form model tags its objects with symbol
+    // properties that a direct deep-equality would trip over.
+    expect(JSON.parse(JSON.stringify(saved.contacts))).toEqual([{
+      memberDocId: 'owner-id',
+      name: 'Owner Name',
+      memberId: 'MEM-1',
+      instructorId: 'I-1',
+      contactEmail: 'owner@example.com',
+      contactUrl: 'https://example.com',
+    }]);
   });
 });

--- a/src/app/event-edit/event-edit.ts
+++ b/src/app/event-edit/event-edit.ts
@@ -25,7 +25,7 @@ import {
   required,
   FieldTree,
 } from '@angular/forms/signals';
-import { IlcEvent, EventStatus, EventSourceKind, eventStatusLabel, initEvent, InstructorPublicData, Member, EventDocument, School } from '../../../functions/src/data-model';
+import { IlcEvent, EventStatus, EventSourceKind, eventStatusLabel, initEvent, initEventContact, InstructorPublicData, Member, EventContact, EventDocument, School } from '../../../functions/src/data-model';
 import { IconComponent } from '../icons/icon.component';
 import { DataManagerService } from '../data-manager.service';
 import { SpinnerComponent } from '../spinner/spinner.component';
@@ -69,11 +69,38 @@ type EventFormModel = {
   ownerContactEmail: string;
   ownerContactUrl: string;
   managerDocIds: string[];
+  // The creator/managers listed publicly as contacts. Membership IS the flag.
+  contacts: EventContact[];
   leadingInstructorId: string;
   schoolId: string;
   schoolDocId: string;
   documents: EventDocument[];
 };
+
+// Whether a member is listed as a public contact in the given form model.
+function isContactIn(model: EventFormModel, memberDocId: string): boolean {
+  return !!memberDocId && model.contacts.some((c) => c.memberDocId === memberDocId);
+}
+
+// The contacts to persist: only the creator and current managers, with the
+// creator's entry taking its display name and contact details from the owner*
+// fields (the single place those are edited).
+function contactsToSave(model: EventFormModel): EventContact[] {
+  const allowed = new Set(
+    [model.ownerDocId, ...model.managerDocIds].filter(Boolean));
+  return model.contacts
+    .filter((c) => allowed.has(c.memberDocId))
+    .map((c) => c.memberDocId === model.ownerDocId
+      ? {
+        ...c,
+        name: model.ownerName,
+        memberId: model.ownerMemberId,
+        instructorId: model.ownerInstructorId,
+        contactEmail: model.ownerContactEmail,
+        contactUrl: model.ownerContactUrl,
+      }
+      : c);
+}
 
 // A single private event material file, as presented in the UI. Materials live
 // only in Cloud Storage (not on the public event doc); see the materials
@@ -106,6 +133,7 @@ function toFormModel(event: IlcEvent): EventFormModel {
     ownerContactEmail: event.ownerContactEmail || '',
     ownerContactUrl: event.ownerContactUrl || '',
     managerDocIds: event.managerDocIds || [],
+    contacts: (event.contacts || []).map((c) => ({ ...initEventContact(), ...c })),
     leadingInstructorId: event.leadingInstructorId || '',
     schoolId: event.schoolId || '',
     schoolDocId: event.schoolDocId || '',
@@ -168,6 +196,7 @@ export class EventEditComponent implements OnInit {
     ownerContactEmail: '',
     ownerContactUrl: '',
     managerDocIds: [],
+    contacts: [],
     leadingInstructorId: '',
     schoolId: '',
     schoolDocId: '',
@@ -482,15 +511,14 @@ export class EventEditComponent implements OnInit {
     return match ? match[1] : value.trim();
   }
 
-  // Assign the owner from the instructor autocomplete. Caches the instructor's
+  // Assign the creator from the instructor autocomplete. Caches the instructor's
   // identity and clears any inline mini-profile (the instructor's own profile is
   // the contact).
   updateOwnerInstructor(value: string) {
     const instructorId = this.extractInstructorId(value);
     const instructor = this.dataService.instructors.get(instructorId);
     if (!instructor) return;
-    this.eventFormModel.update((m) => ({
-      ...m,
+    this.eventFormModel.update((m) => this.applyCreatorChange(m, {
       ownerDocId: instructor.docId,
       ownerName: instructor.name,
       ownerMemberId: instructor.memberId,
@@ -500,18 +528,19 @@ export class EventEditComponent implements OnInit {
     }));
   }
 
-  // Assign the owner from the member autocomplete (admin-only). Caches the
+  // Assign the creator from the member autocomplete (admin-only). Caches the
   // member's identity; instructorId may be '' for a non-instructor.
   updateOwnerMember(value: string) {
     const memberId = this.extractMemberId(value);
     const member = this.dataService.getMemberByMemberId(memberId);
     if (!member) return;
-    this.eventFormModel.update((m) => ({
-      ...m,
+    this.eventFormModel.update((m) => this.applyCreatorChange(m, {
       ownerDocId: member.docId,
       ownerName: member.name,
       ownerMemberId: member.memberId,
       ownerInstructorId: member.instructorId || '',
+      ownerContactEmail: m.ownerContactEmail,
+      ownerContactUrl: m.ownerContactUrl,
     }));
   }
 
@@ -524,8 +553,7 @@ export class EventEditComponent implements OnInit {
   });
 
   clearOwner() {
-    this.eventFormModel.update((m) => ({
-      ...m,
+    this.eventFormModel.update((m) => this.applyCreatorChange(m, {
       ownerDocId: '',
       ownerName: '',
       ownerMemberId: '',
@@ -576,8 +604,15 @@ export class EventEditComponent implements OnInit {
     const instructor = this.dataService.instructors.get(instructorId);
     this.eventFormModel.update((m) => {
       const managerDocIds = [...m.managerDocIds];
-      managerDocIds[index] = instructor?.docId || '';
-      return { ...m, managerDocIds };
+      const previousDocId = managerDocIds[index] || '';
+      const nextDocId = instructor?.docId || '';
+      managerDocIds[index] = nextDocId;
+      const next = { ...m, managerDocIds };
+      // A listed manager who is swapped out hands their contact listing to
+      // whoever replaces them; clearing the row drops the listing entirely.
+      if (!isContactIn(m, previousDocId) || previousDocId === m.ownerDocId) return next;
+      const withoutPrevious = this.withoutContact(next, previousDocId);
+      return nextDocId ? this.withContact(withoutPrevious, nextDocId) : withoutPrevious;
     });
   }
 
@@ -589,10 +624,98 @@ export class EventEditComponent implements OnInit {
   }
 
   removeManagerDocId(index: number) {
+    this.eventFormModel.update((m) => {
+      const removedDocId = m.managerDocIds[index] || '';
+      const next = {
+        ...m,
+        managerDocIds: m.managerDocIds.filter((_, i) => i !== index),
+      };
+      // Someone who is no longer on the team can no longer be a contact —
+      // unless they are the creator, who is on the team either way.
+      return removedDocId && removedDocId !== m.ownerDocId
+        ? this.withoutContact(next, removedDocId)
+        : next;
+    });
+  }
+
+  // --- Publicly listed contacts ----------------------------------------
+  // Membership of `contacts` is the "listed as a contact" flag; only the
+  // creator and the managers may appear in it. The creator's entry takes its
+  // display name and contact details from the owner* fields at save time (they
+  // stay the single place those are edited), so entries here for the creator
+  // hold no separately-edited state.
+
+  isListedContact(memberDocId: string): boolean {
+    return isContactIn(this.eventFormModel(), memberDocId);
+  }
+
+  contactFor(memberDocId: string): EventContact | undefined {
+    return this.eventFormModel().contacts.find((c) => c.memberDocId === memberDocId);
+  }
+
+  setContactListed(memberDocId: string, listed: boolean) {
+    if (!memberDocId) return;
+    this.eventFormModel.update((m) =>
+      listed ? this.withContact(m, memberDocId) : this.withoutContact(m, memberDocId));
+  }
+
+  updateContactField(
+    memberDocId: string,
+    field: 'contactEmail' | 'contactUrl',
+    event: Event,
+  ) {
+    const value = (event.target as HTMLInputElement).value;
     this.eventFormModel.update((m) => ({
       ...m,
-      managerDocIds: m.managerDocIds.filter((_, i) => i !== index)
+      contacts: m.contacts.map((c) =>
+        c.memberDocId === memberDocId ? { ...c, [field]: value } : c),
     }));
+  }
+
+  // Add a contact entry, caching what we know of the member for display. The
+  // onEventUpdated trigger refreshes these fields server-side after each save.
+  private withContact(m: EventFormModel, memberDocId: string): EventFormModel {
+    if (!memberDocId || m.contacts.some((c) => c.memberDocId === memberDocId)) return m;
+    const member = this.dataService.members.get(memberDocId);
+    const contact: EventContact = memberDocId === m.ownerDocId
+      ? {
+        memberDocId,
+        name: m.ownerName,
+        memberId: m.ownerMemberId,
+        instructorId: m.ownerInstructorId,
+        contactEmail: m.ownerContactEmail,
+        contactUrl: m.ownerContactUrl,
+      }
+      : {
+        ...initEventContact(),
+        memberDocId,
+        name: member?.name || '',
+        memberId: member?.memberId || '',
+        instructorId: member?.instructorId || '',
+      };
+    return { ...m, contacts: [...m.contacts, contact] };
+  }
+
+  private withoutContact(m: EventFormModel, memberDocId: string): EventFormModel {
+    return { ...m, contacts: m.contacts.filter((c) => c.memberDocId !== memberDocId) };
+  }
+
+  // Swap in a new creator. The outgoing creator's contact entry goes unless
+  // they are also a manager, and the incoming creator inherits the "listed"
+  // state so an event never silently loses its only contact.
+  private applyCreatorChange(
+    m: EventFormModel,
+    creator: Pick<EventFormModel,
+      'ownerDocId' | 'ownerName' | 'ownerMemberId' | 'ownerInstructorId'
+      | 'ownerContactEmail' | 'ownerContactUrl'>,
+  ): EventFormModel {
+    const wasListed = isContactIn(m, m.ownerDocId);
+    const previousWasManager = m.managerDocIds.includes(m.ownerDocId);
+    let next: EventFormModel = { ...m, ...creator };
+    if (m.ownerDocId && !previousWasManager) {
+      next = this.withoutContact(next, m.ownerDocId);
+    }
+    return wasListed ? this.withContact(next, creator.ownerDocId) : next;
   }
 
   // Document management methods
@@ -859,6 +982,8 @@ export class EventEditComponent implements OnInit {
     try {
       const docRef = doc(this.db, 'events', eventData.docId);
       const formData = this.editableEvent();
+      const managerDocIds = formData.managerDocIds.filter(Boolean);
+      const contacts = contactsToSave({ ...formData, managerDocIds });
       await updateDoc(docRef, {
         title: formData.title,
         start: formData.start,
@@ -876,7 +1001,8 @@ export class EventEditComponent implements OnInit {
         ownerInstructorId: formData.ownerInstructorId,
         ownerContactEmail: formData.ownerContactEmail,
         ownerContactUrl: formData.ownerContactUrl,
-        managerDocIds: formData.managerDocIds.filter(Boolean),
+        managerDocIds,
+        contacts,
         leadingInstructorId: formData.leadingInstructorId,
         schoolId: formData.schoolId,
         schoolDocId: formData.schoolDocId,
@@ -886,11 +1012,15 @@ export class EventEditComponent implements OnInit {
         updatedByEmail: this.firebaseState.user()?.firebaseUser.email || '',
       });
       this.successMessage.set('Event saved successfully.');
+      // Mirror the persisted manager/contact lists back into the form model so
+      // isDirty resets (both are normalised on the way out).
+      this.eventFormModel.update((m) => ({ ...m, managerDocIds, contacts }));
       // Update the local event data so isDirty resets
       this.event.set({
         ...eventData,
         ...formData,
-        managerDocIds: formData.managerDocIds.filter(Boolean),
+        managerDocIds,
+        contacts,
         descriptionMarkdown: formData.description,
         status: formData.status as EventStatus,
         heroImageUrl: formData.heroImageUrl,

--- a/src/app/events-calendar/event-item/event-item.html
+++ b/src/app/events-calendar/event-item/event-item.html
@@ -68,15 +68,25 @@
         }
         @if (contactLabel()) {
           <div>
-          <a class="instructor-link"
-            [href]="contactLink()"
-            title="View contact profile"
-            (click)="$event.stopPropagation()">
-            <span class="icon-only-button">
-              <app-icon name="person"></app-icon>
+          <!-- A contact who isn't an instructor has no profile to link to. -->
+          @if (contactLink()) {
+            <a class="instructor-link"
+              [href]="contactLink()"
+              title="View contact profile"
+              (click)="$event.stopPropagation()">
+              <span class="icon-only-button">
+                <app-icon name="person"></app-icon>
+              </span>
+              <span class="detail-text">Contact: {{ contactLabel() }}</span>
+            </a>
+          } @else {
+            <span class="instructor-link">
+              <span class="icon-only-button">
+                <app-icon name="person"></app-icon>
+              </span>
+              <span class="detail-text">Contact: {{ contactLabel() }}</span>
             </span>
-            <span class="detail-text">Contact: {{ contactLabel() }}</span>
-          </a>
+          }
           </div>
         }
       </div>

--- a/src/app/events-calendar/event-item/event-item.ts
+++ b/src/app/events-calendar/event-item/event-item.ts
@@ -6,7 +6,7 @@ import {
   input,
   signal,
 } from '@angular/core';
-import { IlcEvent } from '../../../../functions/src/data-model';
+import { IlcEvent, eventContacts } from '../../../../functions/src/data-model';
 import { IconComponent } from '../../icons/icon.component';
 import { formatDateRange } from '../format-date-range';
 import { FindInstructorsService } from '../../find-instructors.service';
@@ -54,30 +54,38 @@ export class EventItemComponent {
     return `/instructors/${encodeURIComponent(id)}`;
   });
 
-  // Resolve the event owner (contact) to a display label.
-  // Only shows when the owner is different from the leading instructor.
-  readonly contactLabel = computed(() => {
-    const ownerDocId = this.event().ownerDocId;
-    if (!ownerDocId) return '';
-    const owner = this.findInstructorsService.instructors.entries().find(i => i.docId === ownerDocId);
-    if (!owner) return '';
-    // Don't duplicate if the owner is already shown as the instructor.
-    if (owner.instructorId === this.event().leadingInstructorId) return '';
-    return owner.name;
+  // The event's first listed contact (the creator when none is listed), skipped
+  // when it would just repeat the leading instructor shown above it. This
+  // compact card has room for one contact; the event page lists them all.
+  private readonly firstContact = computed(() => {
+    const contact = eventContacts(this.event())[0];
+    if (!contact) return null;
+    // Prefer the public instructor profile over the fields cached on the event:
+    // events that predate those fields have neither a name nor an instructorId
+    // stored, and the profile is the more current name anyway.
+    const instructors = this.findInstructorsService.instructors;
+    const instructor = contact.instructorId
+      ? instructors.get(contact.instructorId)
+      : instructors.entries().find((i) => i.docId === contact.memberDocId);
+    const instructorId = instructor?.instructorId || contact.instructorId;
+    const name = instructor?.name || contact.name;
+    if (!name) return null;
+    // Don't repeat the leading instructor, shown above.
+    if (instructorId && instructorId === this.event().leadingInstructorId) return null;
+    return { name, instructorId };
   });
 
-  // Build a link to the owner's instructor profile.
+  readonly contactLabel = computed(() => this.firstContact()?.name || '');
+
+  // Link to the contact's instructor profile; '' when they aren't an instructor.
   readonly contactLink = computed(() => {
-    const ownerDocId = this.event().ownerDocId;
-    if (!ownerDocId) return '';
-    const owner = this.findInstructorsService.instructors.entries().find(i => i.docId === ownerDocId);
-    if (!owner || !owner.instructorId) return '';
-    if (owner.instructorId === this.event().leadingInstructorId) return '';
+    const instructorId = this.firstContact()?.instructorId;
+    if (!instructorId) return '';
     const prefix = this.instructorLinkPrefix();
     if (prefix) {
-      return `${prefix}${encodeURIComponent(owner.instructorId)}`;
+      return `${prefix}${encodeURIComponent(instructorId)}`;
     }
-    return `/instructors/${encodeURIComponent(owner.instructorId)}`;
+    return `/instructors/${encodeURIComponent(instructorId)}`;
   });
 
   readonly expandMoreName = 'expand_more' as const;

--- a/src/app/events-calendar/event-view/event-view.html
+++ b/src/app/events-calendar/event-view/event-view.html
@@ -64,44 +64,45 @@
             </a>
           }
 
-          @if (ownerContact(); as owner) {
-            @if (owner.hasOwner) {
-              @if (owner.instructorId) {
-                <a class="instructor-chip" [href]="ownerInstructorLink()">
-                  <span class="icon-only-button">
-                    <app-icon name="salut"></app-icon>
-                  </span>
-                  <span class="detail-text">Contact: {{ owner.name }}</span>
-                </a>
-              } @else {
-                <div class="instructor-chip">
-                  <span class="icon-only-button">
-                    <app-icon name="salut"></app-icon>
-                  </span>
-                  <span class="detail-text">Contact: {{ owner.name }}</span>
-                </div>
-              }
-              @if (owner.contactEmail) {
-                <a class="instructor-chip" [href]="'mailto:' + owner.contactEmail">
-                  <span class="icon-only-button">
-                    <app-icon name="person"></app-icon>
-                  </span>
-                  <span class="detail-text">{{ owner.contactEmail }}</span>
-                </a>
-              }
-              @if (owner.contactUrl) {
-                <a
-                  class="instructor-chip"
-                  [href]="owner.contactUrl"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <span class="icon-only-button">
-                    <app-icon name="link"></app-icon>
-                  </span>
-                  <span class="detail-text">{{ owner.contactUrl }}</span>
-                </a>
-              }
+          <!-- The contacts listed for the event (the creator when none was
+               chosen). With no contacts at all the instructor chip above is
+               the only contact shown. -->
+          @for (contact of contacts(); track contact.memberDocId) {
+            @if (contact.instructorId) {
+              <a class="instructor-chip" [href]="instructorProfileLink(contact.instructorId)">
+                <span class="icon-only-button">
+                  <app-icon name="salut"></app-icon>
+                </span>
+                <span class="detail-text">Contact: {{ contact.name }}</span>
+              </a>
+            } @else {
+              <div class="instructor-chip">
+                <span class="icon-only-button">
+                  <app-icon name="salut"></app-icon>
+                </span>
+                <span class="detail-text">Contact: {{ contact.name }}</span>
+              </div>
+            }
+            @if (contact.contactEmail) {
+              <a class="instructor-chip" [href]="'mailto:' + contact.contactEmail">
+                <span class="icon-only-button">
+                  <app-icon name="person"></app-icon>
+                </span>
+                <span class="detail-text">{{ contact.contactEmail }}</span>
+              </a>
+            }
+            @if (contact.contactUrl) {
+              <a
+                class="instructor-chip"
+                [href]="contact.contactUrl"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <span class="icon-only-button">
+                  <app-icon name="link"></app-icon>
+                </span>
+                <span class="detail-text">{{ contact.contactUrl }}</span>
+              </a>
             }
           }
         </div>

--- a/src/app/events-calendar/event-view/event-view.ts
+++ b/src/app/events-calendar/event-view/event-view.ts
@@ -13,7 +13,7 @@ import { IconComponent } from '../../icons/icon.component';
 import { SpinnerComponent } from '../../spinner/spinner.component';
 import { collection, doc, getDoc, getDocs, getFirestore, query, where } from 'firebase/firestore';
 import { FIREBASE_APP } from '../../app.config';
-import { IlcEvent, EventStatus, eventStatusLabel, initEvent, eventOwnerContact } from '../../../../functions/src/data-model';
+import { IlcEvent, EventStatus, eventStatusLabel, initEvent, eventContacts } from '../../../../functions/src/data-model';
 import { FirebaseStateService } from '../../firebase-state.service';
 import { DataManagerService } from '../../data-manager.service';
 import { MarkdownViewer } from '../../markdown-editor/markdown-viewer';
@@ -64,17 +64,17 @@ export class EventViewComponent implements OnInit {
   });
 
 
-  // The owner / main contact for public display. Falls back to no-owner (in which
-  // case the template shows the leading instructor as the contact instead).
-  ownerContact = computed(() => {
+  // The contacts listed publicly for this event. Falls back to the creator when
+  // none is listed, and is empty when the event has no creator either (the
+  // template then shows only the leading instructor).
+  contacts = computed(() => {
     const ev = this.event();
-    return ev ? eventOwnerContact(ev) : null;
+    return ev ? eventContacts(ev) : [];
   });
 
-  ownerInstructorLink = computed(() => {
-    const id = this.ownerContact()?.instructorId;
-    return id ? `/instructors/${encodeURIComponent(id)}` : '';
-  });
+  instructorProfileLink(instructorId: string): string {
+    return instructorId ? `/instructors/${encodeURIComponent(instructorId)}` : '';
+  }
 
   isOwner = computed(() => {
     const user = this.firebaseState.user();

--- a/src/app/manage-events/manage-events.html
+++ b/src/app/manage-events/manage-events.html
@@ -136,7 +136,7 @@
             <span class="event-status-chip" [class]="'event-status-chip status-' + ev.status">{{ statusLabel(ev) }}</span>
             @if (ownerLabel(ev)) {
               <a class="person-chip owner-chip" [href]="ownerLink(ev)"
-                title="View organiser's member profile"
+                title="View creator's member profile"
                 (click)="$event.stopPropagation()">
                 <app-icon name="person"></app-icon>
                 {{ ownerLabel(ev) }}

--- a/src/app/manage-events/manage-events.ts
+++ b/src/app/manage-events/manage-events.ts
@@ -322,10 +322,10 @@ export class ManageEventsComponent implements OnDestroy {
     return `/manage-events/${id}`;
   }
 
-  // Resolve the event owner to a "Name (MemberId)" chip label.
+  // Resolve the event creator to a "Name (MemberId)" chip label.
   ownerLabel(event: IlcEvent): string {
     if (!event.ownerDocId) return '';
-    // Prefer the fields cached on the event (work for non-instructor owners and
+    // Prefer the fields cached on the event (work for non-instructor creators and
     // when the members collection isn't fully loaded); fall back to a lookup.
     const member = this.dataService.getMemberByDocId(event.ownerDocId);
     const name = event.ownerName || member?.name || '';

--- a/src/app/organise-events/organise-event/organise-event.html
+++ b/src/app/organise-events/organise-event/organise-event.html
@@ -148,7 +148,8 @@
       <label>Event managers</label>
       <div class="intro-text">
         Managers can edit this event's details. You are always a manager. Add other
-        instructors who should be able to manage it.
+        instructors who should be able to manage it, and tick any who should also
+        be listed publicly as a contact for the event.
       </div>
       <div class="manager-list">
         @if (submitter(); as me) {
@@ -197,6 +198,16 @@
               </button>
             }
           </div>
+          @if (managerDocId) {
+            <label class="manager-contact-row">
+              <input
+                type="checkbox"
+                [checked]="isListedContact(managerDocId)"
+                (change)="setContactListed(managerDocId, $any($event.target).checked)"
+              />
+              List as a public contact
+            </label>
+          }
         }
         @if (eventModel().managerDocIds.length === 0) {
           <div>

--- a/src/app/organise-events/organise-event/organise-event.scss
+++ b/src/app/organise-events/organise-event/organise-event.scss
@@ -124,6 +124,17 @@
     }
   }
 
+  // A manager's "list as a public contact" toggle, indented under their row.
+  .manager-contact-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 0 0 10px 1.5em;
+    cursor: pointer;
+    font-size: 0.9em;
+    color: $text-secondary;
+  }
+
   .document-list {
     display: flex;
     flex-direction: column;

--- a/src/app/organise-events/organise-event/organise-event.ts
+++ b/src/app/organise-events/organise-event/organise-event.ts
@@ -110,6 +110,9 @@ export class ProposeEventComponent {
     // Member doc IDs of the *additional* managers. The submitter is always a
     // manager too (shown as a pinned row) and is added server-side.
     managerDocIds: [] as string[],
+    // The managers ticked to be listed publicly as contacts for the event. The
+    // owner is always a contact on a new proposal (added in onSubmit).
+    contactDocIds: [] as string[],
   });
 
   // The submitting member — always pinned as a manager of the event.
@@ -216,8 +219,13 @@ export class ProposeEventComponent {
     if (!instructor) return;
     this.eventModel.update(m => {
       const managerDocIds = [...m.managerDocIds];
+      const previousDocId = managerDocIds[index] || '';
       managerDocIds[index] = instructor.docId;
-      return { ...m, managerDocIds };
+      // A manager swapped out hands their contact listing to their replacement.
+      const contactDocIds = m.contactDocIds.includes(previousDocId)
+        ? [...m.contactDocIds.filter(id => id !== previousDocId), instructor.docId]
+        : m.contactDocIds;
+      return { ...m, managerDocIds, contactDocIds };
     });
     this.proposeForm().dirty();
   }
@@ -227,9 +235,30 @@ export class ProposeEventComponent {
   }
 
   removeManagerDocId(index: number) {
+    this.eventModel.update(m => {
+      const removedDocId = m.managerDocIds[index] || '';
+      return {
+        ...m,
+        managerDocIds: m.managerDocIds.filter((_, i) => i !== index),
+        contactDocIds: m.contactDocIds.filter(id => id !== removedDocId),
+      };
+    });
+    this.proposeForm().dirty();
+  }
+
+  // Whether a manager is ticked to be listed publicly as a contact. The
+  // submitter/owner is always a contact, so they have no checkbox.
+  isListedContact(managerDocId: string): boolean {
+    return !!managerDocId && this.eventModel().contactDocIds.includes(managerDocId);
+  }
+
+  setContactListed(managerDocId: string, listed: boolean) {
+    if (!managerDocId) return;
     this.eventModel.update(m => ({
       ...m,
-      managerDocIds: m.managerDocIds.filter((_, i) => i !== index),
+      contactDocIds: listed
+        ? [...m.contactDocIds.filter(id => id !== managerDocId), managerDocId]
+        : m.contactDocIds.filter(id => id !== managerDocId),
     }));
     this.proposeForm().dirty();
   }
@@ -324,7 +353,13 @@ export class ProposeEventComponent {
         'submitProposedEvent'
       );
 
-      const result = await submitFn(this.eventModel());
+      const model = this.eventModel();
+      const result = await submitFn({
+        ...model,
+        // The owner is always listed as a contact on a new proposal; any ticked
+        // managers are listed alongside them.
+        contactDocIds: [model.ownerDocId, ...model.contactDocIds].filter(Boolean),
+      });
 
       if (result.data.success) {
         const docId = result.data.docId;

--- a/tests/e2e/event-nonInstructor-owner.spec.ts
+++ b/tests/e2e/event-nonInstructor-owner.spec.ts
@@ -89,6 +89,27 @@ describe('story: event-nonInstructor-owner', () => {
       ownerContactEmail: 'owner@example.com',
       ownerContactUrl: 'https://example.com/workshop',
       leadingInstructorId: '',
+      // The owner is listed as a public contact (with the display fields left
+      // for the trigger to fill in), alongside a stale entry for someone who is
+      // no longer on the organising team.
+      contacts: [
+        {
+          memberDocId: ownerDocId,
+          name: '',
+          memberId: '',
+          instructorId: '',
+          contactEmail: 'owner@example.com',
+          contactUrl: 'https://example.com/workshop',
+        },
+        {
+          memberDocId: 'removed-manager',
+          name: 'Removed Manager',
+          memberId: 'RM001',
+          instructorId: '',
+          contactEmail: '',
+          contactUrl: '',
+        },
+      ],
     };
     await db.collection('events').doc(eventDocId).set(event);
   });
@@ -122,6 +143,22 @@ describe('story: event-nonInstructor-owner', () => {
       'My Events mirror',
     );
     expect(mirrored?.['title']).toBe('Community Workshop');
+  });
+
+  it('keeps only the contacts still on the team and fills their cached name', async () => {
+    const event = await waitFor(
+      async () => (await db.collection('events').doc(eventDocId).get()).data() as IlcEvent,
+      (e) => (e.contacts || []).length === 1,
+      'contacts pruning',
+    );
+    expect(event.contacts).toEqual([{
+      memberDocId: ownerDocId,
+      name: 'Non Instructor Owner',
+      memberId: 'NIO001',
+      instructorId: '',
+      contactEmail: 'owner@example.com',
+      contactUrl: 'https://example.com/workshop',
+    }]);
   });
 
   it('notifies the non-instructor owner when the event becomes listed', async () => {


### PR DESCRIPTION
Stacked on #51 — base is `fix/event-owner-editor-ui`, so this PR shows only the new feature. Rebase onto `main` once #51 merges.

## What changes

An event's `ownerDocId` used to mean both *who created it* and *who is shown publicly as the contact*. It now only means the **creator**. Who is listed publicly is a new `contacts` array, whose entries must be the creator or one of `managerDocIds`.

**The "extra bit" per manager is membership of `contacts`**, not a boolean on each manager. `managerDocIds` therefore keeps its exact current shape, so the `array-contains` checks in `firestore.rules`, the event queries, the per-member mirror and the notification fan-out are all untouched.

```ts
export type EventContact = {
  memberDocId: string;
  name: string;          // cached display name
  memberId: string;
  instructorId: string;  // '' if not an instructor
  contactEmail: string;  // opt-in, typed by the editor
  contactUrl: string;
};
```

Display fields are cached on the event because `/members` is not publicly readable — a visitor cannot resolve a member doc ID into a name. Only name/memberId/instructorId are cached automatically; **a member's own email is never copied there**, the email/link are opt-in fields.

## Behaviour

- **Public event page** lists every contact; with none chosen it falls back to the creator, then to the leading instructor — so existing events display exactly as before.
- **Event edit**: label is now "Creator"; a *list as a public contact* checkbox sits on the creator row and on each manager row, revealing that contact's optional email/link. The creator's entry takes its details from the `owner*` fields at save time, keeping one source of truth.
- **Proposal form**: same checkbox on manager rows; the submitter is creator, manager and contact by default.
- **`onEventUpdated`** prunes contacts who are no longer on the organising team and refreshes their cached identifiers. The comparison is key-order-independent — Firestore's field ordering would otherwise rewrite the document on every trigger and loop forever.

## Migration

`scripts/backfill-event-contacts.ts` (dry run by default, `--commit`, idempotent):

1. adds `ownerDocId` to `managerDocIds` when missing;
2. adds the creator to `contacts`, topping the display name up from their member document — older events cached no `ownerName`, and without this the backfill would have published an email address as the contact's display name;
3. creates the `members/{ownerDocId}/events/{eventId}` mirror if adding the creator as a manager left it missing.

Events with no creator are left alone.

## Verification

- `pnpm test` (430) and `pnpm test:functions` (256) pass, with new coverage for the contact toggles / save normalisation and for `resolveEventContacts` + `sameContacts`.
- The e2e spec ran against the real triggers in the Firestore + Functions emulator: contacts pruned, cached name filled, no trigger loop.
- The backfill was exercised against the emulator end to end — dry run wrote nothing, `--commit` applied, a second `--commit` was a no-op.
- The local `tmp/seed-data/events.json` export was migrated in place (11 of 72 events) so a fresh `pnpm seed:emulator` loads the new shape.

Not done: the rendered UI was not driven in a browser; the new markup is covered by build + unit tests only.

Follow-up (not in this PR): `functions/scripts/export-anonymized-data.ts` copies event documents verbatim, so real names and emails — now including `contacts` — land in the local seed export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)