### PR TITLE
fix(event-edit): independent contact checkboxes and a creator that always shows

### DIFF
--- a/src/app/event-edit/event-edit.html
+++ b/src/app/event-edit/event-edit.html
@@ -403,15 +403,15 @@
                   [searchableSet]="dataService.members"
                   [placeholder]="'Search for a member'"
                   [displayFns]="memberDisplayFns"
-                  [initSearchTerm]="eventFormModel().ownerMemberId"
+                  [initSearchTerm]="creatorMemberId()"
                   [inputBoxIsChip]="true"
                   (textUpdated)="updateOwnerMember($event)"
                 ></app-autocomplete>
                 @if (eventFormModel().ownerDocId) {
                   <span class="note selected-note">
-                    <span>{{ eventFormModel().ownerName || eventFormModel().ownerMemberId }}</span>
-                    @if (eventFormModel().ownerMemberId) {
-                      <span class="identifier-chip">{{ eventFormModel().ownerMemberId }}</span>
+                    <span>{{ creatorName() || creatorMemberId() }}</span>
+                    @if (creatorMemberId()) {
+                      <span class="identifier-chip">{{ creatorMemberId() }}</span>
                       <a class="icon-only-button" [href]="ownerMemberLink()" title="Go to member">
                         <app-icon name="visibility"></app-icon>
                       </a>
@@ -428,12 +428,23 @@
                   shown as the contact.
                 </div>
               }
+            } @else {
+              <!-- Only admins can reassign a non-instructor creator, but everyone
+                   who can edit the event needs to see who it is. -->
+              <div class="owner-selector-row">
+                <span class="note selected-note">
+                  <span>{{ creatorName() || creatorMemberId() }}</span>
+                  @if (creatorMemberId()) {
+                    <span class="identifier-chip">{{ creatorMemberId() }}</span>
+                  }
+                </span>
+              </div>
             }
           } @else {
             <div class="owner-selector-row">
               <app-instructor-selector
                 [placeholder]="'Search for an instructor'"
-                [value]="eventFormModel().ownerInstructorId"
+                [value]="creatorInstructorId()"
                 (valueChange)="updateOwnerInstructor($event)"
               ></app-instructor-selector>
               @if (eventFormModel().ownerDocId) {
@@ -452,7 +463,7 @@
                 [checked]="assignMemberAsOwner()"
                 (change)="assignMemberAsOwner.set($any($event.target).checked)"
               />
-              Allow a non-instructor to be the event creator
+              Set a non-instructor to be the event creator
             </label>
           }
 
@@ -471,7 +482,7 @@
 
           <!-- An instructor creator is contacted through their public profile,
                so only a non-instructor needs these details filled in. -->
-          @if (isListedContact(eventFormModel().ownerDocId) && !eventFormModel().ownerInstructorId) {
+          @if (isListedContact(eventFormModel().ownerDocId) && !creatorInstructorId()) {
             <div class="mini-profile">
               <label for="ownerContactName">Contact name</label>
               <input

--- a/src/app/event-edit/event-edit.html
+++ b/src/app/event-edit/event-edit.html
@@ -469,7 +469,9 @@
             </label>
           }
 
-          @if (isListedContact(eventFormModel().ownerDocId)) {
+          <!-- An instructor creator is contacted through their public profile,
+               so only a non-instructor needs these details filled in. -->
+          @if (isListedContact(eventFormModel().ownerDocId) && !eventFormModel().ownerInstructorId) {
             <div class="mini-profile">
               <label for="ownerContactName">Contact name</label>
               <input
@@ -506,7 +508,7 @@
             <div class="manager-row" style="display: flex; gap: 10px; align-items: center; margin-bottom: 5px;">
               <app-instructor-selector
                 [placeholder]="'Search for a manager'"
-                [value]="managerInstructorId(managerId)"
+                [value]="instructorIdForMember(managerId)"
                 (valueChange)="updateManagerDocId($index, $event)"
               ></app-instructor-selector>
               <button type="button" class="icon-only-button" (click)="removeManagerDocId($index)" title="Remove manager">
@@ -518,7 +520,15 @@
                 </button>
               }
             </div>
-            @if (managerId) {
+            <!-- A contact is one flag per person, so the creator — who is also
+                 a manager on every proposed event — is listed from the Creator
+                 section above rather than getting a second checkbox here that
+                 would move in lockstep with it. -->
+            @if (managerId && managerId === eventFormModel().ownerDocId) {
+              <div class="note manager-contact-row">
+                Also the event creator — set their public listing above.
+              </div>
+            } @else if (managerId) {
               <label class="checkbox-row manager-contact-row">
                 <input
                   type="checkbox"
@@ -527,7 +537,8 @@
                 />
                 List as a public contact
               </label>
-              @if (contactFor(managerId); as contact) {
+              <!-- An instructor is contacted through their public profile. -->
+              @if (!contactIsInstructor(managerId) && contactFor(managerId); as contact) {
                 <div class="mini-profile manager-contact-profile">
                   <label [for]="'contactEmail-' + $index">Contact email</label>
                   <input

--- a/src/app/event-edit/event-edit.spec.ts
+++ b/src/app/event-edit/event-edit.spec.ts
@@ -504,4 +504,39 @@ describe('EventEditComponent', () => {
 
     expect(fixture.nativeElement.querySelector('.manager-contact-profile')).toBeTruthy();
   });
+
+  it('shows a creator that the event only stored as a doc ID', async () => {
+    // Events created before the owner identity was cached on the document have
+    // an ownerDocId and nothing else, so the creator has to be resolved from
+    // the caches or the section renders blank.
+    const creator = { docId: 'creator-doc-id', instructorId: '7', memberId: 'MEM-7', name: 'Creator Name' };
+    (mockDataManagerService.instructors as any).setEntries([creator]);
+
+    await renderEvent({
+      ownerDocId: 'creator-doc-id',
+      managerDocIds: ['creator-doc-id'],
+      contacts: [],
+    });
+
+    const selector: HTMLInputElement = fixture.nativeElement.querySelector(
+      '.owner-editor input[type="text"]',
+    );
+    expect(selector.value).toBe('7');
+    expect(fixture.nativeElement.querySelector('.owner-editor').textContent)
+      .toContain('Creator Name');
+  });
+
+  it('caches a doc-ID-only creator identity on save', async () => {
+    const creator = { docId: 'creator-doc-id', instructorId: '7', memberId: 'MEM-7', name: 'Creator Name' };
+    (mockDataManagerService.instructors as any).setEntries([creator]);
+    await renderEvent({ ownerDocId: 'creator-doc-id', managerDocIds: [], contacts: [] });
+
+    await component.saveEvent({ preventDefault: vi.fn() } as unknown as Event);
+
+    expect(component.errorMessage()).toBe(null);
+    const saved = (updateDoc as any).mock.calls.at(-1)[1];
+    expect(saved.ownerName).toBe('Creator Name');
+    expect(saved.ownerMemberId).toBe('MEM-7');
+    expect(saved.ownerInstructorId).toBe('7');
+  });
 });

--- a/src/app/event-edit/event-edit.spec.ts
+++ b/src/app/event-edit/event-edit.spec.ts
@@ -395,4 +395,113 @@ describe('EventEditComponent', () => {
       contactUrl: 'https://example.com',
     }]);
   });
+
+  // --- Contact checkboxes and mini-profiles in the rendered form ---------
+
+  // Loads an event and renders it. Contacts are keyed by member doc ID, so the
+  // rendered checkboxes are what tell us whether two of them share a flag.
+  async function renderEvent(event: Partial<IlcEvent>) {
+    (mockDataManagerService.getEventById as any).mockResolvedValue({
+      docId: 'test-doc-id',
+      title: 'T', start: '2026-04-13', end: '2026-04-13',
+      description: 'D', location: 'L',
+      status: EventStatus.Proposed,
+      heroImageUrl: '',
+      ...event,
+    } as IlcEvent);
+    await component.loadEvent();
+    fixture.detectChanges();
+    await fixture.whenStable();
+  }
+
+  const creatorCheckbox = (): HTMLInputElement =>
+    fixture.nativeElement.querySelector('.owner-editor input[type="checkbox"]');
+  const managerCheckboxes = (): HTMLInputElement[] =>
+    Array.from(fixture.nativeElement.querySelectorAll('.manager-contact-row input[type="checkbox"]'));
+
+  it('gives the creator a single contact checkbox when they are also a manager', async () => {
+    const creator = { docId: 'creator-doc-id', instructorId: '7', memberId: 'MEM-7', name: 'Creator' };
+    const other = { docId: 'other-doc-id', instructorId: '9', memberId: 'MEM-9', name: 'Other' };
+    (mockDataManagerService.instructors as any).setEntries([creator, other]);
+
+    // Every proposed event starts this way: the submitter is both the creator
+    // and a manager.
+    await renderEvent({
+      ownerDocId: 'creator-doc-id',
+      ownerName: 'Creator',
+      ownerMemberId: 'MEM-7',
+      ownerInstructorId: '7',
+      managerDocIds: ['creator-doc-id', 'other-doc-id'],
+      contacts: [],
+    });
+
+    // Only the second manager gets a row checkbox; the creator's listing is
+    // controlled once, in the Creator section.
+    expect(managerCheckboxes().length).toBe(1);
+
+    creatorCheckbox().click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(component.isListedContact('creator-doc-id')).toBe(true);
+    expect(component.isListedContact('other-doc-id')).toBe(false);
+    expect(managerCheckboxes()[0].checked).toBe(false);
+  });
+
+  it('keeps each manager contact checkbox independent', async () => {
+    const a = { docId: 'doc-a', instructorId: '1', memberId: 'MEM-A', name: 'A' };
+    const b = { docId: 'doc-b', instructorId: '2', memberId: 'MEM-B', name: 'B' };
+    (mockDataManagerService.instructors as any).setEntries([a, b]);
+
+    await renderEvent({ ownerDocId: '', managerDocIds: ['doc-a', 'doc-b'], contacts: [] });
+
+    const [first, second] = managerCheckboxes();
+    first.click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(component.isListedContact('doc-a')).toBe(true);
+    expect(component.isListedContact('doc-b')).toBe(false);
+    expect(managerCheckboxes()[1].checked).toBe(false);
+    expect(second).toBeTruthy();
+  });
+
+  it('omits the contact details fields for an instructor', async () => {
+    const instructor = { docId: 'doc-a', instructorId: '1', memberId: 'MEM-A', name: 'A' };
+    (mockDataManagerService.instructors as any).setEntries([instructor]);
+
+    await renderEvent({
+      ownerDocId: 'creator-doc-id',
+      ownerInstructorId: '7',
+      managerDocIds: ['doc-a'],
+      contacts: [
+        { memberDocId: 'creator-doc-id', name: 'Creator', memberId: 'MEM-7', instructorId: '7', contactEmail: '', contactUrl: '' },
+        { memberDocId: 'doc-a', name: 'A', memberId: 'MEM-A', instructorId: '1', contactEmail: '', contactUrl: '' },
+      ],
+    });
+
+    // Both are instructors: their public profile is the contact, so there is
+    // nothing extra to fill in.
+    expect(fixture.nativeElement.querySelectorAll('.mini-profile').length).toBe(0);
+  });
+
+  it('keeps the contact details fields for a non-instructor', async () => {
+    (mockDataManagerService.instructors as any).setEntries([]);
+    (mockDataManagerService.members as any).setEntries([
+      { docId: 'doc-a', instructorId: '', memberId: 'MEM-A', name: 'A' },
+    ]);
+
+    await renderEvent({
+      ownerDocId: 'creator-doc-id',
+      ownerName: 'Creator',
+      ownerInstructorId: '',
+      managerDocIds: ['doc-a'],
+      contacts: [
+        { memberDocId: 'creator-doc-id', name: 'Creator', memberId: '', instructorId: '', contactEmail: '', contactUrl: '' },
+        { memberDocId: 'doc-a', name: 'A', memberId: 'MEM-A', instructorId: '', contactEmail: '', contactUrl: '' },
+      ],
+    });
+
+    expect(fixture.nativeElement.querySelector('.manager-contact-profile')).toBeTruthy();
+  });
 });

