### PR TITLE
fix(notifications): route the removed-student profile link

### DIFF
--- a/functions/src/instructor-students.spec.ts
+++ b/functions/src/instructor-students.spec.ts
@@ -49,7 +49,7 @@ describe('removedStudentMarkdown', () => {
     const md = removedStudentMarkdown(sifu);
     expect(md).toContain('Sifu Sam');
     expect(md).toContain('INST-1');
-    expect(md).toContain('(#/myProfile)');
+    expect(md).toContain('](/myProfile)');
     expect(md).toContain('talk to them directly');
   });
 

--- a/functions/src/instructor-students.ts
+++ b/functions/src/instructor-students.ts
@@ -47,7 +47,7 @@ export function removedStudentMarkdown(instructor: Member): string {
   return (
     `${who} has removed you from their student list, so you no longer have a ` +
     `primary instructor.\n\n` +
-    `You can [choose a new primary instructor](#/myProfile) whenever you like.\n\n` +
+    `You can [choose a new primary instructor](/myProfile) whenever you like.\n\n` +
     `If you think this was a mistake and you would like ${who} to remain your ` +
     `primary instructor, please talk to them directly and they can add you back.`
   );

--- a/tests/e2e/instructor-remove-student.spec.ts
+++ b/tests/e2e/instructor-remove-student.spec.ts
@@ -225,7 +225,7 @@ describe('story: instructor-remove-student', () => {
       (n) => n.kind === NotificationKind.PrimaryInstructorRemoved,
     )!;
     expect(note.markdown).toContain('Sifu Sam');
-    expect(note.markdown).toContain('#/myProfile');
+    expect(note.markdown).toContain('](/myProfile)');
     expect(note.markdown).toContain('talk to them directly');
     expect(note.data).toMatchObject({
       instructorId: sifuInstructorId,


### PR DESCRIPTION
## What

`removedStudentMarkdown()` in `functions/src/instructor-students.ts` builds the notification a student gets when their primary instructor removes them. Its link to the profile page was `[choose a new primary instructor](#/myProfile)` — now `(/myProfile)`.

## Why

`App.onDocumentClick` in `src/app/app.ts:156` deliberately skips any href starting with `#`, so the app's router never picked the link up; clicking it only set the page hash and left the student on the same page. Every other notification in `functions/src` uses a plain path link that the handler does route (`/myProfile` and `/members-area` in `on-member-update.ts`, `/my-events/{id}` in `proposed-events.ts`), so this brings the removed-student notification in line with them.

## Notes for reviewers

Two assertions pinned the old form and were updated. Both now assert `'](/myProfile)'` rather than a substring that a bare `#` link would also satisfy, so they can't silently pass on a regression:

- `functions/src/instructor-students.spec.ts` — was `toContain('(#/myProfile)')`
- `tests/e2e/instructor-remove-student.spec.ts` — was `toContain('#/myProfile')`

## Verification

- `pnpm --prefix functions test` — 253 passed (20 files)
- `pnpm test:e2e` — 19 passed (5 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)