### PR TITLE
Redact contact details from event free-text copy in the data export

### DIFF
--- a/functions/scripts/anonymise.ts
+++ b/functions/scripts/anonymise.ts
@@ -100,6 +100,106 @@ export function anonymiseSchool(doc: RawDoc, schoolId: string): RawDoc {
   };
 }
 
+/*
+ * Event copy is written by hand — much of it pasted into Google Calendar — so
+ * it routinely carries the organiser's own email, phone number and personal
+ * links inline, well away from the structured fields below.
+ *
+ * This copy is public-facing (it renders on the live events pages), so the PII
+ * is substituted in place rather than the field being blanked: the seeded event
+ * keeps prose of a realistic shape and length, which is the whole reason the
+ * export carries real descriptions at all.
+ */
+export const REDACTED_EMAIL = 'event-contact@example.com';
+export const REDACTED_PHONE = '555-0000';
+export const REDACTED_URL = 'https://example.com/event-link';
+
+// Hosts that carry no personal information and that the events pages render
+// meaningfully — the venue map, the calendar entry, ILC's own site, and the
+// storage buckets images are embedded from. Compared against the host, so
+// subdomains are covered. Everything else is treated as somebody's personal
+// link and replaced.
+const KEPT_URL_HOSTS = [
+  'iliqchuan.com',
+  'google.com',
+  'goo.gl',
+  'googleapis.com',
+  'googleusercontent.com',
+];
+
+// Stops at the delimiters that end a link in HTML (" '), markdown ( ) ] ) or
+// prose, so the surrounding copy is left intact.
+const URL_RE = /\b(?:https?:\/\/|www\.)[^\s<>"'`)\]]+/gi;
+const EMAIL_RE = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi;
+// Anchored on an international (+CC) or trunk (0X) prefix, so the date ranges,
+// opening times and prices that fill event copy are not read as phone numbers.
+const PHONE_RE = /(?:\+\d|\b0\d)[\d\s().-]{6,}\d/g;
+
+function isKeptUrl(url: string, depth = 0): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url.toLowerCase().startsWith('www.') ? `https://${url}` : url);
+  } catch {
+    return false; // Unparseable, so we cannot vouch for it.
+  }
+  const host = parsed.hostname.toLowerCase();
+  if (!KEPT_URL_HOSTS.some((h) => host === h || host.endsWith(`.${h}`))) return false;
+
+  // Google Calendar rewrites outbound links through its own /url redirector, so
+  // most personal links in this copy arrive wrapped in an allowlisted host with
+  // the real destination sitting in the query string. Judge the destination.
+  if ((host === 'google.com' || host.endsWith('.google.com')) && parsed.pathname === '/url') {
+    const target = parsed.searchParams.get('q') ?? parsed.searchParams.get('url');
+    if (!target) return false;
+    return depth < 3 && isKeptUrl(target, depth + 1);
+  }
+  return true;
+}
+
+// Replaces personal contact details embedded in free text, leaving the rest of
+// the wording untouched.
+export function redactFreeText(input: string): string {
+  if (!input) return input;
+
+  // Links we keep are stashed behind a NUL sentinel first, so that the email
+  // and phone passes below cannot chew through their query strings and place
+  // IDs. NUL cannot occur in Firestore string data, so the sentinel can never
+  // collide with something that was already in the copy.
+  const kept: string[] = [];
+
+  let out = input.replace(URL_RE, (match) => {
+    // Trailing punctuation belongs to the sentence, not to the link.
+    const trailing = /[.,;:!?]+$/.exec(match)?.[0] ?? '';
+    const url = match.slice(0, match.length - trailing.length);
+    if (!isKeptUrl(url)) return REDACTED_URL + trailing;
+    return `\u0000${kept.push(url) - 1}\u0000${trailing}`;
+  });
+
+  // Runs after the URL pass, which leaves `mailto:` untouched (it is neither
+  // http(s) nor www), so this covers both bare addresses and mailto: hrefs.
+  out = out.replace(EMAIL_RE, REDACTED_EMAIL);
+
+  out = out.replace(PHONE_RE, (match) => {
+    const digits = match.match(/\d/g)?.length ?? 0;
+    // E.164 caps a real number at 15 digits; under 9 and this is far more
+    // likely to be a date range, an opening time or a price.
+    return digits >= 9 && digits <= 15 ? REDACTED_PHONE : match;
+  });
+
+  return out.replace(/\u0000(\d+)\u0000/g, (_, i: string) => kept[Number(i)]);
+}
+
+// The free-text event fields, redacted. Absent fields stay absent rather than
+// being materialised as empty strings.
+function redactedEventText(doc: RawDoc): RawDoc {
+  const out: RawDoc = {};
+  for (const key of ['description', 'descriptionMarkdown', 'location']) {
+    const value = doc[key];
+    if (typeof value === 'string') out[key] = redactFreeText(value);
+  }
+  return out;
+}
+
 // One entry of an event's `contacts` array (see EventContact in
 // functions/src/data-model.ts). Every entry is the event's creator or one of
 // its managers, so its identity is anonymised the same way theirs is; the
