### PR TITLE
Anonymise event documents in the data export

### DIFF
--- a/functions/scripts/anonymise.ts
+++ b/functions/scripts/anonymise.ts
@@ -1,0 +1,196 @@
+/*
+ * Anonymisation rules shared by the data-export scripts.
+ *
+ * Deliberately free of side effects (no Firestore, no filesystem, no CLI
+ * parsing) so the rules can be unit-tested directly — see
+ * tests/unit/anonymise-export.spec.ts.
+ */
+
+export type RawDoc = Record<string, unknown>;
+
+function str(doc: RawDoc, key: string): string {
+  const v = doc[key];
+  return typeof v === 'string' ? v : '';
+}
+
+function strArr(doc: RawDoc, key: string): string[] {
+  const v = doc[key];
+  return Array.isArray(v) ? (v.filter((x) => typeof x === 'string') as string[]) : [];
+}
+
+// Email addresses must be lowercase — checkEmailStatus normalises with .toLowerCase()
+export function memberEmail(memberId: string): string {
+  return `member-${memberId.toLowerCase()}@example.com`;
+}
+
+// Stand-in for a personal contact URL (event mini-profiles link to a member's
+// own site / socials, which is PII).
+export function memberContactUrl(memberId: string): string {
+  return `https://example.com/contact/${memberId.toLowerCase()}`;
+}
+
+// Lookups from a member's Firestore doc ID / real email to their human-readable
+// memberId, so documents that reference a member by doc ID or email can be
+// rewritten to the same anonymised identity that members.json gets.
+export type MemberIndex = {
+  memberIdByDocId: Map<string, string>;
+  memberIdByEmail: Map<string, string>; // keys are lowercased
+};
+
+export function buildMemberIndex(rawMembers: Array<{ id: string } & RawDoc>): MemberIndex {
+  const memberIdByDocId = new Map<string, string>();
+  const memberIdByEmail = new Map<string, string>();
+  for (const m of rawMembers) {
+    const memberId = str(m, 'memberId');
+    if (!memberId) continue;
+    memberIdByDocId.set(m.id, memberId);
+    for (const email of strArr(m, 'emails')) {
+      memberIdByEmail.set(email.toLowerCase(), memberId);
+    }
+  }
+  return { memberIdByDocId, memberIdByEmail };
+}
+
+// The anonymised identity to use for a member referenced by doc ID. Falls back
+// to the doc ID itself when the member is missing from the export (dangling
+// ref), which is still PII-free. Returns '' when there is no reference at all.
+function memberKey(index: MemberIndex, memberDocId: string, cachedMemberId: string): string {
+  if (cachedMemberId) return cachedMemberId;
+  if (!memberDocId) return '';
+  return index.memberIdByDocId.get(memberDocId) ?? memberDocId;
+}
+
+export function anonymiseMember(doc: RawDoc, memberId: string): RawDoc {
+  return {
+    ...doc,
+    name: `Test Member ${memberId}`,
+    emails: [memberEmail(memberId)],
+    phone: doc['phone'] ? '555-0000' : '',
+    address: doc['address'] ? '123 Test St' : '',
+    city: doc['city'] ? 'Test City' : '',
+    zipCode: doc['zipCode'] ? '00000' : '',
+    countyOrState: doc['countyOrState'] ? 'Test State' : '',
+    // publicEmail / publicPhone appear on member AND instructor records
+    publicEmail: doc['publicEmail'] ? memberEmail(memberId) : '',
+    publicPhone: doc['publicPhone'] ? '555-0000' : '',
+    // Clear admin-only free-text notes
+    notes: '',
+  };
+}
+
+export function anonymiseInstructor(doc: RawDoc, instructorId: string): RawDoc {
+  return {
+    ...doc,
+    name: `Instructor ${instructorId}`,
+    publicEmail: doc['publicEmail'] ? `instructor-${instructorId}@example.com` : '',
+    publicPhone: doc['publicPhone'] ? '555-0000' : '',
+  };
+}
+
+export function anonymiseSchool(doc: RawDoc, schoolId: string): RawDoc {
+  return {
+    ...doc,
+    schoolName: `Test School ${schoolId}`,
+    // Contact fields
+    contactEmail: doc['contactEmail'] ? `school-${schoolId}@example.com` : '',
+    contactPhone: doc['contactPhone'] ? '555-0000' : '',
+    address: doc['address'] ? '123 Test St' : '',
+    city: doc['city'] ? 'Test City' : '',
+    zipCode: doc['zipCode'] ? '00000' : '',
+  };
+}
+
+// One entry of an event's `contacts` array (see EventContact in
+// functions/src/data-model.ts). Every entry is the event's creator or one of
+// its managers, so its identity is anonymised the same way theirs is; the
+// memberDocId / memberId / instructorId keys are left untouched so the seeded
+// data still resolves each contact to a seeded member.
+function anonymiseEventContact(contact: RawDoc, index: MemberIndex): RawDoc {
+  const key = memberKey(index, str(contact, 'memberDocId'), str(contact, 'memberId'));
+  return {
+    ...contact,
+    name: contact['name'] ? `Test Member ${key}` : '',
+    contactEmail: contact['contactEmail'] && key ? memberEmail(key) : '',
+    contactUrl: contact['contactUrl'] && key ? memberContactUrl(key) : '',
+  };
+}
+
+/*
+ * Events carry the creator's cached name (the `owner*` field names predate the
+ * rename), the creator's and managers' real login emails, an optional
+ * mini-profile contact (email + URL), the email of whoever last edited the
+ * event, and — on events created since the contacts feature — a `contacts`
+ * array with the same identity fields again.
+ *
+ * Emails are rebuilt from the creator/manager doc IDs rather than scrambled in
+ * place, so they match the single `member-{memberId}@example.com` address that
+ * anonymiseMember() gives each member. That keeps the seeded data usable:
+ * firestore.rules and the event notifications both match a signed-in user to an
+ * event by looking their email up in ownerEmails / managerEmails.
+ */
+export function anonymiseEvent(doc: RawDoc, index: MemberIndex): RawDoc {
+  const ownerKey = memberKey(index, str(doc, 'ownerDocId'), str(doc, 'ownerMemberId'));
+  const managerDocIds = strArr(doc, 'managerDocIds');
+  const updatedBy = str(doc, 'updatedByEmail');
+  const updatedByMemberId = index.memberIdByEmail.get(updatedBy.toLowerCase());
+  const contacts = doc['contacts'];
+
+  return {
+    ...doc,
+    ownerName: doc['ownerName'] ? `Test Member ${ownerKey}` : '',
+    ownerEmails: ownerKey ? [memberEmail(ownerKey)] : [],
+    // A member's real `emails` array can hold several addresses, so the stored
+    // managerEmails is a flattened list; after anonymisation each member has
+    // exactly one address, hence one per manager doc ID. Events that predate
+    // managerDocIds keep their length with a placeholder rather than a real
+    // address.
+    managerEmails:
+      managerDocIds.length > 0
+        ? managerDocIds.map((id) => memberEmail(memberKey(index, id, '')))
+        : strArr(doc, 'managerEmails').map((_, i) => `event-manager-${i}@example.com`),
+    ownerContactEmail: doc['ownerContactEmail'] && ownerKey ? memberEmail(ownerKey) : '',
+    ownerContactUrl: doc['ownerContactUrl'] && ownerKey ? memberContactUrl(ownerKey) : '',
+    updatedByEmail: updatedBy
+      ? updatedByMemberId
+        ? memberEmail(updatedByMemberId)
+        : 'event-editor@example.com'
+      : '',
+    ...(Array.isArray(contacts)
+      ? {
+          contacts: contacts.map((c) =>
+            c && typeof c === 'object' ? anonymiseEventContact(c as RawDoc, index) : c,
+          ),
+        }
+      : {}),
+  };
+}
+
+export function anonymiseSheetsOrder(doc: RawDoc): RawDoc {
+  const externalId = str(doc, 'externalId');
+  return {
+    ...doc,
+    firstName: 'Test',
+    lastName: `Member${externalId}`,
+    email: externalId ? `member-${externalId}@example.com` : 'unknown@example.com',
+  };
+}
+
+export function anonymiseSquarespaceOrder(doc: RawDoc): RawDoc {
+  const email = str(doc, 'customerEmail');
+  const anonEmail = email ? `order-${Buffer.from(email).toString('base64').substring(0, 8)}@example.com` : 'unknown@example.com';
+  // Anonymise billing address if present
+  let billingAddress = doc['billingAddress'];
+  if (billingAddress && typeof billingAddress === 'object') {
+    billingAddress = {
+      ...(billingAddress as Record<string, unknown>),
+      firstName: 'Test',
+      lastName: 'Customer',
+      address1: '123 Test St',
+      address2: '',
+      city: 'Test City',
+      postalCode: '00000',
+      phone: '',
+    };
+  }
+  return { ...doc, customerEmail: anonEmail, billingAddress };
+}