--- a/src/app/event-edit/event-edit.ts
+++ b/src/app/event-edit/event-edit.ts
@@ -583,14 +583,15 @@ export class EventEditComponent implements OnInit {
     return byDocId;
   });
 
-  // The instructorId to show in a manager row, or '' when the row is empty or
-  // unresolvable. Must round-trip with updateManagerDocId below, otherwise a
-  // just-picked manager renders as "None selected".
-  managerInstructorId(managerDocId: string): string {
-    if (!managerDocId) return '';
+  // The instructorId for a member doc ID, or '' if they have no public
+  // instructor profile. Used for the manager row's value, which must round-trip
+  // with updateManagerDocId below, otherwise a just-picked manager renders as
+  // "None selected".
+  instructorIdForMember(memberDocId: string): string {
+    if (!memberDocId) return '';
     return (
-      this.instructorsByDocId().get(managerDocId)?.instructorId ||
-      this.dataService.members.get(managerDocId)?.instructorId ||
+      this.instructorsByDocId().get(memberDocId)?.instructorId ||
+      this.dataService.members.get(memberDocId)?.instructorId ||
       ''
     );
   }
@@ -651,6 +652,17 @@ export class EventEditComponent implements OnInit {
 
   contactFor(memberDocId: string): EventContact | undefined {
     return this.eventFormModel().contacts.find((c) => c.memberDocId === memberDocId);
+  }
+
+  // A contact with a public instructor profile needs no separately-entered
+  // name, email or link — the event page links to their profile instead. The
+  // cached instructorId is the fallback for someone who has since dropped off
+  // the public instructor list.
+  contactIsInstructor(memberDocId: string): boolean {
+    return !!(
+      this.instructorIdForMember(memberDocId) ||
+      this.contactFor(memberDocId)?.instructorId
+    );
   }
 
   setContactListed(memberDocId: string, listed: boolean) {

--- a/src/app/event-edit/event-edit.ts
+++ b/src/app/event-edit/event-edit.ts
@@ -13,6 +13,7 @@ import {
   inject,
   signal,
   computed,
+  linkedSignal,
   effect,
   ChangeDetectionStrategy,
   OnInit,
@@ -203,10 +204,41 @@ export class EventEditComponent implements OnInit {
     documents: [],
   });
 
-  // UI-only: when an admin ticks this, the owner picker switches from the
+  // The creator's identity for display. Events written before these fields were
+  // cached on the document hold only an ownerDocId, so fall back to the caches —
+  // otherwise the whole Creator section renders blank.
+  creatorInstructorId = computed(() =>
+    this.eventFormModel().ownerInstructorId ||
+    this.instructorIdForMember(this.eventFormModel().ownerDocId));
+
+  creatorName = computed(() => {
+    const m = this.eventFormModel();
+    return m.ownerName || this.memberFieldFor(m.ownerDocId, 'name');
+  });
+
+  creatorMemberId = computed(() => {
+    const m = this.eventFormModel();
+    return m.ownerMemberId || this.memberFieldFor(m.ownerDocId, 'memberId');
+  });
+
+  private memberFieldFor(memberDocId: string, field: 'name' | 'memberId'): string {
+    if (!memberDocId) return '';
+    return (
+      this.instructorsByDocId().get(memberDocId)?.[field] ||
+      this.dataService.members.get(memberDocId)?.[field] ||
+      ''
+    );
+  }
+
+  // UI-only: when an admin ticks this, the creator picker switches from the
   // instructor autocomplete to a member autocomplete so any member (not just
-  // instructors) can be assigned as the event owner/contact.
-  assignMemberAsOwner = signal(false);
+  // instructors) can be assigned as the event creator/contact. Derived from the
+  // resolved creator so it settles on the right mode once the instructor cache
+  // arrives, while still honouring an admin's manual toggle.
+  assignMemberAsOwner = linkedSignal(() => {
+    const m = this.eventFormModel();
+    return !!m.ownerDocId && !this.creatorInstructorId();
+  });
 
   form: FieldTree<EventFormModel> = form(this.eventFormModel, (schema) => {
     required(schema.title, { message: 'Title is required.' });
@@ -380,9 +412,6 @@ export class EventEditComponent implements OnInit {
         }
         this.event.set(data);
         this.eventFormModel.set(toFormModel(data));
-        // Default the picker to "member" mode when the existing owner is a
-        // non-instructor member, so an admin sees the member selector.
-        this.assignMemberAsOwner.set(!!data.ownerDocId && !(data.ownerInstructorId || ''));
         this.titleLoaded.emit(data.title);
         if (data.docId && this.canManageMaterials()) {
           this.loadMaterials(data.docId);
@@ -993,7 +1022,15 @@ export class EventEditComponent implements OnInit {
     this.isSaving.set(true);
     try {
       const docRef = doc(this.db, 'events', eventData.docId);
-      const formData = this.editableEvent();
+      // A creator the event only stored as a doc ID gets their identity cached
+      // on save, so their public contact entry resolves to an instructor
+      // profile instead of showing up as a bare name.
+      const formData = {
+        ...this.editableEvent(),
+        ownerName: this.creatorName(),
+        ownerMemberId: this.creatorMemberId(),
+        ownerInstructorId: this.creatorInstructorId(),
+      };
       const managerDocIds = formData.managerDocIds.filter(Boolean);
       const contacts = contactsToSave({ ...formData, managerDocIds });
       await updateDoc(docRef, {


### PR DESCRIPTION
Two fixes to the public-contact controls on the event edit page.

## One contact checkbox per person

Contacts are keyed by member doc ID, so there is a single "listed publicly"
flag per person. The creator is also a manager on every proposed event (the
submitter is both), which rendered that one flag as **two** checkboxes — the
Creator one and a row in the Managers list — so ticking either appeared to tick
the other. The creator's manager row now shows a note pointing at the Creator
section instead of a duplicate checkbox, leaving every remaining checkbox
independent.

Manager-to-manager checkboxes were already independent; there is a test
covering that so it stays true.

## No contact details for instructors

The contact name/email/link fields are dropped for anyone with a public
instructor profile, creator or manager alike: the event page already renders
an instructor contact as a link to that profile, so the extra entry had
nothing to add. Non-instructors keep the fields.

## A creator stored only as a doc ID

Events written before the creator's identity was cached on the document carry
an `ownerDocId` and nothing else, which left the Creator section blank while a
manager row below it said "Also the event creator":

- with no cached `ownerInstructorId` the picker fell into non-instructor mode,
  where the member box seeded from an empty `ownerMemberId` and the name note
  rendered empty;
- for a non-admin that branch rendered *nothing at all*, since only admins get
  the member selector.

The creator's instructorId, name and memberId now resolve from the caches when
the event lacks them, the picker mode is derived from that resolved value so it
settles once the instructor cache arrives, non-admins get a read-only creator,
and the resolved identity is written back on save so the public contact links
to the instructor profile.

Also rewords the admin toggle to "Set a non-instructor to be the event creator".

## Testing

438 tests pass, production build clean. New coverage: duplicate creator/manager
checkbox, checkbox independence, instructor vs non-instructor contact fields,
doc-ID-only creator rendering, and the save-time identity backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)