### PR TITLE
fix(test): index-signature access in the grading e2e member snapshot

### DIFF
--- a/tests/e2e/grading-paid-and-snapshot.spec.ts
+++ b/tests/e2e/grading-paid-and-snapshot.spec.ts
@@ -59,8 +59,8 @@ const memberLevel = (docId: string) => async () => {
   const snap = await db.collection('members').doc(docId).get();
   const d = (snap.data() as Record<string, unknown> | undefined) || {};
   return {
-    studentLevel: (d.studentLevel as string) || '',
-    applicationLevel: (d.applicationLevel as string) || '',
+    studentLevel: (d['studentLevel'] as string) || '',
+    applicationLevel: (d['applicationLevel'] as string) || '',
   };
 };
 


### PR DESCRIPTION
`pnpm run typecheck:tests` fails on main:

```
tests/e2e/grading-paid-and-snapshot.spec.ts(62,22): error TS4111: Property 'studentLevel' comes from an index signature, so it must be accessed with ['studentLevel'].
tests/e2e/grading-paid-and-snapshot.spec.ts(63,26): error TS4111: Property 'applicationLevel' ...
```

`tests/tsconfig.json` sets `noPropertyAccessFromIndexSignature`, so reading
these off a `Record<string, unknown>` needs bracket access. Pre-existing since
`3efc72e`; the e2e suite itself is emulator-gated so it never surfaced in CI-less
local runs.

`pnpm run typecheck:tests` is clean with this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)