--- a/functions/scripts/export-anonymized-data.ts
+++ b/functions/scripts/export-anonymized-data.ts
@@ -18,6 +18,17 @@
 import * as admin from 'firebase-admin';
 import * as fs from 'fs';
 import * as path from 'path';
+import {
+  RawDoc,
+  anonymiseEvent,
+  anonymiseInstructor,
+  anonymiseMember,
+  anonymiseSchool,
+  anonymiseSheetsOrder,
+  anonymiseSquarespaceOrder,
+  buildMemberIndex,
+  memberEmail,
+} from './anonymise';
 
 // ============================================================
 // CLI args
@@ -51,87 +62,6 @@ fs.mkdirSync(subcollectionsDir, { recursive: true });
 // ============================================================
 admin.initializeApp({ projectId });
 const db = admin.firestore();
-
-// ============================================================
-// Anonymisation helpers
-// ============================================================
-
-type RawDoc = Record<string, unknown>;
-
-// Email addresses must be lowercase — checkEmailStatus normalises with .toLowerCase()
-function memberEmail(memberId: string): string {
-  return `member-${memberId.toLowerCase()}@example.com`;
-}
-
-function anonymiseMember(doc: RawDoc, memberId: string): RawDoc {
-  return {
-    ...doc,
-    name: `Test Member ${memberId}`,
-    emails: [memberEmail(memberId)],
-    phone: doc['phone'] ? '555-0000' : '',
-    address: doc['address'] ? '123 Test St' : '',
-    city: doc['city'] ? 'Test City' : '',
-    zipCode: doc['zipCode'] ? '00000' : '',
-    countyOrState: doc['countyOrState'] ? 'Test State' : '',
-    // publicEmail / publicPhone appear on member AND instructor records
-    publicEmail: doc['publicEmail'] ? memberEmail(memberId) : '',
-    publicPhone: doc['publicPhone'] ? '555-0000' : '',
-    // Clear admin-only free-text notes
-    notes: '',
-  };
-}
-
-function anonymiseInstructor(doc: RawDoc, instructorId: string): RawDoc {
-  return {
-    ...doc,
-    name: `Instructor ${instructorId}`,
-    publicEmail: doc['publicEmail'] ? `instructor-${instructorId}@example.com` : '',
-    publicPhone: doc['publicPhone'] ? '555-0000' : '',
-  };
-}
-
-function anonymiseSchool(doc: RawDoc, schoolId: string): RawDoc {
-  return {
-    ...doc,
-    schoolName: `Test School ${schoolId}`,
-    // Contact fields
-    contactEmail: doc['contactEmail'] ? `school-${schoolId}@example.com` : '',
-    contactPhone: doc['contactPhone'] ? '555-0000' : '',
-    address: doc['address'] ? '123 Test St' : '',
-    city: doc['city'] ? 'Test City' : '',
-    zipCode: doc['zipCode'] ? '00000' : '',
-  };
-}
-
-function anonymiseSheetsOrder(doc: RawDoc): RawDoc {
-  const externalId = (doc['externalId'] as string) || '';
-  return {
-    ...doc,
-    firstName: 'Test',
-    lastName: `Member${externalId}`,
-    email: externalId ? `member-${externalId}@example.com` : 'unknown@example.com',
-  };
-}
-
-function anonymiseSquarespaceOrder(doc: RawDoc): RawDoc {
-  const email = (doc['customerEmail'] as string) || '';
-  const anonEmail = email ? `order-${Buffer.from(email).toString('base64').substring(0, 8)}@example.com` : 'unknown@example.com';
-  // Anonymise billing address if present
-  let billingAddress = doc['billingAddress'];
-  if (billingAddress && typeof billingAddress === 'object') {
-    billingAddress = {
-      ...(billingAddress as Record<string, unknown>),
-      firstName: 'Test',
-      lastName: 'Customer',
-      address1: '123 Test St',
-      address2: '',
-      city: 'Test City',
-      postalCode: '00000',
-      phone: '',
-    };
-  }
-  return { ...doc, customerEmail: anonEmail, billingAddress };
-}
 
 // ============================================================
 // Collection fetchers
