### PR TITLE
feat(my-students): mark a lapsed student inactive, from an actions menu

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "emulator",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["run", "start:emulator"],
+      "port": 4200
+    }
+  ]
+}

--- a/functions/src/data-model.ts
+++ b/functions/src/data-model.ts
@@ -141,6 +141,49 @@ export enum MembershipType {
   NotYetAMember = 'NotYetAMember',
 }
 
+/** The membership fields the active/inactive rules below look at. */
+export type MembershipFields = {
+  membershipType: MembershipType;
+  currentMembershipExpires: string;
+};
+
+/**
+ * Whether the member's ILC membership is live right now: Life members always
+ * are, Annual members are up to and including `currentMembershipExpires`, and
+ * every other type (Inactive, Deceased, NotYetAMember) never is.
+ *
+ * `today` is a YYYY-MM-DD string, the same format expiry dates are stored in,
+ * so the two compare lexicographically.
+ */
+export function hasActiveMembership(
+  member: MembershipFields,
+  today: string,
+): boolean {
+  if (member.membershipType === MembershipType.Life) return true;
+  if (member.membershipType !== MembershipType.Annual) return false;
+  const expires = member.currentMembershipExpires;
+  return !!expires && expires >= today;
+}
+
+/**
+ * Whether a primary instructor may mark this student's membership Inactive
+ * (the action offered on the My Students view). Only lapsed memberships
+ * qualify: a live membership must never be switched off this way, and someone
+ * already recorded as Inactive or Deceased has nothing to change.
+ */
+export function canMarkMembershipInactive(
+  member: MembershipFields,
+  today: string,
+): boolean {
+  if (
+    member.membershipType === MembershipType.Inactive ||
+    member.membershipType === MembershipType.Deceased
+  ) {
+    return false;
+  }
+  return !hasActiveMembership(member, today);
+}
+
 /** Status of a membership or license expiry. */
 export enum ExpiryStatus {
   Valid = 'valid',
@@ -537,6 +580,10 @@ export enum NotificationKind {
   // rather than an action: picking a new primary instructor is entirely optional
   // and in practice is not something the student is expected to act on here.
   PrimaryInstructorRemoved = 'PrimaryInstructorRemoved',
+  // Sent to a student when their primary instructor records their lapsed
+  // membership as Inactive. Informational: renewing is always an option, but
+  // nothing is being asked of them here.
+  MembershipMarkedInactive = 'MembershipMarkedInactive',
   MembershipPending = 'MembershipPending',
   MembershipActivated = 'MembershipActivated',
   InstructorLicensePending = 'InstructorLicensePending',
@@ -659,6 +706,12 @@ export interface NotificationPrimaryInstructorRemovedData {
   instructorName: string;
 }
 
+export interface NotificationMembershipMarkedInactiveData {
+  // The primary instructor who recorded the membership as inactive.
+  instructorId: string;
+  instructorName: string;
+}
+
 export type MemberNotification = MemberNotificationCommon & (
   | {
     kind: NotificationKind.GradingRequestAccepted;
@@ -739,6 +792,10 @@ export type MemberNotification = MemberNotificationCommon & (
   | {
     kind: NotificationKind.PrimaryInstructorRemoved;
     data: NotificationPrimaryInstructorRemovedData;
+  }
+  | {
+    kind: NotificationKind.MembershipMarkedInactive;
+    data: NotificationMembershipMarkedInactiveData;
   }
 );
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -32,7 +32,7 @@ export {
 
 export { requestGrading } from './grading-request';
 
-export { removeStudentFromInstructor } from './instructor-students';
+export { removeStudentFromInstructor, markStudentInactive } from './instructor-students';
 
 export { sendPushOnNotification } from './send-push';
 

--- a/functions/src/instructor-students.spec.ts
+++ b/functions/src/instructor-students.spec.ts
@@ -1,44 +1,57 @@
-/* instructor-students.spec.ts — tests for the "instructor removes a student"
- * permission guard and the message the removed student is sent. */
+/* instructor-students.spec.ts — tests for the permission guards behind the
+ * actions an instructor can take on their own student (removing them, and
+ * recording a lapsed membership as inactive), and the messages the student is
+ * sent for each. */
 import { describe, it, expect } from 'vitest';
-import { findRemovingInstructor, removedStudentMarkdown } from './instructor-students';
-import { Member, NotificationKind, notificationStyle } from './data-model';
+import {
+  findPrimaryInstructorProfile,
+  markedInactiveMarkdown,
+  markInactiveRefusal,
+  removedStudentMarkdown,
+} from './instructor-students';
+import {
+  canMarkMembershipInactive,
+  Member,
+  MembershipType,
+  NotificationKind,
+  notificationStyle,
+} from './data-model';
 
 const member = (overrides: Partial<Member>): Member =>
   ({ docId: 'doc', name: '', memberId: '', instructorId: '', primaryInstructorId: '', ...overrides }) as Member;
 
-describe('findRemovingInstructor', () => {
+describe('findPrimaryInstructorProfile', () => {
   const sifu = member({ docId: 'sifu-doc', name: 'Sifu Sam', instructorId: 'INST-1' });
   const student = member({ docId: 'student-doc', memberId: 'FR23', primaryInstructorId: 'INST-1' });
 
   it('finds the caller profile whose instructorId is the student’s primary instructor', () => {
-    expect(findRemovingInstructor([sifu], student)).toBe(sifu);
+    expect(findPrimaryInstructorProfile([sifu], student)).toBe(sifu);
   });
 
   it('picks the matching profile when the caller manages several', () => {
     const otherProfile = member({ docId: 'other-doc', instructorId: 'INST-9' });
-    expect(findRemovingInstructor([otherProfile, sifu], student)).toBe(sifu);
+    expect(findPrimaryInstructorProfile([otherProfile, sifu], student)).toBe(sifu);
   });
 
   it('rejects an instructor who is not the student’s primary instructor', () => {
     const otherSifu = member({ docId: 'other-doc', instructorId: 'INST-2' });
-    expect(findRemovingInstructor([otherSifu], student)).toBeUndefined();
+    expect(findPrimaryInstructorProfile([otherSifu], student)).toBeUndefined();
   });
 
   it('rejects a caller with no instructor ID', () => {
     const nonInstructor = member({ docId: 'plain-doc', instructorId: '' });
-    expect(findRemovingInstructor([nonInstructor], student)).toBeUndefined();
+    expect(findPrimaryInstructorProfile([nonInstructor], student)).toBeUndefined();
   });
 
   it('rejects when the student has no primary instructor, even for a caller with no instructorId', () => {
     const unattached = member({ docId: 'student-doc', primaryInstructorId: '' });
     const nonInstructor = member({ docId: 'plain-doc', instructorId: '' });
-    expect(findRemovingInstructor([nonInstructor], unattached)).toBeUndefined();
-    expect(findRemovingInstructor([sifu], unattached)).toBeUndefined();
+    expect(findPrimaryInstructorProfile([nonInstructor], unattached)).toBeUndefined();
+    expect(findPrimaryInstructorProfile([sifu], unattached)).toBeUndefined();
   });
 
   it('rejects when the caller manages no member profiles', () => {
-    expect(findRemovingInstructor([], student)).toBeUndefined();
+    expect(findPrimaryInstructorProfile([], student)).toBeUndefined();
   });
 });
 
@@ -57,5 +70,89 @@ describe('removedStudentMarkdown', () => {
   // know rather than a TODO — it must not render with the 'action' styling.
   it('is an informational notification, not an action', () => {
     expect(notificationStyle(NotificationKind.PrimaryInstructorRemoved)).toBe('info');
+  });
+});
+
+describe('markedInactiveMarkdown', () => {
+  const sifu = member({ name: 'Sifu Sam', instructorId: 'INST-1' });
+
+  it('names the instructor, links to renewal, and invites a conversation', () => {
+    const md = markedInactiveMarkdown(sifu);
+    expect(md).toContain('Sifu Sam');
+    expect(md).toContain('INST-1');
+    // A path link, so the app's in-page link handler routes it (a '#/…' link
+    // is deliberately left alone by that handler and would go nowhere).
+    expect(md).toContain('](/products)');
+    expect(md).toContain('talk to');
+  });
+
+  // The student keeps their instructor and their records; only the membership
+  // status changes. Saying so avoids reading this as a removal.
+  it('says the instructor relationship is unchanged', () => {
+    expect(markedInactiveMarkdown(sifu)).toContain('still your primary instructor');
+  });
+
+  // Renewing is optional, so this is something to know rather than a TODO.
+  it('is an informational notification, not an action', () => {
+    expect(notificationStyle(NotificationKind.MembershipMarkedInactive)).toBe('info');
+  });
+});
+
+// The guard the markStudentInactive callable applies on top of the primary
+// instructor check: only a membership that has actually lapsed can be recorded
+// as inactive.
+describe('canMarkMembershipInactive', () => {
+  const today = '2026-08-03';
+  const membership = (
+    membershipType: MembershipType,
+    currentMembershipExpires = '',
+  ) => ({ membershipType, currentMembershipExpires });
+
+  it('allows an Annual membership that has expired', () => {
+    expect(
+      canMarkMembershipInactive(membership(MembershipType.Annual, '2026-08-02'), today),
+    ).toBe(true);
+  });
+
+  it('allows an Annual membership with no expiry date recorded', () => {
+    expect(canMarkMembershipInactive(membership(MembershipType.Annual), today)).toBe(true);
+  });
+
+  it('allows a student who never became a member', () => {
+    expect(
+      canMarkMembershipInactive(membership(MembershipType.NotYetAMember), today),
+    ).toBe(true);
+  });
+
+  it('refuses an Annual membership that is still current', () => {
+    expect(
+      canMarkMembershipInactive(membership(MembershipType.Annual, '2026-12-31'), today),
+    ).toBe(false);
+  });
+
+  // Expiry is inclusive: a membership is still current on the day it expires.
+  it('refuses an Annual membership expiring today', () => {
+    expect(
+      canMarkMembershipInactive(membership(MembershipType.Annual, today), today),
+    ).toBe(false);
+  });
+
+  it('refuses a Life membership, which never lapses', () => {
+    expect(canMarkMembershipInactive(membership(MembershipType.Life), today)).toBe(false);
+  });
+
+  it('refuses members already recorded as Inactive or Deceased', () => {
+    expect(canMarkMembershipInactive(membership(MembershipType.Inactive), today)).toBe(false);
+    expect(canMarkMembershipInactive(membership(MembershipType.Deceased), today)).toBe(false);
+  });
+});
+
+// The instructor only sees these when their copy of the member was stale, so
+// each refusal has to explain which case it hit rather than blaming the date.
+describe('markInactiveRefusal', () => {
+  it('distinguishes already-inactive, deceased, and still-current', () => {
+    expect(markInactiveRefusal(MembershipType.Inactive)).toContain('already marked inactive');
+    expect(markInactiveRefusal(MembershipType.Deceased)).toContain('deceased');
+    expect(markInactiveRefusal(MembershipType.Annual)).toContain('still current');
   });
 });

--- a/functions/src/instructor-students.ts
+++ b/functions/src/instructor-students.ts
@@ -1,9 +1,11 @@
 /* instructor-students.ts
  *
- * Callable Cloud Function letting an instructor remove a student who lists them
- * as their primary instructor (the "My Students" list at /my-students).
+ * Callable Cloud Functions backing the actions an instructor can take on a
+ * student who lists them as their primary instructor (the "My Students" list at
+ * /my-students): removing the student, and recording a lapsed membership as
+ * Inactive so the student drops out of the list's default view.
  *
- * This has to be a callable rather than a client Firestore write: the security
+ * These have to be callables rather than client Firestore writes: the security
  * rules only let a member's owner, their school's managers, or an admin write a
  * member document, and an instructor is none of those for their students. The
  * removal itself is just clearing the student's `primaryInstructorId`; the
@@ -15,17 +17,22 @@ import { onCall, HttpsError, CallableRequest } from 'firebase-functions/v2/https
 import * as admin from 'firebase-admin';
 import * as logger from 'firebase-functions/logger';
 import { FieldValue } from 'firebase-admin/firestore';
-import { Member, NotificationKind } from './data-model';
+import {
+  canMarkMembershipInactive,
+  Member,
+  MembershipType,
+  NotificationKind,
+} from './data-model';
 import { allowedOrigins, getUserMemberDocIds } from './common';
 import { createMemberNotification } from './notifications';
 
 /**
- * Picks the caller profile entitled to remove `student`: one of the member
+ * Picks the caller profile entitled to act on `student`: one of the member
  * profiles the caller manages whose instructorId is the student's current
  * primary instructor. Returns undefined when no profile qualifies, which is
  * exactly the "not your student" case.
  */
-export function findRemovingInstructor(
+export function findPrimaryInstructorProfile(
   callerProfiles: Member[],
   student: Member,
 ): Member | undefined {
@@ -53,48 +60,110 @@ export function removedStudentMarkdown(instructor: Member): string {
   );
 }
 
+/**
+ * The message the student sees when their primary instructor records their
+ * lapsed membership as Inactive. Says who did it and what it means, and points
+ * at renewal — but as an option, not a demand: this is an 'info' notification.
+ */
+export function markedInactiveMarkdown(instructor: Member): string {
+  const who = `**${instructor.name}** (${instructor.instructorId})`;
+  return (
+    `${who}, your primary instructor, has recorded your ILC membership as ` +
+    `**inactive**, because it is no longer current.\n\n` +
+    `Nothing else changes: ${who} is still your primary instructor and your ` +
+    `records are kept. You will not have access to the members' area while ` +
+    `your membership is inactive.\n\n` +
+    `You can [renew your membership](/products) whenever you like, and it ` +
+    `becomes active again straight away. If you think this was a mistake, ` +
+    `please talk to ${who} directly.`
+  );
+}
+
+/**
+ * Why `markStudentInactive` turned down a student, phrased for the instructor
+ * who tried it. Reached when the UI offered the action against a stale copy of
+ * the member, so it has to say which of the three cases applies.
+ */
+export function markInactiveRefusal(membershipType: MembershipType): string {
+  switch (membershipType) {
+    case MembershipType.Inactive:
+      return 'This student is already marked inactive.';
+    case MembershipType.Deceased:
+      return 'This student is recorded as deceased, so their status is not changed here.';
+    default:
+      return 'This student’s membership is still current, so it cannot be marked inactive.';
+  }
+}
+
+/** The student, their doc ref, and the caller profile allowed to act on them. */
+type StudentAndInstructor = {
+  db: FirebaseFirestore.Firestore;
+  student: Member;
+  studentRef: FirebaseFirestore.DocumentReference;
+  instructor: Member;
+};
+
+/**
+ * Shared front half of both callables: authenticate the caller, load the
+ * student, and check the caller really is that student's primary instructor.
+ * Throws the appropriate HttpsError when any of that fails.
+ *
+ * `action` names the attempted action ("remove a student") so the error
+ * messages the client shows say which one was refused.
+ */
+async function resolveStudentAndInstructor(
+  request: CallableRequest<{ studentMemberDocId: string }>,
+  action: string,
+): Promise<StudentAndInstructor> {
+  if (!request.auth || !request.auth.token.email) {
+    throw new HttpsError(
+      'unauthenticated',
+      `Must be authenticated to ${action}.`,
+    );
+  }
+  const email = request.auth.token.email;
+  const studentMemberDocId = request.data?.studentMemberDocId;
+  if (!studentMemberDocId) {
+    throw new HttpsError('invalid-argument', 'studentMemberDocId is required.');
+  }
+
+  const db = admin.firestore();
+
+  const studentRef = db.collection('members').doc(studentMemberDocId);
+  const studentSnap = await studentRef.get();
+  if (!studentSnap.exists) {
+    throw new HttpsError('not-found', 'Student not found.');
+  }
+  const student = { ...studentSnap.data(), docId: studentSnap.id } as Member;
+
+  // Resolve the caller's own member profiles from the ACL, then read them so
+  // the instructorId check is made against live member docs rather than the
+  // ACL's cached copy.
+  const callerDocIds = await getUserMemberDocIds(email, db);
+  const callerSnaps = await Promise.all(
+    callerDocIds.map((docId) => db.collection('members').doc(docId).get()),
+  );
+  const callerProfiles = callerSnaps
+    .filter((snap) => snap.exists)
+    .map((snap) => ({ ...snap.data(), docId: snap.id }) as Member);
+
+  const instructor = findPrimaryInstructorProfile(callerProfiles, student);
+  if (!instructor) {
+    throw new HttpsError(
+      'permission-denied',
+      `You can only ${action} who lists you as their primary instructor.`,
+    );
+  }
+
+  return { db, student, studentRef, instructor };
+}
+
 export const removeStudentFromInstructor = onCall(
   { cors: allowedOrigins },
   async (request: CallableRequest<{ studentMemberDocId: string }>) => {
-    if (!request.auth || !request.auth.token.email) {
-      throw new HttpsError(
-        'unauthenticated',
-        'Must be authenticated to remove a student.',
-      );
-    }
-    const email = request.auth.token.email;
-    const studentMemberDocId = request.data?.studentMemberDocId;
-    if (!studentMemberDocId) {
-      throw new HttpsError('invalid-argument', 'studentMemberDocId is required.');
-    }
-
-    const db = admin.firestore();
-
-    const studentRef = db.collection('members').doc(studentMemberDocId);
-    const studentSnap = await studentRef.get();
-    if (!studentSnap.exists) {
-      throw new HttpsError('not-found', 'Student not found.');
-    }
-    const student = { ...studentSnap.data(), docId: studentSnap.id } as Member;
-
-    // Resolve the caller's own member profiles from the ACL, then read them so
-    // the instructorId check is made against live member docs rather than the
-    // ACL's cached copy.
-    const callerDocIds = await getUserMemberDocIds(email, db);
-    const callerSnaps = await Promise.all(
-      callerDocIds.map((docId) => db.collection('members').doc(docId).get()),
-    );
-    const callerProfiles = callerSnaps
-      .filter((snap) => snap.exists)
-      .map((snap) => ({ ...snap.data(), docId: snap.id }) as Member);
-
-    const instructor = findRemovingInstructor(callerProfiles, student);
-    if (!instructor) {
-      throw new HttpsError(
-        'permission-denied',
-        'You can only remove students who list you as their primary instructor.',
-      );
-    }
+    const { db, student, studentRef, instructor } =
+      await resolveStudentAndInstructor(request, 'remove a student');
+    const studentMemberDocId = studentRef.id;
 
     await studentRef.update({
       primaryInstructorId: '',
@@ -115,6 +184,56 @@ export const removeStudentFromInstructor = onCall(
     logger.info(
       `Instructor ${instructor.instructorId} (${instructor.docId}) removed ` +
         `student ${student.memberId} (${studentMemberDocId}).`,
+    );
+
+    return { success: true };
+  },
+);
+
+/**
+ * Records a student's lapsed membership as Inactive, so they drop out of the
+ * default (active-only) view of their instructor's My Students list. The
+ * student stays the instructor's student — only `membershipType` changes — and
+ * renewing a membership sets it back to Annual.
+ *
+ * Refused for a membership that is still current: `canMarkMembershipInactive`
+ * is checked here as well as in the UI, since the client's copy of the member
+ * can be stale and the callable is reachable directly.
+ */
+export const markStudentInactive = onCall(
+  { cors: allowedOrigins },
+  async (request: CallableRequest<{ studentMemberDocId: string }>) => {
+    const { db, student, studentRef, instructor } =
+      await resolveStudentAndInstructor(request, 'mark a student inactive');
+    const studentMemberDocId = studentRef.id;
+
+    const today = new Date().toISOString().split('T')[0];
+    if (!canMarkMembershipInactive(student, today)) {
+      throw new HttpsError(
+        'failed-precondition',
+        markInactiveRefusal(student.membershipType),
+      );
+    }
+
+    await studentRef.update({
+      membershipType: MembershipType.Inactive,
+      lastUpdated: FieldValue.serverTimestamp(),
+    });
+
+    await createMemberNotification(db, studentMemberDocId, {
+      kind: NotificationKind.MembershipMarkedInactive,
+      markdown: markedInactiveMarkdown(instructor),
+      createdAt: new Date().toISOString(),
+      dismissed: false,
+      data: {
+        instructorId: instructor.instructorId,
+        instructorName: instructor.name,
+      },
+    });
+
+    logger.info(
+      `Instructor ${instructor.instructorId} (${instructor.docId}) marked ` +
+        `student ${student.memberId} (${studentMemberDocId}) inactive.`,
     );
 
     return { success: true };

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -246,7 +246,7 @@
             [memberId]="routingService.signals[Views.MyStudentView].pathVars.memberId()"
             basePath="my-students"
             backLabel="My Students"
-            [allowRemoveStudent]="true"
+            [allowStudentActions]="true"
           ></app-member-view>
         }
         @case (Views.MembersAreaCategory) {

--- a/src/app/data-manager.service.ts
+++ b/src/app/data-manager.service.ts
@@ -1436,6 +1436,17 @@ export class DataManagerService {
     await fn({ studentMemberDocId });
   }
 
+  // Record a student's lapsed membership as Inactive, so they drop out of the
+  // default view of the signed-in instructor's My Students list. Guarded by the
+  // same Cloud Function as the removal, for the same reason.
+  async markStudentInactive(studentMemberDocId: string): Promise<void> {
+    const fn = httpsCallable<
+      { studentMemberDocId: string },
+      { success: boolean }
+    >(this.functions, 'markStudentInactive');
+    await fn({ studentMemberDocId });
+  }
+
   async reprocessOrder(docId: string): Promise<void> {
     const fn = httpsCallable<{ docId: string }, { success: boolean }>(
       this.functions,

--- a/src/app/member-details/member-details.ts
+++ b/src/app/member-details/member-details.ts
@@ -122,6 +122,8 @@ export class MemberDetailsComponent {
         return 'Purchase Processed';
       case NotificationKind.PrimaryInstructorRemoved:
         return 'Removed by Your Primary Instructor';
+      case NotificationKind.MembershipMarkedInactive:
+        return 'Membership Marked Inactive';
       default:
         return kind;
     }

--- a/src/app/member-view/member-view.html
+++ b/src/app/member-view/member-view.html
@@ -1,55 +1,122 @@
+@let m = member();
+
 <div class="member-view-actions">
   <a class="back-link subtle-button" [href]="routingService.hrefWithParams('/' + basePath() + '?jumpTo=' + memberId())">
     <app-icon name="arrow_back"></app-icon> <span>Back to {{ backLabel() }}</span>
   </a>
+
+  @if (m && allowStudentActions()) {
+    <div class="actions-menu-container">
+      <button
+        type="button"
+        class="icon-only-button"
+        (click)="menuOpen.set(!menuOpen())"
+        [attr.aria-expanded]="menuOpen()"
+        aria-haspopup="true"
+        aria-label="More actions for this student"
+        title="More actions"
+      >
+        <app-icon name="more_vert"></app-icon>
+      </button>
+      @if (menuOpen()) {
+        <div class="menu-overlay transparent" (click)="menuOpen.set(false)"></div>
+        <div class="actions-menu">
+          @if (canMarkInactive()) {
+            <button
+              type="button"
+              class="menu-item"
+              (click)="startAction(StudentAction.MarkInactive)"
+            >
+              <app-icon name="visibility_off"></app-icon>
+              <span class="action-text">
+                <span class="action-label">Mark as inactive</span>
+                <span class="action-note">
+                  Their membership is no longer current. Records it as inactive,
+                  which hides them from your students list.
+                </span>
+              </span>
+            </button>
+          }
+          <button
+            type="button"
+            class="menu-item"
+            (click)="startAction(StudentAction.Remove)"
+          >
+            <app-icon name="trash"></app-icon>
+            <span class="action-text">
+              <span class="action-label">Remove from my students</span>
+              <span class="action-note">
+                You stop being their primary instructor and lose access to their
+                details.
+              </span>
+            </span>
+          </button>
+        </div>
+      }
+    </div>
+  }
 </div>
 
+@if (m && pendingAction(); as action) {
+  <div class="action-confirm">
+    @if (action === StudentAction.MarkInactive) {
+      <h3>Mark {{ m.name }} as inactive?</h3>
+      <p>
+        This records <strong>{{ m.name }}</strong>'s membership status as
+        <strong>Inactive</strong>, because their ILC membership is no longer
+        current. They stay your student and all their records are kept, but they
+        will no longer appear in your students list unless you choose to show
+        inactive members, and they lose access to the members' area until they
+        renew.
+      </p>
+      <p>
+        {{ m.name }} is notified, told that you are still their primary
+        instructor, and can renew their membership at any time — which makes
+        them active again.
+      </p>
+    } @else {
+      <h3>Remove {{ m.name }} from your students?</h3>
+      <p>
+        You will no longer be <strong>{{ m.name }}</strong>'s primary instructor
+        and will lose access to their details. {{ m.name }} will be notified,
+        can then choose a new primary instructor, and is told to talk to you if
+        they think it was a mistake.
+      </p>
+    }
+
+    @if (actionError()) {
+      <div class="error-message">{{ actionError() }}</div>
+    }
+
+    @if (isWorking()) {
+      <app-spinner></app-spinner>
+    } @else {
+      <div class="action-confirm-buttons">
+        @if (action === StudentAction.MarkInactive) {
+          <button type="button" (click)="confirmAction()">
+            <app-icon name="visibility_off" fill="#000" /> Yes, mark
+            {{ m.name }} inactive
+          </button>
+        } @else {
+          <button type="button" class="delete-button" (click)="confirmAction()">
+            <app-icon name="trash" fill="#000" /> Yes, remove {{ m.name }}
+          </button>
+        }
+        <button type="button" class="subtle-button" (click)="cancelAction()">
+          Cancel
+        </button>
+      </div>
+    }
+  </div>
+}
+
 <div class="member-view-content">
-  @let m = member();
   @if (m) {
     <app-member-details
       [member]="m"
       [allMembers]="dataService.members.entries()"
       (close)="goBack()"
     ></app-member-details>
-
-    @if (allowRemoveStudent()) {
-      <div class="remove-student">
-        @if (removeError()) {
-          <div class="error-message">{{ removeError() }}</div>
-        }
-        @if (isRemoving()) {
-          <app-spinner></app-spinner>
-        } @else if (confirmingRemove()) {
-          <p>
-            Remove <strong>{{ m.name }}</strong> from your students? You will no
-            longer be their primary instructor and will lose access to their
-            details. {{ m.name }} will be notified, can then choose a new primary
-            instructor, and is told to talk to you if they think it was a mistake.
-          </p>
-          <div class="remove-student-buttons">
-            <button type="button" class="delete-button" (click)="removeStudent()">
-              <app-icon name="trash" fill="#000" /> Yes, remove {{ m.name }}
-            </button>
-            <button
-              type="button"
-              class="subtle-button"
-              (click)="confirmingRemove.set(false)"
-            >
-              Cancel
-            </button>
-          </div>
-        } @else {
-          <button
-            type="button"
-            class="delete-button"
-            (click)="confirmingRemove.set(true)"
-          >
-            <app-icon name="trash" fill="#000" /> Remove from my students
-          </button>
-        }
-      </div>
-    }
   } @else {
     <div class="not-found">
       Member not found.

--- a/src/app/member-view/member-view.scss
+++ b/src/app/member-view/member-view.scss
@@ -1,33 +1,97 @@
 @use "../../scss_variables.scss" as v;
+@use "../../styles.scss" as *;
 
 :host {
   display: block;
 }
 
-.remove-student {
-  margin-top: 1.5rem;
-  padding-top: 1rem;
-  border-top: 1px solid v.$border-color-light;
-
-  p {
-    max-width: 55em;
-  }
-
-  .remove-student-buttons {
-    display: flex;
-    gap: 0.5rem;
-    align-items: center;
-  }
-}
-
 .member-view-actions {
   margin-bottom: 1rem;
-  
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+
   .back-link {
     display: inline-flex;
     align-items: center;
     gap: 0.5rem;
     font-size: 0.9rem;
     padding: 0.5rem 0.5rem;
+  }
+}
+
+.actions-menu-container {
+  position: relative;
+}
+
+.actions-menu {
+  @extend .menu-style;
+  position: absolute;
+  top: calc(100% + 5px);
+  right: 0;
+  min-width: 20em;
+
+  // The menu items are buttons (for keyboard access) styled as menu rows, so
+  // the default button chrome has to go.
+  .menu-item {
+    background: none;
+    border: none;
+    box-shadow: none;
+    font: inherit;
+    color: inherit;
+    text-align: left;
+    align-items: flex-start;
+    width: 100%;
+    white-space: normal;
+
+    &:hover {
+      box-shadow: none;
+    }
+
+    &:active {
+      transform: none;
+      box-shadow: none;
+    }
+
+    app-icon {
+      flex-shrink: 0;
+      // Line the icon up with the label rather than the wrapped note below it.
+      margin-top: 0.1em;
+    }
+  }
+
+  .action-text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15em;
+  }
+
+  .action-note {
+    font-size: 0.8em;
+    color: v.$text-secondary;
+    max-width: 24em;
+  }
+}
+
+.action-confirm {
+  margin-bottom: 1.5rem;
+  padding: 1rem;
+  border: 1px solid v.$border-color-light;
+  border-radius: 5px;
+
+  h3 {
+    margin-top: 0;
+  }
+
+  p {
+    max-width: 55em;
+  }
+
+  .action-confirm-buttons {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    flex-wrap: wrap;
   }
 }

--- a/src/app/member-view/member-view.ts
+++ b/src/app/member-view/member-view.ts
@@ -6,6 +6,16 @@ import { AppPathPatterns } from '../app.config';
 import { MemberDetailsComponent } from '../member-details/member-details';
 import { IconComponent } from '../icons/icon.component';
 import { SpinnerComponent } from '../spinner/spinner.component';
+import { canMarkMembershipInactive } from '../../../functions/src/data-model';
+
+/** The actions a primary instructor can take on one of their own students. */
+export enum StudentAction {
+  // Record a lapsed membership as Inactive, which hides the student from the
+  // default (active-only) view of the instructor's students list.
+  MarkInactive = 'MarkInactive',
+  // Clear the student's primaryInstructorId, ending the relationship.
+  Remove = 'Remove',
+}
 
 @Component({
   selector: 'app-member-view',
@@ -22,14 +32,18 @@ export class MemberViewComponent implements OnInit {
   basePath = input.required<string>();
   backLabel = input.required<string>();
 
-  // Offers the "remove from my students" action. Only set on the My Students
-  // route, where the viewer is the member's primary instructor.
-  allowRemoveStudent = input<boolean>(false);
+  // Offers the instructor actions menu. Only set on the My Students route,
+  // where the viewer is the member's primary instructor.
+  allowStudentActions = input<boolean>(false);
 
-  // Two-step confirmation state for the removal.
-  confirmingRemove = signal(false);
-  isRemoving = signal(false);
-  removeError = signal('');
+  StudentAction = StudentAction;
+
+  // The three-dot actions menu, and the two-step confirmation every action in
+  // it goes through.
+  menuOpen = signal(false);
+  pendingAction = signal<StudentAction | null>(null);
+  isWorking = signal(false);
+  actionError = signal('');
 
   ngOnInit() {
     window.scrollTo(0, 0);
@@ -49,26 +63,63 @@ export class MemberViewComponent implements OnInit {
     );
   });
 
+  // "Mark as inactive" is only on offer once the membership has actually
+  // lapsed. The callable re-checks this, so a stale copy of the member here can
+  // only cost the instructor an error message, never deactivate a live
+  // membership.
+  canMarkInactive = computed(() => {
+    const m = this.member();
+    if (!m || !this.allowStudentActions()) return false;
+    const today = new Date().toISOString().split('T')[0];
+    return canMarkMembershipInactive(m, today);
+  });
+
   goBack() {
     this.routingService.navigateToParts([`/${this.basePath()}?jumpTo=${this.memberId()}`]);
   }
 
-  async removeStudent() {
+  /** Closes the menu and asks the instructor to confirm `action`. */
+  startAction(action: StudentAction) {
+    this.menuOpen.set(false);
+    this.actionError.set('');
+    this.pendingAction.set(action);
+  }
+
+  cancelAction() {
+    this.pendingAction.set(null);
+    this.actionError.set('');
+  }
+
+  /**
+   * Runs the confirmed action. Both actions take the student out of the
+   * instructor's default list view, so both return to that list on success —
+   * where the effect of the action is visible.
+   */
+  async confirmAction() {
     const m = this.member();
-    if (!m || this.isRemoving()) return;
-    this.isRemoving.set(true);
-    this.removeError.set('');
+    const action = this.pendingAction();
+    if (!m || !action || this.isWorking()) return;
+    this.isWorking.set(true);
+    this.actionError.set('');
     try {
-      await this.dataService.removeStudentFromInstructor(m.docId);
+      if (action === StudentAction.Remove) {
+        await this.dataService.removeStudentFromInstructor(m.docId);
+      } else {
+        await this.dataService.markStudentInactive(m.docId);
+      }
+      this.pendingAction.set(null);
       this.routingService.navigateToParts([`/${this.basePath()}`]);
     } catch (e) {
-      console.error('Failed to remove student', e);
-      this.removeError.set(
-        e instanceof Error ? e.message : 'Failed to remove this student.',
+      console.error(`Failed to run ${action} on student ${m.docId}`, e);
+      this.actionError.set(
+        e instanceof Error
+          ? e.message
+          : action === StudentAction.Remove
+            ? 'Failed to remove this student.'
+            : 'Failed to mark this student inactive.',
       );
     } finally {
-      this.isRemoving.set(false);
-      this.confirmingRemove.set(false);
+      this.isWorking.set(false);
     }
   }
 }

--- a/src/app/settings/notification-settings/notification-settings.component.ts
+++ b/src/app/settings/notification-settings/notification-settings.component.ts
@@ -175,6 +175,8 @@ export class NotificationSettingsComponent implements OnInit {
         return 'Purchase Processed';
       case NotificationKind.PrimaryInstructorRemoved:
         return 'Removed by Your Primary Instructor';
+      case NotificationKind.MembershipMarkedInactive:
+        return 'Membership Marked Inactive';
       default:
         return kind;
     }

--- a/tests/e2e/emulator-helpers.ts
+++ b/tests/e2e/emulator-helpers.ts
@@ -1,0 +1,96 @@
+/*
+ * Shared plumbing for the emulator-driven e2e stories: the admin SDK pointed at
+ * the emulators, member seeding, polling for asynchronously-fired triggers, and
+ * calling a callable the way the browser client does.
+ *
+ * Import this before `firebase-admin` in a spec (or instead of it): the
+ * emulator host variables have to be set before the SDK is loaded, and this
+ * module does that at the top.
+ */
+
+// Must be set before firebase-admin is imported so the SDK talks to the emulator.
+process.env['FIRESTORE_EMULATOR_HOST'] ||= '127.0.0.1:8080';
+process.env['FIREBASE_AUTH_EMULATOR_HOST'] ||= '127.0.0.1:9099';
+
+import * as admin from 'firebase-admin';
+import { initMember } from '../../functions/src/data-model';
+
+export const PROJECT_ID = 'demo-ilc-test';
+export const FUNCTIONS_HOST =
+  process.env['FUNCTIONS_EMULATOR_HOST'] || '127.0.0.1:5001';
+
+if (admin.apps.length === 0) {
+  admin.initializeApp({ projectId: PROJECT_ID });
+}
+export const db = admin.firestore();
+
+export const seedMember = (docId: string, overrides: Record<string, unknown>) =>
+  db.collection('members').doc(docId).set({ ...initMember(), ...overrides });
+
+/** Poll until `predicate` is satisfied or the timeout elapses (triggers run async). */
+export async function waitFor<T>(
+  read: () => Promise<T>,
+  predicate: (v: T) => boolean,
+  label: string,
+  timeoutMs = 15000,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  let last: T | undefined;
+  while (Date.now() < deadline) {
+    last = await read();
+    if (predicate(last)) return last;
+    await new Promise((r) => setTimeout(r, 400));
+  }
+  throw new Error(`Timed out waiting for ${label}. Last: ${JSON.stringify(last)}`);
+}
+
+const b64url = (o: unknown) =>
+  Buffer.from(JSON.stringify(o)).toString('base64url');
+
+/**
+ * An unsigned ID token. The Functions emulator runs with token verification
+ * disabled, so this is enough to authenticate a callable as the given email.
+ */
+export function fakeIdToken(uid: string, email: string): string {
+  const now = Math.floor(Date.now() / 1000);
+  const payload = {
+    iss: `https://securetoken.google.com/${PROJECT_ID}`,
+    aud: PROJECT_ID,
+    auth_time: now,
+    user_id: uid,
+    sub: uid,
+    iat: now,
+    exp: now + 3600,
+    email,
+    email_verified: true,
+    firebase: {
+      identities: { email: [email] },
+      sign_in_provider: 'password',
+    },
+  };
+  return `${b64url({ alg: 'none', typ: 'JWT' })}.${b64url(payload)}.`;
+}
+
+/**
+ * Calls a callable the way the browser client does, returning the raw HTTP
+ * status alongside the decoded body so error cases can be asserted.
+ */
+export async function callFunction(
+  name: string,
+  data: unknown,
+  token: string,
+): Promise<{ status: number; body: any }> {
+  const res = await fetch(
+    `http://${FUNCTIONS_HOST}/${PROJECT_ID}/us-central1/${name}`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+        Origin: 'http://localhost:4200',
+      },
+      body: JSON.stringify({ data }),
+    },
+  );
+  return { status: res.status, body: await res.json() };
+}

--- a/tests/e2e/instructor-mark-student-inactive.spec.ts
+++ b/tests/e2e/instructor-mark-student-inactive.spec.ts
@@ -1,0 +1,209 @@
+/*
+ * Emulator-driven e2e test for the user story:
+ *   An instructor can record a lapsed membership as Inactive for a student who
+ *   lists them as their primary instructor, so that student drops out of the
+ *   default view of their My Students list.
+ *
+ * Exercises the real `markStudentInactive` callable (invoked over HTTP against
+ * the Functions emulator, the way the browser client calls it) together with
+ * the `onMemberUpdated` trigger it relies on:
+ *   - the student's membershipType becomes Inactive, and nothing else about the
+ *     relationship changes (they are still the instructor's student);
+ *   - the change reaches the mirrored /instructors/{docId}/members/{studentDocId}
+ *     entry, which is what the My Students list actually reads;
+ *   - the student is notified, and told renewing reactivates them;
+ *   - a still-current membership is refused, as is an instructor who is NOT the
+ *     student's primary instructor.
+ *
+ * Run via `pnpm test:e2e` (starts the Firestore + Functions emulators with
+ * `firebase emulators:exec` then runs this spec). Not part of `pnpm test`.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  callFunction,
+  db,
+  fakeIdToken,
+  seedMember,
+  waitFor,
+} from './emulator-helpers';
+import {
+  MembershipType,
+  NotificationKind,
+  type Member,
+  type MemberNotification,
+} from '../../functions/src/data-model';
+
+describe('story: instructor-mark-student-inactive', () => {
+  const suffix = Date.now().toString(36);
+  const sifuDocId = `mi-sifu-${suffix}`;
+  const otherSifuDocId = `mi-other-sifu-${suffix}`;
+  const lapsedDocId = `mi-lapsed-${suffix}`;
+  const currentDocId = `mi-current-${suffix}`;
+  const sifuEmail = `mi-sifu-${suffix}@example.com`;
+  const otherSifuEmail = `mi-other-sifu-${suffix}@example.com`;
+  const sifuInstructorId = `MI-INST-${suffix}`;
+  const otherInstructorId = `MI-INST-OTHER-${suffix}`;
+
+  const readMember = async (docId: string) =>
+    (await db.collection('members').doc(docId).get()).data() as Member;
+
+  beforeAll(async () => {
+    await seedMember(sifuDocId, {
+      name: 'Sifu Sam',
+      memberId: `FR${suffix}`,
+      instructorId: sifuInstructorId,
+      emails: [sifuEmail],
+    });
+    await seedMember(otherSifuDocId, {
+      name: 'Sifu Other',
+      memberId: `FR9${suffix}`,
+      instructorId: otherInstructorId,
+      emails: [otherSifuEmail],
+    });
+    // A student whose annual membership ran out a long time ago.
+    await seedMember(lapsedDocId, {
+      name: 'Lapsed Lee',
+      memberId: `FR23${suffix}`,
+      emails: [`mi-lapsed-${suffix}@example.com`],
+      primaryInstructorId: sifuInstructorId,
+      membershipType: MembershipType.Annual,
+      currentMembershipExpires: '2020-01-01',
+    });
+    // A student of the same instructor whose membership is still current.
+    await seedMember(currentDocId, {
+      name: 'Current Chris',
+      memberId: `FR24${suffix}`,
+      emails: [`mi-current-${suffix}@example.com`],
+      primaryInstructorId: sifuInstructorId,
+      membershipType: MembershipType.Annual,
+      currentMembershipExpires: '2099-12-31',
+    });
+
+    // onMemberCreated builds the ACL entries the callable reads to work out
+    // which member profiles each login email manages.
+    await waitFor(
+      async () => (await db.collection('acl').doc(sifuEmail).get()).data(),
+      (d) => !!d && (d['memberDocIds'] || []).includes(sifuDocId),
+      'ACL entry for the instructor',
+    );
+    await waitFor(
+      async () => (await db.collection('acl').doc(otherSifuEmail).get()).data(),
+      (d) => !!d && (d['memberDocIds'] || []).includes(otherSifuDocId),
+      'ACL entry for the other instructor',
+    );
+
+    // The students show up in the instructor's My Students list via this mirror.
+    await waitFor(
+      async () =>
+        (
+          await db
+            .collection('instructors')
+            .doc(sifuDocId)
+            .collection('members')
+            .doc(lapsedDocId)
+            .get()
+        ).exists,
+      (exists) => exists,
+      'student mirrored into the instructor’s My Students',
+    );
+  });
+
+  afterAll(async () => {
+    await db.terminate();
+  });
+
+  it('refuses an instructor who is not the student’s primary instructor', async () => {
+    const res = await callFunction(
+      'markStudentInactive',
+      { studentMemberDocId: lapsedDocId },
+      fakeIdToken('mi-other-sifu-uid', otherSifuEmail),
+    );
+    expect(res.status).toBe(403);
+    expect(res.body.error?.status).toBe('PERMISSION_DENIED');
+
+    const student = await readMember(lapsedDocId);
+    expect(student.membershipType).toBe(MembershipType.Annual);
+  });
+
+  // The guard that stops this being a way to switch off a paid-up membership.
+  it('refuses a student whose membership is still current', async () => {
+    const res = await callFunction(
+      'markStudentInactive',
+      { studentMemberDocId: currentDocId },
+      fakeIdToken('mi-sifu-uid', sifuEmail),
+    );
+    expect(res.status).toBe(400);
+    expect(res.body.error?.status).toBe('FAILED_PRECONDITION');
+
+    const student = await readMember(currentDocId);
+    expect(student.membershipType).toBe(MembershipType.Annual);
+  });
+
+  it('marks a lapsed membership inactive and leaves the relationship intact', async () => {
+    const res = await callFunction(
+      'markStudentInactive',
+      { studentMemberDocId: lapsedDocId },
+      fakeIdToken('mi-sifu-uid', sifuEmail),
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.result).toEqual({ success: true });
+
+    const student = await readMember(lapsedDocId);
+    expect(student.membershipType).toBe(MembershipType.Inactive);
+    // Still this instructor's student — this action only changes the status.
+    expect(student.primaryInstructorId).toBe(sifuInstructorId);
+
+    // The My Students list reads the mirror, so the new status has to reach it
+    // for the student to be filtered out of the default view.
+    await waitFor(
+      async () =>
+        (
+          await db
+            .collection('instructors')
+            .doc(sifuDocId)
+            .collection('members')
+            .doc(lapsedDocId)
+            .get()
+        ).data() as Member | undefined,
+      (m) => !!m && m.membershipType === MembershipType.Inactive,
+      'Inactive status mirrored into the instructor’s My Students',
+    );
+  });
+
+  it('notifies the student that renewing makes them active again', async () => {
+    const notes = await waitFor(
+      async () => {
+        const snap = await db
+          .collection('members')
+          .doc(lapsedDocId)
+          .collection('notifications')
+          .get();
+        return snap.docs.map((d) => d.data() as MemberNotification);
+      },
+      (list) => list.some((n) => n.kind === NotificationKind.MembershipMarkedInactive),
+      'MembershipMarkedInactive notification for the student',
+    );
+    const note = notes.find(
+      (n) => n.kind === NotificationKind.MembershipMarkedInactive,
+    )!;
+    expect(note.markdown).toContain('Sifu Sam');
+    expect(note.markdown).toContain('](/products)');
+    expect(note.markdown).toContain('still your primary instructor');
+    expect(note.data).toMatchObject({
+      instructorId: sifuInstructorId,
+      instructorName: 'Sifu Sam',
+    });
+  });
+
+  it('refuses a second attempt, once the student is already inactive', async () => {
+    const res = await callFunction(
+      'markStudentInactive',
+      { studentMemberDocId: lapsedDocId },
+      fakeIdToken('mi-sifu-uid', sifuEmail),
+    );
+    expect(res.status).toBe(400);
+    expect(res.body.error?.status).toBe('FAILED_PRECONDITION');
+    expect(res.body.error?.message).toContain('already marked inactive');
+  });
+});

--- a/tests/e2e/instructor-remove-student.spec.ts
+++ b/tests/e2e/instructor-remove-student.spec.ts
@@ -16,93 +16,19 @@
  * `firebase emulators:exec` then runs this spec). Not part of `pnpm test`.
  */
 
-// Must be set before firebase-admin is imported so the SDK talks to the emulator.
-process.env['FIRESTORE_EMULATOR_HOST'] ||= '127.0.0.1:8080';
-process.env['FIREBASE_AUTH_EMULATOR_HOST'] ||= '127.0.0.1:9099';
-
-import * as admin from 'firebase-admin';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import {
+  callFunction,
+  db,
+  fakeIdToken,
+  seedMember,
+  waitFor,
+} from './emulator-helpers';
+import {
   NotificationKind,
-  initMember,
   type Member,
   type MemberNotification,
 } from '../../functions/src/data-model';
-
-const PROJECT_ID = 'demo-ilc-test';
-const FUNCTIONS_HOST = process.env['FUNCTIONS_EMULATOR_HOST'] || '127.0.0.1:5001';
-
-if (admin.apps.length === 0) {
-  admin.initializeApp({ projectId: PROJECT_ID });
-}
-const db = admin.firestore();
-
-const seedMember = (docId: string, overrides: Record<string, unknown>) =>
-  db.collection('members').doc(docId).set({ ...initMember(), ...overrides });
-
-// Poll until `predicate` is satisfied or the timeout elapses (triggers run async).
-async function waitFor<T>(
-  read: () => Promise<T>,
-  predicate: (v: T) => boolean,
-  label: string,
-  timeoutMs = 15000,
-): Promise<T> {
-  const deadline = Date.now() + timeoutMs;
-  let last: T | undefined;
-  while (Date.now() < deadline) {
-    last = await read();
-    if (predicate(last)) return last;
-    await new Promise((r) => setTimeout(r, 400));
-  }
-  throw new Error(`Timed out waiting for ${label}. Last: ${JSON.stringify(last)}`);
-}
-
-const b64url = (o: unknown) =>
-  Buffer.from(JSON.stringify(o)).toString('base64url');
-
-// An unsigned ID token. The Functions emulator runs with token verification
-// disabled, so this is enough to authenticate a callable as the given email.
-function fakeIdToken(uid: string, email: string): string {
-  const now = Math.floor(Date.now() / 1000);
-  const payload = {
-    iss: `https://securetoken.google.com/${PROJECT_ID}`,
-    aud: PROJECT_ID,
-    auth_time: now,
-    user_id: uid,
-    sub: uid,
-    iat: now,
-    exp: now + 3600,
-    email,
-    email_verified: true,
-    firebase: {
-      identities: { email: [email] },
-      sign_in_provider: 'password',
-    },
-  };
-  return `${b64url({ alg: 'none', typ: 'JWT' })}.${b64url(payload)}.`;
-}
-
-// Calls a callable the way the browser client does, returning the raw HTTP
-// status alongside the decoded body so error cases can be asserted.
-async function callFunction(
-  name: string,
-  data: unknown,
-  token: string,
-): Promise<{ status: number; body: any }> {
-  const res = await fetch(
-    `http://${FUNCTIONS_HOST}/${PROJECT_ID}/us-central1/${name}`,
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
-        Origin: 'http://localhost:4200',
-      },
-      body: JSON.stringify({ data }),
-    },
-  );
-  return { status: res.status, body: await res.json() };
-}
 
 describe('story: instructor-remove-student', () => {
   const suffix = Date.now().toString(36);


### PR DESCRIPTION
An instructor viewing one of their own students at `/my-students/{id}` can now record a lapsed membership as **Inactive**, so that student drops out of the default (active-only) view of their students list — still reachable under "Show N inactive members".

## The menu

Both this and the existing "remove from my students" now live in a three-dot menu at the top of the page, right-aligned on the same row as the back link, each with a line of explanation under its label:

- **Mark as inactive** — "Their membership is no longer current. Records it as inactive, which hides them from your students list."
- **Remove from my students** — "You stop being their primary instructor and lose access to their details."

Picking either opens a confirmation panel spelling out the consequences before anything happens. The removal's own button, which used to sit alone at the bottom of the page, is gone.

## When "Mark as inactive" is offered

`canMarkMembershipInactive` (new, in `data-model.ts` so client and server share one rule) accepts an expired Annual membership, an Annual one with no expiry recorded, and a never-a-member. It refuses Life memberships and anyone already Inactive or Deceased. Expiry is inclusive, so the action stays hidden on the expiry day itself.

## Server side

A new `markStudentInactive` callable, guarded like the removal — instructors have no write access to their students' member documents. It shares the primary-instructor check with `removeStudentFromInstructor` (extracted as `resolveStudentAndInstructor`; `findRemovingInstructor` renamed `findPrimaryInstructorProfile` now that two actions use it) and re-checks the lapsed rule itself, so a stale page cannot switch off a live membership.

Only `membershipType` changes — `primaryInstructorId` is left alone, so the student stays the instructor's student — and the `onMemberUpdated` trigger carries the new status to the mirror the students list actually reads.

The student gets an informational notification: their instructor recorded the membership as inactive, the instructor relationship is unchanged, and renewing reactivates them.

## Verification

- 264 function tests, 439 client tests, 24 e2e tests (5 new), both builds.
- Driven in the browser against the seeded emulator as an instructor: opened the menu on a lapsed student, confirmed, landed back on My Students with them gone, and the "Show N inactive members" count went up by one and revealed them. Checked Firestore directly — `membershipType: Inactive`, `primaryInstructorId` intact, notification written.

## For the reviewer

- The e2e plumbing both instructor stories share moved to `tests/e2e/emulator-helpers.ts`; `instructor-remove-student.spec.ts` is unchanged apart from importing it.
- **Pre-existing bug, deliberately not fixed here:** `removedStudentMarkdown` links to `#/myProfile`, which goes nowhere — `App.onDocumentClick` explicitly skips `#` hrefs, and every other notification uses a plain path. The new notification uses `/products` rather than copy that; the existing one is left for a separate change.
- `.claude/launch.json` is added so the emulator dev server can be launched directly — happy to drop it if you'd rather it stayed untracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)