### PR TITLE
fix(routing): follow legacy #/ links clicked inside the app

### DIFF
--- a/functions/src/send-push.ts
+++ b/functions/src/send-push.ts
@@ -133,7 +133,7 @@ export const sendPushOnNotification = onDocumentCreated(
           notifId,
           kind: notification.kind,
           onActionClick: {
-            default: { operation: 'focusLastFocusedOrOpen', url: '/#/notifications' },
+            default: { operation: 'focusLastFocusedOrOpen', url: '/notifications' },
           },
         },
       },

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -235,5 +235,54 @@ describe('App', () => {
     expect(clickEvent.defaultPrevented).toBe(true);
     expect(navigateSpy).toHaveBeenCalledWith('members');
   });
+
+  // Legacy hash-routing links still turn up in old emails and notifications.
+  // main.ts rewrites them on a cold load, but a click inside the app never
+  // reloads, so the interceptor has to strip the `#` itself — otherwise it
+  // pushes `/#/...` and silently leaves the user on Home.
+  it('should navigate to the path equivalent of a legacy hash link', async () => {
+    const fixture = TestBed.createComponent(App);
+    const app = fixture.componentInstance;
+    await fixture.whenStable();
+
+    const navigateSpy = vi.spyOn(app.routingService, 'navigateTo').mockImplementation(() => {});
+    const compiled = fixture.nativeElement as HTMLElement;
+
+    for (const [href, expected] of [
+      ['/#/resources/instructors/Instructor%20Packet%202026.pdf',
+       'resources/instructors/Instructor%20Packet%202026.pdf'],
+      ['#/notifications', 'notifications'],
+    ]) {
+      navigateSpy.mockClear();
+      const link = document.createElement('a');
+      link.setAttribute('href', href);
+      compiled.appendChild(link);
+
+      const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true, button: 0 });
+      link.dispatchEvent(clickEvent);
+
+      expect(clickEvent.defaultPrevented).toBe(true);
+      expect(navigateSpy).toHaveBeenCalledWith(expected);
+    }
+  });
+
+  it('should leave genuine in-page anchors to the browser', async () => {
+    const fixture = TestBed.createComponent(App);
+    const app = fixture.componentInstance;
+    await fixture.whenStable();
+
+    const navigateSpy = vi.spyOn(app.routingService, 'navigateTo').mockImplementation(() => {});
+    const compiled = fixture.nativeElement as HTMLElement;
+
+    const link = document.createElement('a');
+    link.setAttribute('href', '#section-2');
+    compiled.appendChild(link);
+
+    const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true, button: 0 });
+    link.dispatchEvent(clickEvent);
+
+    expect(clickEvent.defaultPrevented).toBe(false);
+    expect(navigateSpy).not.toHaveBeenCalled();
+  });
 });
 

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -150,12 +150,25 @@ export class App {
     const href = anchor.getAttribute('href');
     if (!href) return;
 
+    // Legacy hash-routing links (`/#/resources/...`, `#/notifications`) name an
+    // app route, not an in-page anchor — they still turn up in older emails and
+    // notifications. main.ts rewrites them to their path equivalent, but only on
+    // a cold load; a click from inside the app is handled here and never
+    // reloads, so without the same rewrite we would `preventDefault` and push
+    // `/#/resources/...`, leaving the user on Home with the fragment stuck in
+    // the URL.
+    const linkPath = href.startsWith('/#/')
+      ? href.substring(2)
+      : href.startsWith('#/')
+        ? href.substring(1)
+        : href;
+
     if (
-      !href.startsWith('http') &&
-      !href.startsWith('//') &&
-      !href.startsWith('#') &&
-      !href.startsWith('mailto:') &&
-      !href.startsWith('tel:') &&
+      !linkPath.startsWith('http') &&
+      !linkPath.startsWith('//') &&
+      !linkPath.startsWith('#') &&
+      !linkPath.startsWith('mailto:') &&
+      !linkPath.startsWith('tel:') &&
       !anchor.hasAttribute('download') &&
       anchor.getAttribute('target') !== '_blank' &&
       !event.ctrlKey &&
@@ -164,7 +177,7 @@ export class App {
       event.button === 0
     ) {
       event.preventDefault();
-      let path = href;
+      let path = linkPath;
       if (path.startsWith('/')) {
         path = path.substring(1);
       }


### PR DESCRIPTION
## The bug

The instructor packet link (`https://app.iliqchuan.com/#/resources/instructors/Instructor%20Packet%202026.pdf`) did nothing when clicked from inside the app — the URL changed but the user stayed on Home.

## Root cause

The app moved from hash routing to path routing (#36), and [`main.ts`](../blob/main/src/main.ts) rewrites legacy `#/...` URLs to their path equivalent. But that rewrite only runs **at bootstrap**, while `App.onDocumentClick` intercepts same-origin anchor clicks and routes client-side **without reloading**.

For `href="/#/resources/instructors/Instructor%20Packet%202026.pdf"`:

1. It doesn't start with `http`, `//`, or `#` (it starts with `/`), so the interceptor claimed it.
2. `preventDefault()` killed the full-page navigation that would have let `main.ts` fix the URL.
3. It stripped the leading `/` and navigated to `#/resources/...`, which matches no route pattern — `#` becomes an extra path segment.
4. So it pushed `/` plus the leftover fragment → the user silently landed on **Home**, URL stuck at `/#/resources/...`.

This looked intermittent: pasting the link or reloading works (cold load, `main.ts` runs); only clicking it inside the app failed. Notifications render their markdown as plain `<a href>` on the Home page, so notification links were the common way to hit it.

Reproduced locally against the emulator: the URL changed to the resource path while `document.title` stayed `Home`, and a `window` marker survived the click — proving no reload happened.

## Changes

- **`src/app/app.ts`** — normalise `/#/...` and `#/...` to their path form before the interceptor's checks. Genuine in-page anchors (`#section`) still fall through to the browser.
- **`functions/src/send-push.ts`** — the web push notification still pointed at the pre-migration `/#/notifications`; now `/notifications`.
- **`src/app/app.spec.ts`** — two regression tests. Confirmed the first *fails* without the fix rather than passing vacuously.

## Verified

- 441 frontend tests, 264 functions tests, `tsc` on functions — all pass.
- End-to-end against the emulator: clicking the link from Home now lands on the Download Resource page with the correct file and access tier.

## Checked and found fine

- Cold loads of the hash URL work correctly (verified on both production and local).
- `%20` encoding round-trips correctly — the backend located the exact file in storage.
- The `%2520` double-encoded `returnUrl` on the Sign In link looks alarming but is correct: an already-encoded path encoded once more for query-string transport.

## Not verifiable locally

After the fix the page reaches the file and passes the instructor-licence check, then stops at `Failed to generate download URL` — the storage emulator can't produce signed URLs without service-account credentials. If instructors still see *that specific message* in production, it's a separate issue: `getSignedUrl` needs the functions service account to hold `roles/iam.serviceAccountTokenCreator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)