@@ -127,6 +227,9 @@ function anonymiseEventContact(contact: RawDoc, index: MemberIndex): RawDoc {
  * anonymiseMember() gives each member. That keeps the seeded data usable:
  * firestore.rules and the event notifications both match a signed-in user to an
  * event by looking their email up in ownerEmails / managerEmails.
+ *
+ * The same details also turn up loose in the description and location copy, so
+ * those are redacted in place — see redactFreeText above.
  */
 export function anonymiseEvent(doc: RawDoc, index: MemberIndex): RawDoc {
   const ownerKey = memberKey(index, str(doc, 'ownerDocId'), str(doc, 'ownerMemberId'));
@@ -137,6 +240,7 @@ export function anonymiseEvent(doc: RawDoc, index: MemberIndex): RawDoc {
 
   return {
     ...doc,
+    ...redactedEventText(doc),
     ownerName: doc['ownerName'] ? `Test Member ${ownerKey}` : '',
     ownerEmails: ownerKey ? [memberEmail(ownerKey)] : [],
     // A member's real `emails` array can hold several addresses, so the stored

--- a/tests/unit/anonymise-export.spec.ts
+++ b/tests/unit/anonymise-export.spec.ts
@@ -8,10 +8,14 @@
 import { describe, expect, it } from 'vitest';
 import { EventContact } from '../../functions/src/data-model';
 import {
+  REDACTED_EMAIL,
+  REDACTED_PHONE,
+  REDACTED_URL,
   anonymiseEvent,
   anonymiseMember,
   buildMemberIndex,
   memberEmail,
+  redactFreeText,
 } from '../../functions/scripts/anonymise';
 
 const rawMembers = [
@@ -160,6 +164,33 @@ describe('anonymiseEvent', () => {
     expect(out['managerEmails']).toEqual(['event-manager-0@example.com', 'event-manager-1@example.com']);
   });
 
+  it('redacts contact details left loose in the description and location copy', () => {
+    const out = anonymiseEvent(
+      anEvent({
+        description:
+          '<p>Book with Sifu at <a href="mailto:real.owner@gmail.com">real.owner@gmail.com</a> or call +33 6 12 34 56 78.</p>',
+        descriptionMarkdown:
+          'Book with Sifu at [real.owner@gmail.com](mailto:real.owner@gmail.com) or call +33 6 12 34 56 78.',
+        location: 'Dojo Paris, contact 06 12 34 56 78 or real.owner@gmail.com',
+      }),
+      index,
+    );
+    expect(out['description']).toBe(
+      `<p>Book with Sifu at <a href="mailto:${REDACTED_EMAIL}">${REDACTED_EMAIL}</a> or call ${REDACTED_PHONE}.</p>`,
+    );
+    expect(out['descriptionMarkdown']).toBe(
+      `Book with Sifu at [${REDACTED_EMAIL}](mailto:${REDACTED_EMAIL}) or call ${REDACTED_PHONE}.`,
+    );
+    expect(out['location']).toBe(`Dojo Paris, contact ${REDACTED_PHONE} or ${REDACTED_EMAIL}`);
+  });
+
+  it('leaves free-text fields absent rather than materialising them', () => {
+    const out = anonymiseEvent(anEvent(), index);
+    expect('description' in out).toBe(false);
+    expect('descriptionMarkdown' in out).toBe(false);
+    expect('location' in out).toBe(false);
+  });
+
   it('leaves no real name, email or personal URL anywhere in the output', () => {
     const out = anonymiseEvent(anEvent({ contacts }), index);
     for (const s of allStrings(out)) {
@@ -170,5 +201,68 @@ describe('anonymiseEvent', () => {
     expect(out['title']).toBe('Sydney Workshop');
     expect(out['ownerDocId']).toBe('ownerDoc');
     expect(out['managerDocIds']).toEqual(['mgrDoc1', 'mgrDoc2']);
+  });
+});
+
+describe('redactFreeText', () => {
+  it('keeps the links the events pages render, which carry no PII', () => {
+    for (const url of [
+      'https://www.google.com/maps/search/?api=1&query=Dojo+Paris',
+      'https://calendar.google.com/event?eid=abc123',
+      'https://www.iliqchuan.com/workshops',
+      'https://firebasestorage.googleapis.com/v0/b/x/o/hero.jpg',
+    ]) {
+      expect(redactFreeText(`See ${url} for details`)).toBe(`See ${url} for details`);
+    }
+  });
+
+  it('replaces links to somebody else, which may be a personal site', () => {
+    expect(redactFreeText('Book at https://sifu-dupont.fr/stages')).toBe(`Book at ${REDACTED_URL}`);
+    expect(redactFreeText('Book at www.sifu-dupont.fr/stages')).toBe(`Book at ${REDACTED_URL}`);
+  });
+
+  it('sees through the Google Calendar /url redirector to the real destination', () => {
+    // Calendar rewrites outbound links this way, so an allowlisted google.com
+    // host can still be carrying somebody's personal site in its query string.
+    expect(
+      redactFreeText('https://www.google.com/url?q=https://sifu-dupont.fr/stages&sa=D'),
+    ).toBe(REDACTED_URL);
+    // ...but a wrapped map link is not PII and stays.
+    const wrappedMap = 'https://www.google.com/url?q=https://www.google.com/maps/search/x&sa=D';
+    expect(redactFreeText(wrappedMap)).toBe(wrappedMap);
+  });
+
+  it('treats trailing punctuation as sentence, not link', () => {
+    expect(redactFreeText('Details: https://www.iliqchuan.com/a.')).toBe(
+      'Details: https://www.iliqchuan.com/a.',
+    );
+    expect(redactFreeText('Details: https://sifu-dupont.fr/a.')).toBe(`Details: ${REDACTED_URL}.`);
+  });
+
+  it('does not mistake dates, times or prices for phone numbers', () => {
+    for (const text of [
+      'Seminar 2-4 December 2026',
+      'Doors 10:00-17:00 each day',
+      'Cost is 1,200 EUR for the weekend',
+      'Runs 0800-1200 on Saturday',
+      'Group of 10 to 12 students',
+    ]) {
+      expect(redactFreeText(text)).toBe(text);
+    }
+  });
+
+  it('does not let a kept link swallow numbers elsewhere in the copy', () => {
+    // Guards the internal stash-and-restore: plain numbers in the surrounding
+    // prose must survive untouched.
+    expect(redactFreeText('From 10 to 12 at https://www.iliqchuan.com/x, room 3')).toBe(
+      'From 10 to 12 at https://www.iliqchuan.com/x, room 3',
+    );
+  });
+
+  it('passes through copy with nothing to redact, including empty strings', () => {
+    expect(redactFreeText('A weekend of internal martial arts training.')).toBe(
+      'A weekend of internal martial arts training.',
+    );
+    expect(redactFreeText('')).toBe('');
   });
 });


### PR DESCRIPTION
Follow-up to #56. That PR made `anonymiseEvent` rewrite the structured owner/manager/contact identity fields, but `description`, `descriptionMarkdown` and `location` still passed through verbatim. Much of that copy is pasted in from Google Calendar, so it routinely carries the organiser's own email, phone number and personal links inline.

The copy is public-facing — it renders on the live events pages — so PII is substituted **in place** rather than the field being blanked. Seeded events keep prose of a realistic shape and length, which is the reason the export carries real descriptions at all.

## What gets redacted

| Target | Replacement | Notes |
|---|---|---|
| Emails | `event-contact@example.com` | Runs after the URL pass, so it also covers `mailto:` hrefs |
| Phone numbers | `555-0000` | Anchored on `+CC` / `0X`, gated on a 9–15 digit count |
| Off-allowlist links | `https://example.com/event-link` | ILC, Google and the storage buckets images are embedded from are kept |

Fields that are absent stay absent rather than being materialised as empty strings.

## The Google Calendar redirector

Worth a look during review. Calendar rewrites outbound links through `google.com/url?q=<target>`, so an allowlisted host can still carry somebody's personal site in its query string — and because that rewriting is automatic, it's the *common* shape for personal links in this data rather than an edge case. An early version of this change leaked them:

```
IN : ...google.com/url?q=https://sifu-dupont.fr/stages&sa=D
OUT: ...google.com/url?q=https://sifu-dupont.fr/stages&sa=D   ← leaked
```

`isKeptUrl` now unwraps the redirector and judges the destination, so a wrapped personal site is replaced while a wrapped maps link survives. Caught by running the redactor over realistic Calendar HTML rather than only the unit tests.

## Judgment calls

- **Phone matching favours false negatives.** Runs under 9 digits are ignored, so `0800-1200` (a time range) survives — but so would a genuine 8-digit local number. Given how much of this copy is dates, times and prices, I weighted against mangling real text.
- **`info@iliqchuan.com` is redacted too.** It's an org address rather than personal PII, so that's mild over-redaction chosen for simplicity.

## Testing

`pnpm test:fixtures` — 26 passing. New cases cover each redaction target, the redirector unwrap, trailing punctuation, and the false-positive guards (dates, times, prices, and plain numbers sitting next to a kept link).

Not verified against a real export: `tmp/seed-data/` is gitignored and regenerating it needs prod ADC. The tests use synthetic samples shaped like that data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)