@@ -177,12 +107,9 @@ async function main(): Promise<void> {
   const members = rawMembers.map((m) => anonymiseMember(m, (m['memberId'] as string) || m.id));
   save('members.json', members);
 
-  // Build docId -> memberId map for ACL remapping
-  const docIdToMemberId = new Map<string, string>();
-  for (const m of rawMembers) {
-    const memberId = (m['memberId'] as string) || '';
-    if (memberId) docIdToMemberId.set(m.id, memberId);
-  }
+  // docId/email -> memberId lookups, used to remap the member references that
+  // event and ACL documents carry.
+  const memberIndex = buildMemberIndex(rawMembers);
 
   // --- Schools ---
   console.log('\nFetching schools...');
@@ -237,7 +164,8 @@ async function main(): Promise<void> {
 
   // --- Events ---
   console.log('\nFetching events...');
-  const events = await fetchCollection('events');
+  const rawEvents = await fetchCollection('events');
+  const events = rawEvents.map((e) => anonymiseEvent(e, memberIndex));
   save('events.json', events);
 
   // --- Orders ---
@@ -265,7 +193,7 @@ async function main(): Promise<void> {
     const memberDocIds = (entry['memberDocIds'] as string[]) || [];
     // Derive the canonical memberId from the first linked member
     const firstMemberId = memberDocIds.length > 0
-      ? (docIdToMemberId.get(memberDocIds[0]) ?? memberDocIds[0])
+      ? (memberIndex.memberIdByDocId.get(memberDocIds[0]) ?? memberDocIds[0])
       : null;
     const anonEmail = firstMemberId
       ? memberEmail(firstMemberId)

--- a/tests/unit/anonymise-export.spec.ts
+++ b/tests/unit/anonymise-export.spec.ts
@@ -1,0 +1,174 @@
+/*
+ * Unit tests for the export anonymisation rules (functions/scripts/anonymise.ts),
+ * focused on events — the collection that carries the owner's cached name, the
+ * owner's/managers' login emails, mini-profile contacts and the `contacts` array.
+ *
+ * No emulator or credentials needed; run via `pnpm test:fixtures`.
+ */
+import { describe, expect, it } from 'vitest';
+import { EventContact } from '../../functions/src/data-model';
+import {
+  anonymiseEvent,
+  anonymiseMember,
+  buildMemberIndex,
+  memberEmail,
+} from '../../functions/scripts/anonymise';
+
+const rawMembers = [
+  { id: 'ownerDoc', memberId: 'M-100', name: 'Real Owner', emails: ['real.owner@gmail.com', 'owner@work.com'] },
+  { id: 'mgrDoc1', memberId: 'M-200', name: 'Real Manager', emails: ['manager@gmail.com'] },
+  { id: 'mgrDoc2', memberId: 'M-300', name: 'Other Manager', emails: ['other@gmail.com'] },
+  { id: 'contactDoc', memberId: 'M-400', name: 'Real Contact', emails: ['contact@gmail.com'] },
+];
+const index = buildMemberIndex(rawMembers);
+
+// A realistic firebase-sourced event with a non-instructor owner + mini-profile.
+function anEvent(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'evt1',
+    title: 'Sydney Workshop',
+    ownerDocId: 'ownerDoc',
+    ownerMemberId: 'M-100',
+    ownerName: 'Real Owner',
+    ownerInstructorId: '',
+    ownerEmails: ['real.owner@gmail.com', 'owner@work.com'],
+    ownerContactEmail: 'real.owner@gmail.com',
+    ownerContactUrl: 'https://realowner.example.org/about',
+    managerDocIds: ['mgrDoc1', 'mgrDoc2'],
+    managerEmails: ['manager@gmail.com', 'other@gmail.com'],
+    updatedByEmail: 'manager@gmail.com',
+    ...overrides,
+  };
+}
+
+// Typed as EventContact so this fixture breaks if the stored shape changes.
+const contacts: EventContact[] = [
+  {
+    memberDocId: 'contactDoc',
+    memberId: 'M-400',
+    instructorId: '',
+    name: 'Real Contact',
+    contactEmail: 'contact@gmail.com',
+    contactUrl: 'https://realcontact.example.org',
+  },
+  // A contact with no opt-in public contact details: blanks stay blank.
+  {
+    memberDocId: 'mgrDoc1',
+    memberId: 'M-200',
+    instructorId: 'INS-7',
+    name: 'Real Manager',
+    contactEmail: '',
+    contactUrl: '',
+  },
+];
+
+// Every string anywhere in the doc, so PII checks cannot miss a nested field.
+function allStrings(value: unknown): string[] {
+  if (typeof value === 'string') return [value];
+  if (Array.isArray(value)) return value.flatMap(allStrings);
+  if (value && typeof value === 'object') return Object.values(value).flatMap(allStrings);
+  return [];
+}
+
+describe('anonymiseEvent', () => {
+  it('replaces the cached owner name and owner emails with the member forms', () => {
+    const out = anonymiseEvent(anEvent(), index);
+    expect(out['ownerName']).toBe('Test Member M-100');
+    // One address per member, matching what anonymiseMember writes to members.json.
+    expect(out['ownerEmails']).toEqual(['member-m-100@example.com']);
+    expect(anonymiseMember(rawMembers[0], 'M-100')['emails']).toEqual(out['ownerEmails']);
+  });
+
+  it('rewrites managerEmails from managerDocIds, one per manager', () => {
+    const out = anonymiseEvent(anEvent(), index);
+    expect(out['managerEmails']).toEqual(['member-m-200@example.com', 'member-m-300@example.com']);
+  });
+
+  it('anonymises the mini-profile contact email and URL', () => {
+    const out = anonymiseEvent(anEvent(), index);
+    expect(out['ownerContactEmail']).toBe('member-m-100@example.com');
+    expect(out['ownerContactUrl']).toBe('https://example.com/contact/m-100');
+  });
+
+  it('maps updatedByEmail back to the editing member', () => {
+    expect(anonymiseEvent(anEvent(), index)['updatedByEmail']).toBe('member-m-200@example.com');
+    // An editor who is not a seeded member still must not leak a real address.
+    const stranger = anonymiseEvent(anEvent({ updatedByEmail: 'admin@ilc.com' }), index);
+    expect(stranger['updatedByEmail']).toBe('event-editor@example.com');
+  });
+
+  it('leaves empty owner/contact fields empty rather than inventing data', () => {
+    const out = anonymiseEvent(
+      anEvent({
+        ownerDocId: '',
+        ownerMemberId: '',
+        ownerName: '',
+        ownerEmails: [],
+        ownerContactEmail: '',
+        ownerContactUrl: '',
+        managerDocIds: [],
+        managerEmails: [],
+        updatedByEmail: '',
+      }),
+      index,
+    );
+    expect(out['ownerName']).toBe('');
+    expect(out['ownerEmails']).toEqual([]);
+    expect(out['ownerContactEmail']).toBe('');
+    expect(out['ownerContactUrl']).toBe('');
+    expect(out['managerEmails']).toEqual([]);
+    expect(out['updatedByEmail']).toBe('');
+  });
+
+  it('anonymises a contacts array, keeping its shape and member references', () => {
+    const out = anonymiseEvent(anEvent({ contacts }), index);
+    expect(out['contacts']).toEqual([
+      {
+        memberDocId: 'contactDoc',
+        memberId: 'M-400',
+        instructorId: '',
+        name: 'Test Member M-400',
+        contactEmail: 'member-m-400@example.com',
+        contactUrl: 'https://example.com/contact/m-400',
+      },
+      {
+        memberDocId: 'mgrDoc1',
+        memberId: 'M-200',
+        instructorId: 'INS-7',
+        name: 'Test Member M-200',
+        contactEmail: '',
+        contactUrl: '',
+      },
+    ]);
+  });
+
+  it('omits `contacts` entirely for events that do not have it', () => {
+    expect('contacts' in anonymiseEvent(anEvent(), index)).toBe(false);
+  });
+
+  it('falls back to the doc ID for members missing from the export', () => {
+    const out = anonymiseEvent(
+      anEvent({ ownerDocId: 'unknownDoc', ownerMemberId: '', managerDocIds: ['ghostDoc'] }),
+      index,
+    );
+    expect(out['ownerEmails']).toEqual([memberEmail('unknownDoc')]);
+    expect(out['managerEmails']).toEqual([memberEmail('ghostDoc')]);
+  });
+
+  it('keeps managerEmails non-empty for legacy events that predate managerDocIds', () => {
+    const out = anonymiseEvent(anEvent({ managerDocIds: [] }), index);
+    expect(out['managerEmails']).toEqual(['event-manager-0@example.com', 'event-manager-1@example.com']);
+  });
+
+  it('leaves no real name, email or personal URL anywhere in the output', () => {
+    const out = anonymiseEvent(anEvent({ contacts }), index);
+    for (const s of allStrings(out)) {
+      expect(s).not.toMatch(/gmail\.com|owner@work\.com|realowner|realcontact/i);
+      expect(s).not.toMatch(/Real Owner|Real Manager|Real Contact/);
+    }
+    // Non-PII event content is preserved.
+    expect(out['title']).toBe('Sydney Workshop');
+    expect(out['ownerDocId']).toBe('ownerDoc');
+    expect(out['managerDocIds']).toEqual(['mgrDoc1', 'mgrDoc2']);
+  });
+});


### PR DESCRIPTION
## Problem

`export-anonymized-data.ts` saved the `events` collection verbatim while members, instructors, schools and orders all went through an `anonymise*` helper. Event documents carry real personal data:

- `ownerName` — the creator's cached display name
- `ownerEmails` / `managerEmails` — real login addresses, copied from the members' `emails` arrays
- `ownerContactEmail` / `ownerContactUrl` — the opt-in mini-profile contact
- `updatedByEmail` — the last editor's address
- `contacts[]` (`EventContact`, added in #55) — the same identity fields again, per listed contact

On a live export that is 86 event documents, 25 of them with a creator and 7 with managers.

## Change

`anonymiseEvent(doc, memberIndex)` rebuilds emails **from `ownerDocId` / `managerDocIds`** rather than scrambling them in place, so each one lands on the single `member-{memberId}@example.com` address that `anonymiseMember()` gives that member. That matters for seeded data staying usable: `firestore.rules` and the event notifications both match a signed-in user to an event by looking their email up in `ownerEmails` / `managerEmails`, so the addresses have to agree with `members.json`.

Cached display names become `Test Member {memberId}`, personal contact URLs become `https://example.com/contact/{memberId}`, and each `contacts[]` entry gets the same treatment while keeping `memberDocId` / `memberId` / `instructorId` intact so seeded data still exercises the contacts UI. Empty fields stay empty rather than gaining invented data, and a reference to a member missing from the export falls back to the doc ID (still PII-free).

The helpers move to a side-effect-free `functions/scripts/anonymise.ts` so they can be unit-tested — `export-anonymized-data.ts` calls `initializeApp()` and `process.exit()` at module scope, so it can't be imported from a test. The move is verbatim; the only behavioural change is to events. The `docId -> memberId` map built inline for ACL remapping is now `buildMemberIndex()`, which also indexes members by email (needed to resolve `updatedByEmail`).

## Verification

- `pnpm test:fixtures` — 17 passed, including 10 new cases in `tests/unit/anonymise-export.spec.ts`. The contacts fixture is typed as `EventContact`, so it breaks if the stored shape changes.
- Ran the real export against `ilc-paris-class-tracker`: across every identity field of all 86 events, **0** non-`@example.com` addresses, and every populated `ownerName` in the `Test Member …` form.
- `pnpm typecheck:tests` reports only the two pre-existing `TS4111` errors in `tests/e2e/grading-paid-and-snapshot.spec.ts`.

Production data exercises the new paths thinly — no event yet has a mini-profile or a `contacts` array, since both features only just shipped — so those branches are covered by unit tests rather than by the live export.

## Not covered

69 of the 86 events have a real email address inside the free-text `description` / `location` — organiser addresses pasted into Google Calendar copy. Scrubbing those would mangle public-facing event text, so it is left for a follow-up decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)