### PR TITLE
fix(navigation): derive back links and breadcrumbs from one tree

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -73,14 +73,14 @@ export enum Views {
 
 export const memberListPathPatterns = {
   [Views.MyStudents]: addUrlParams(pathPattern`my-students`, [
-    'jumpTo', 'q', 'tag',
+    { name: 'jumpTo', ephemeral: true }, 'q', 'tag',
     { name: 'sortBy', default: 'lastUpdated' },
     { name: 'sortDir', default: 'desc' },
   ]),
   [Views.SchoolMembers]: addUrlParams(
     pathPattern`school/${pv('schoolId')}/members`,
     [
-      'jumpTo', 'q', 'tag',
+      { name: 'jumpTo', ephemeral: true }, 'q', 'tag',
       { name: 'sortBy', default: 'lastUpdated' },
       { name: 'sortDir', default: 'desc' },
     ],
@@ -88,7 +88,7 @@ export const memberListPathPatterns = {
   [Views.InstructorStudents]: addUrlParams(
     pathPattern`instructor/${pv('instructorId')}/students`,
     [
-      'jumpTo', 'q', 'tag',
+      { name: 'jumpTo', ephemeral: true }, 'q', 'tag',
       { name: 'sortBy', default: 'lastUpdated' },
       { name: 'sortDir', default: 'desc' },
     ],
@@ -101,7 +101,7 @@ export type MemberListPathPatternsIds = keyof MemberListPathPatterns;
 export const initPathPatterns = {
   ...memberListPathPatterns,
   [Views.Home]: pathPattern``,
-  [Views.Login]: addUrlParams(pathPattern`login`, ['returnUrl']),
+  [Views.Login]: addUrlParams(pathPattern`login`, [{ name: 'returnUrl', ephemeral: true }]),
   [Views.ClassCalendarView]: pathPattern`calendar/instructor/${pv('instructorId')}`,
   [Views.SchoolCalendarView]: pathPattern`calendar/school/${pv('schoolId')}`,
   [Views.ImportExport]: addUrlParams(pathPattern`import-export`, ['tab']),
@@ -113,7 +113,7 @@ export const initPathPatterns = {
   [Views.ManageSchoolEdit]: pathPattern`schools/${pv('schoolId')}/edit`,
   [Views.MyProfile]: pathPattern`myProfile`,
   [Views.ManageMembers]: addUrlParams(pathPattern`members`, [
-    'jumpTo', 'q', 'tag',
+    { name: 'jumpTo', ephemeral: true }, 'q', 'tag',
     { name: 'sortBy', default: 'lastUpdated' },
     { name: 'sortDir', default: 'desc' },
   ]),
@@ -128,7 +128,7 @@ export const initPathPatterns = {
   [Views.InstructorsArea]: pathPattern`instructors-area`,
   [Views.InstructorsAreaCategory]: pathPattern`instructors-area/category/${pv('category')}`,
   [Views.ManageGradings]: addUrlParams(pathPattern`gradings`, ['tab', 'event', 'groupDate', 'groupInstructor']),
-  [Views.GradingView]: addUrlParams(pathPattern`gradings/${pv('gradingId')}`, ['from']),
+  [Views.GradingView]: addUrlParams(pathPattern`gradings/${pv('gradingId')}`, [{ name: 'from', ephemeral: true }]),
   [Views.MemberGradings]: addUrlParams(pathPattern`my-gradings`, ['tab', 'event', 'groupDate', 'groupInstructor']),
   [Views.Settings]: addUrlParams(pathPattern`settings`, ['tab']),
   [Views.NotificationSettings]: pathPattern`settings/notifications`,
@@ -144,7 +144,7 @@ export const initPathPatterns = {
   [Views.OrderView]: pathPattern`order-view/${pv('orderId')}`,
   [Views.MembersAreaPost]: pathPattern`members-area/post/${pv('blogPostPath')}`,
   [Views.InstructorsAreaPost]: pathPattern`instructors-area/post/${pv('blogPostPath')}`,
-  [Views.NewMember]: addUrlParams(pathPattern`new-member`, ['basePath']),
+  [Views.NewMember]: addUrlParams(pathPattern`new-member`, [{ name: 'basePath', ephemeral: true }]),
   [Views.Statistics]: pathPattern`statistics`,
   [Views.EventsCalendar]: addUrlParams(pathPattern`events`, ['q', 'fromDate', 'schoolId', 'instructorId']),
   [Views.EventView]: pathPattern`events/${pv('eventId')}`,
@@ -166,13 +166,15 @@ export const initPathPatterns = {
   // Standalone Stripe purchase flow. Intentionally not linked from the home
   // page or navigation — reachable directly via its URL.
   [Views.Products]: pathPattern`products`,
-  [Views.OrderComplete]: addUrlParams(pathPattern`order-complete`, ['session_id']),
+  [Views.OrderComplete]: addUrlParams(pathPattern`order-complete`, [{ name: 'session_id', ephemeral: true }]),
 };
 
 // Santiy check for type correctness...
 addUrlParams(pathPattern`school/${pv('schoolId')}/members`, []).pathVars
   .schoolId;
 addUrlParams(pathPattern`school/${pv('schoolId')}/members`, ['jumpTo'])
+  .urlParams.jumpTo;
+addUrlParams(pathPattern`school/${pv('schoolId')}/members`, [{ name: 'jumpTo', ephemeral: true }])
   .urlParams.jumpTo;
 addUrlParams(pathPattern`school/${pv('schoolId')}/members`, ['jumpTo'])
   .pathVars.schoolId;

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -47,16 +47,12 @@
           <app-class-calendar
             [calendarId]="instructorCalendarId()"
             [calendarOwnerName]="instructorCalendarOwnerName()"
-            backLabel="Find an Instructor"
-            backUrl="find-an-instructor"
           ></app-class-calendar>
         }
         @case (Views.SchoolCalendarView) {
           <app-class-calendar
             [calendarId]="schoolCalendarId()"
             [calendarOwnerName]="schoolCalendarOwnerName()"
-            backLabel="Find a School"
-            backUrl="find-school"
           ></app-class-calendar>
         }
         @case (Views.EventsCalendar) {
@@ -199,9 +195,6 @@
         @case (Views.MyEvents) {
           <app-event-list
             [collectionPath]="'members/' + user.member.docId + '/events'"
-            [showBackButton]="true"
-            backLabel="Back to Home"
-            backUrl="/"
           ></app-event-list>
         }
         @case (Views.MySchools) {
@@ -224,28 +217,24 @@
           <app-member-view
             [memberId]="routingService.signals[Views.ManageMemberView].pathVars.memberId()"
             basePath="members"
-            backLabel="Members List"
           ></app-member-view>
         }
         @case (Views.SchoolMemberView) {
           <app-member-view
             [memberId]="routingService.signals[Views.SchoolMemberView].pathVars.memberId()"
             [basePath]="'school/' + routingService.signals[Views.SchoolMemberView].pathVars.schoolId() + '/members'"
-            [backLabel]="'School ' + routingService.signals[Views.SchoolMemberView].pathVars.schoolId() + ' Members'"
           ></app-member-view>
         }
         @case (Views.InstructorStudentView) {
           <app-member-view
             [memberId]="routingService.signals[Views.InstructorStudentView].pathVars.memberId()"
             [basePath]="'instructor/' + routingService.signals[Views.InstructorStudentView].pathVars.instructorId() + '/students'"
-            backLabel="Students List"
           ></app-member-view>
         }
         @case (Views.MyStudentView) {
           <app-member-view
             [memberId]="routingService.signals[Views.MyStudentView].pathVars.memberId()"
             basePath="my-students"
-            backLabel="My Students"
             [allowStudentActions]="true"
           ></app-member-view>
         }

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -219,9 +219,11 @@ describe('App', () => {
     const navigateSpy = vi.spyOn(app.routingService, 'navigateTo').mockImplementation(() => {});
 
     const compiled = fixture.nativeElement as HTMLElement;
-    // Find the link to "/members"
+    // Find the link back to the members list. It carries `jumpTo` so the list
+    // scrolls to the member you came from — the same target the in-page back
+    // link uses, since both come from the navigation tree.
     const crumbLink = Array.from(compiled.querySelectorAll('.crumb-link'))
-      .find((el) => el.getAttribute('href') === '/members') as HTMLAnchorElement;
+      .find((el) => el.getAttribute('href') === '/members?jumpTo=M1') as HTMLAnchorElement;
     expect(crumbLink).toBeTruthy();
 
     // Click it!
@@ -233,7 +235,7 @@ describe('App', () => {
     crumbLink.dispatchEvent(clickEvent);
 
     expect(clickEvent.defaultPrevented).toBe(true);
-    expect(navigateSpy).toHaveBeenCalledWith('members');
+    expect(navigateSpy).toHaveBeenCalledWith('members?jumpTo=M1');
   });
 
   // Legacy hash-routing links still turn up in old emails and notifications.

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,4 +1,4 @@
-import { Component, computed, inject, signal, effect, HostListener } from '@angular/core';
+import { Component, computed, inject, signal, effect, HostListener, Signal } from '@angular/core';
 import { FirebaseStateService, LoginStatus } from './firebase-state.service';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
@@ -50,6 +50,7 @@ import { ProductsComponent } from './products/products';
 import { OrderCompleteComponent } from './order-complete/order-complete';
 import { MembershipType } from '../../functions/src/data-model';
 import { APP_VERSION } from './version';
+import { NavigationTreeService } from './navigation-tree';
 
 @Component({
   selector: 'app-root',
@@ -110,12 +111,8 @@ export class App {
   public findInstructorsService = inject(FindInstructorsService);
   public routingService: RoutingService<AppPathPatterns> =
     inject(RoutingService);
+  public navTree = inject(NavigationTreeService);
   public menuOpen = signal(false);
-  public loadedEventTitle = signal<string | null>(null);
-  public loadedOrderTitle = signal<string | null>(null);
-  public loadedSchoolTitle = signal<string | null>(null);
-  public loadedGradingTitle = signal<string | null>(null);
-  public loadedInstructorTitle = signal<string | null>(null);
 
   // Views that are accessible without login.
   private static readonly PUBLIC_VIEWS: ReadonlySet<Views> = new Set([
@@ -138,7 +135,7 @@ export class App {
   });
 
   onEventTitleLoaded(title: string) {
-    this.loadedEventTitle.set(title);
+    this.navTree.loadedEventTitle.set(title);
   }
 
   @HostListener('document:click', ['$event'])
@@ -186,144 +183,25 @@ export class App {
   }
 
   onOrderTitleLoaded(title: string) {
-    this.loadedOrderTitle.set(title);
+    this.navTree.loadedOrderTitle.set(title);
   }
 
   onSchoolTitleLoaded(title: string) {
-    this.loadedSchoolTitle.set(title);
+    this.navTree.loadedSchoolTitle.set(title);
   }
   onGradingTitleLoaded(title: string) {
-    this.loadedGradingTitle.set(title);
+    this.navTree.loadedGradingTitle.set(title);
   }
   onInstructorTitleLoaded(title: string) {
-    this.loadedInstructorTitle.set(title);
+    this.navTree.loadedInstructorTitle.set(title);
   }
-  // Whether the grading currently open in GradingView belongs to the signed-in
-  // user (they are its student, on any of their member profiles). Drives the
-  // parent breadcrumb so it matches the back link in grading-view.
-  public gradingViewIsOwn = computed(() => {
-    const gradingId = this.routingService.signals[Views.GradingView].pathVars.gradingId();
-    if (!gradingId) return false;
-    const grading = this.dataService.gradings.get(gradingId)
-      ?? this.dataService.myGradings.get(gradingId)
-      ?? this.dataService.myGradingsAssessed.get(gradingId);
-    if (!grading) return false;
-    const profiles = this.firebaseService.user()?.memberProfiles ?? [];
-    return profiles.some((p) => p.docId === grading.studentMemberDocId);
-  });
-  // True when the grading detail was opened from the member-facing "My Gradings"
-  // page (any tab), tagged via the `from` URL param on the link.
-  public gradingViewFromMyGradings = computed(
-    () => this.routingService.signals[Views.GradingView].urlParams.from() === 'my-gradings',
-  );
-  public breadcrumbs = computed<Breadcrumb[]>(() => {
-    const baseBreadcrumbs: Breadcrumb[] = [
-      { label: 'I Liq Chuan', shortLabel: 'ILC', url: 'https://iliqchuan.com' },
-      { label: 'Members Portal App', shortLabel: 'App', url: '/' },
-    ];
-    const view = this.currentView();
-    if (view !== Views.Home && view) {
-      if (view === Views.OrderView) {
-        baseBreadcrumbs.push({ label: 'Orders', url: '/orders' });
-      } else if (view === Views.MembersAreaPost) {
-        baseBreadcrumbs.push({ label: 'Members Area', url: '/members-area' });
-      } else if (view === Views.InstructorsAreaPost) {
-        baseBreadcrumbs.push({ label: 'Instructors Area', url: '/instructors-area' });
-      } else if (view === Views.ManageMemberView) {
-        baseBreadcrumbs.push({ label: 'Manage Members', url: '/members' });
-      } else if (view === Views.SchoolMemberView) {
-        const schoolId = this.routingService.signals[Views.SchoolMemberView].pathVars.schoolId();
-        baseBreadcrumbs.push({ label: `School ${schoolId} Members`, url: `/school/${schoolId}/members` });
-      } else if (view === Views.InstructorStudents || view === Views.InstructorStudentView) {
-        const instructorId = view === Views.InstructorStudents
-          ? this.routingService.signals[Views.InstructorStudents].pathVars.instructorId()
-          : this.routingService.signals[Views.InstructorStudentView].pathVars.instructorId();
-        const instructor = this.dataService.instructors.get(instructorId);
-        if (!instructor) {
-          baseBreadcrumbs.push({ label: `Instructor Not Found (${instructorId})`, url: `/instructor/${instructorId}/students` });
-          return baseBreadcrumbs;
-        }
-        baseBreadcrumbs.push({ label: `Manage Members`, url: `/members` });
-        baseBreadcrumbs.push({ label: `${instructor.name} [${instructorId}]`, url: `/members/${instructor.memberId}` });
-        baseBreadcrumbs.push({ label: `Students of ${instructor.name} [${instructorId}]`, url: `/instructor/${instructorId}/students` });
-        if (view === Views.InstructorStudentView) {
-          const studentId = this.routingService.signals[Views.InstructorStudentView].pathVars.memberId();
-          const student = this.dataService.getMember(studentId);
-          if (!student) {
-            baseBreadcrumbs.push({ label: `Student Not Found (${studentId})`, url: `/instructor/${instructorId}/students` });
-            return baseBreadcrumbs;
-          }
-          baseBreadcrumbs.push({ label: `${student.name} (${studentId})`, url: `/instructor/${instructorId}/students` });
-        }
-        return baseBreadcrumbs;
-      } else if (view === Views.MyStudentView) {
-        baseBreadcrumbs.push({ label: 'My Students', url: '/my-students' });
-      } else if (view === Views.NewMember) {
-        const basePath = this.routingService.signals[Views.NewMember].urlParams.basePath();
-        if (basePath === 'members') {
-          baseBreadcrumbs.push({ label: 'Manage Members', url: '/members' });
-        } else if (basePath?.startsWith('school/')) {
-          baseBreadcrumbs.push({ label: 'School Members', url: `/${basePath}` });
-        } else if (basePath?.startsWith('instructor/')) {
-          baseBreadcrumbs.push({ label: 'Students', url: `/${basePath}` });
-        } else if (basePath === 'my-students') {
-          baseBreadcrumbs.push({ label: 'My Students', url: '/my-students' });
-        }
-      } else if (view === Views.ClassCalendarView) {
-        baseBreadcrumbs.push({ label: 'Find an Instructor', url: '/find-an-instructor' });
-      } else if (view === Views.SchoolCalendarView) {
-        baseBreadcrumbs.push({ label: 'Find a School', url: '/find-school' });
-      } else if (view === Views.InstructorView) {
-        baseBreadcrumbs.push({ label: 'Find an Instructor', url: '/find-an-instructor' });
-      } else if (view === Views.SchoolView) {
-        baseBreadcrumbs.push({ label: 'Find a School', url: '/find-school' });
-      } else if (view === Views.EventsCalendar) {
-        // No parent breadcrumb needed for events
-      } else if (view === Views.EventView) {
-        baseBreadcrumbs.push({ label: 'Events', url: '/events' });
-      } else if (view === Views.MyEventView) {
-        baseBreadcrumbs.push({ label: 'My Events', url: '/my-events' });
-      } else if (view === Views.ManageEventView) {
-        baseBreadcrumbs.push({ label: 'Manage Events', url: '/manage-events' });
-      } else if (view === Views.EventEdit || view === Views.ManageEventEdit) {
-        baseBreadcrumbs.push({ label: 'Manage Events', url: '/manage-events' });
-      } else if (view === Views.MyEventEdit) {
-        baseBreadcrumbs.push({ label: 'My Events', url: '/my-events' });
-      } else if (view === Views.ProposeEvent) {
-        baseBreadcrumbs.push({ label: 'Events', url: '/events' });
-      } else if (view === Views.ManageEvents) {
-        // No parent breadcrumb needed for manage events
-      } else if (view === Views.ManageSchoolEdit) {
-        baseBreadcrumbs.push({ label: 'Manage Schools', url: '/schools' });
-      } else if (view === Views.MySchoolEdit) {
-        baseBreadcrumbs.push({ label: 'My Schools', url: '/my-schools' });
-      } else if (view === Views.GradingView) {
-        // The parent is "My Gradings" when this was opened from there (any tab,
-        // tagged via the `from` param) or it's the viewer's own grading;
-        // otherwise (an admin browsing the global list) it's "Manage Gradings".
-        // Mirrors the back link in grading-view.
-        if (this.gradingViewIsOwn() || this.gradingViewFromMyGradings()) {
-          baseBreadcrumbs.push({ label: 'My Gradings', url: '/my-gradings' });
-        } else {
-          baseBreadcrumbs.push({ label: 'Manage Gradings', url: '/gradings' });
-        }
-      }
-      const isEventView = view === Views.EventView || view === Views.MyEventView || view === Views.ManageEventView;
-      const isEventEdit = view === Views.EventEdit || view === Views.MyEventEdit || view === Views.ManageEventEdit;
-      const isOrderView = view === Views.OrderView;
-      const isSchoolEdit = view === Views.ManageSchoolEdit || view === Views.MySchoolEdit;
-      const isGradingView = view === Views.GradingView;
-      const isLoading = ((isEventView || isEventEdit) && !this.loadedEventTitle()) || (isOrderView && !this.loadedOrderTitle()) || (isSchoolEdit && !this.loadedSchoolTitle()) || (isGradingView && !this.loadedGradingTitle());
-      baseBreadcrumbs.push({ label: this.currentViewTitle(), isLoading });
-    }
-    return baseBreadcrumbs;
-  });
-  public currentView = computed(() => {
-    const view = this.routingService.matchedPatternId() as Views | null;
-    if (view === Views.MembersArea) return Views.MembersAreaCategory;
-    if (view === Views.InstructorsArea) return Views.InstructorsAreaCategory;
-    return view;
-  });
+  // Breadcrumbs, the current view and its title all come from the navigation
+  // tree, which the in-page back links are derived from too — see
+  // NavigationTreeService. That is what keeps the two in step.
+  public breadcrumbs: Signal<Breadcrumb[]> = this.navTree.breadcrumbs;
+  public currentView = this.navTree.currentView;
+  public currentViewTitle = this.navTree.currentTitle;
+
 
   /** Resolved calendar ID for instructor calendar view. */
   instructorCalendarId = computed(() => {
@@ -372,12 +250,6 @@ export class App {
     return '';
   });
 
-  currentViewTitle = computed(() => {
-    return this.viewIdToTitle(
-      this.routingService.matchedPatternId() as Views | '',
-    );
-  });
-
   constructor() {
     effect(() => {
       const isLoggedOut =
@@ -385,25 +257,6 @@ export class App {
       const isLoggedIn =
         this.firebaseService.loginStatus() === LoginStatus.SignedIn;
       const view = this.routingService.matchedPatternId();
-
-      const isEventView = view === Views.EventView || view === Views.MyEventView || view === Views.ManageEventView;
-      const isEventEdit = view === Views.EventEdit || view === Views.MyEventEdit || view === Views.ManageEventEdit;
-      const isSchoolEdit = view === Views.ManageSchoolEdit || view === Views.MySchoolEdit;
-      if (!isEventView && !isEventEdit) {
-        this.loadedEventTitle.set(null);
-      }
-      if (view !== Views.OrderView) {
-        this.loadedOrderTitle.set(null);
-      }
-      if (!isSchoolEdit && view !== Views.SchoolView) {
-        this.loadedSchoolTitle.set(null);
-      }
-      if (view !== Views.GradingView) {
-        this.loadedGradingTitle.set(null);
-      }
-      if (view !== Views.InstructorView) {
-        this.loadedInstructorTitle.set(null);
-      }
 
       const isOnPublicPage = !!view && App.PUBLIC_VIEWS.has(view);
       if (isLoggedOut && (!view || view === Views.Home)) {
@@ -450,150 +303,6 @@ export class App {
     );
   });
 
-  viewIdToTitle(viewId: Views | ''): string {
-    switch (viewId) {
-      case Views.ManageMembers:
-        return 'Manage Members';
-      case Views.FindAnInstructor:
-        return 'Find an Instructor';
-      case Views.InstructorView:
-        return this.loadedInstructorTitle() || 'Instructor';
-      case Views.ManageSchools:
-        return 'Manage Schools';
-      case Views.ManageSchoolEdit:
-        return this.loadedSchoolTitle() ? `Edit: ${this.loadedSchoolTitle()}` : 'Edit School';
-      case Views.MySchoolEdit:
-        return this.loadedSchoolTitle() || 'My School';
-      case Views.FindSchool:
-        return 'Find a School';
-      case Views.SchoolView:
-        return this.loadedSchoolTitle() || 'School';
-      case Views.ClassCalendarView:
-        const calInstructorId = this.routingService.signals[Views.ClassCalendarView].pathVars.instructorId();
-        const calInstructor = calInstructorId
-          ? this.findInstructorsService.instructors.get(calInstructorId)
-          : undefined;
-        return calInstructor
-          ? `${calInstructor.name} (${calInstructorId})'s Class Calendar`
-          : 'Class Calendar';
-      case Views.SchoolCalendarView:
-        const calSchoolId = this.routingService.signals[Views.SchoolCalendarView].pathVars.schoolId();
-        const calSchool = calSchoolId
-          ? this.dataService.schools.get(calSchoolId)
-          : undefined;
-        return calSchool
-          ? `${calSchool.schoolName}'s Calendar`
-          : 'School Calendar';
-      case Views.SchoolMembers:
-        const schoolId =
-          this.routingService.signals[viewId].pathVars.schoolId();
-        return `School ${schoolId} Members`;
-      case Views.InstructorStudents:
-        return 'Students';
-      case Views.ImportExport:
-        return 'Import/Export';
-      case Views.Home:
-        return 'Home';
-      case Views.MyProfile:
-        return 'My Profile';
-      case Views.MyStudents:
-        return 'My Students';
-      case Views.MyEvents:
-        return 'My Events';
-      case Views.MySchools:
-        return 'My Schools';
-      case Views.MembersArea:
-      case Views.MembersAreaCategory:
-        return 'Members Area';
-      case Views.InstructorsArea:
-      case Views.InstructorsAreaCategory:
-        return 'Instructors Area';
-      case Views.ManageGradings:
-        return 'Manage Gradings';
-      case Views.MemberGradings: {
-        const member = this.firebaseService.user()?.member;
-        if (member) {
-          return `My Gradings: (${member.memberId || 'No ID'}) ${member.name}`;
-        }
-        return 'My Gradings';
-      }
-      case Views.GradingView:
-        return this.loadedGradingTitle() || 'Grading Details';
-      case Views.Settings:
-        return 'Settings';
-      case Views.NotificationSettings:
-        return 'Notification Settings';
-      case Views.Notifications:
-        return 'Notifications';
-      case Views.Statistics:
-        return 'Statistics';
-      case Views.EventsCalendar:
-        return 'Events & Workshops';
-      case Views.EventView:
-      case Views.MyEventView:
-      case Views.ManageEventView:
-        return this.loadedEventTitle() || 'Event Details';
-      case Views.EventEdit:
-      case Views.MyEventEdit:
-      case Views.ManageEventEdit:
-        return this.loadedEventTitle() ? `Edit: ${this.loadedEventTitle()}` : 'Edit Event';
-      case Views.ProposeEvent:
-        return 'Organise Event';
-      case Views.ManageEvents:
-        return 'Manage Events';
-      case Views.ClassVideoLibrary:
-        return 'Class Video Library';
-      case Views.ManageOrders:
-        return 'Manage Orders';
-      case Views.OrderView:
-        return this.loadedOrderTitle() || 'Order Details';
-      case Views.MembersAreaPost:
-      case Views.InstructorsAreaPost:
-        return 'Article';
-      case Views.DownloadResource:
-        return 'Download Resource';
-      case Views.Products:
-        return 'Products';
-      case Views.OrderComplete:
-        return 'Order Complete';
-      case Views.Login:
-        return 'Login';
-      case Views.NewMember:
-        return 'New Member';
-      case Views.MyStudentView: {
-        const mIdOrDocId = this.routingService.signals[viewId].pathVars.memberId();
-        const m = this.dataService.getMyStudent(mIdOrDocId);
-        if (!m) {
-          return `Unknown student of yours (${mIdOrDocId})`;
-        }
-        if (m.name?.trim() && m.memberId) {
-          return `${m.name} (${m.memberId})`;
-        }
-        if (m.name?.trim()) {
-          return `${m.name} (Not yet a Member)`;
-        }
-        return `Unknown student of yours (doc:${m.docId})`;
-      }
-      case Views.ManageMemberView:
-      case Views.SchoolMemberView:
-      case Views.InstructorStudentView: {
-        const mIdOrDocId = this.routingService.signals[viewId].pathVars.memberId();
-        const m = this.dataService.getMember(mIdOrDocId);
-        if (!m) {
-          return `Unknown (${mIdOrDocId})`;
-        }
-        if (m.name.trim() && m.memberId) {
-          return `${m.name} (${m.memberId})`;
-        }
-        if (m.name.trim() && !m.memberId) {
-          return `${m.name} (Not yet a Member)`;
-        }
-        return `Unnamed and not yet a Member (doc:${m.docId})`;
-      }
-      default:
-        return 'Unknown View';
-    }
-  }
 
   public logoutError = signal<string | null>(null);
 

--- a/src/app/back-link/back-link.ts
+++ b/src/app/back-link/back-link.ts
@@ -1,0 +1,58 @@
+import { Component, computed, inject, input } from '@angular/core';
+import { IconComponent } from '../icons/icon.component';
+import { NavigationTreeService } from '../navigation-tree';
+
+/**
+ * The in-page "Back to ..." link. It always points one level up the navigation
+ * tree, so it matches the second-to-last breadcrumb by construction — see
+ * NavigationTreeService. Renders nothing on a top-level page, which has no
+ * parent to go back to.
+ *
+ * `jumpTo` adds a `jumpTo` param to the parent link, so a list scrolls to the
+ * row you came from. Pages under a member list get this for free from the tree;
+ * pass it only where the tree cannot know the row.
+ */
+@Component({
+  selector: 'app-back-link',
+  standalone: true,
+  imports: [IconComponent],
+  template: `
+    @if (parent(); as p) {
+      <a class="back-link subtle-button" [href]="p.url">
+        <app-icon name="arrow_back"></app-icon> <span>Back to {{ p.label }}</span>
+      </a>
+    }
+  `,
+  styles: `
+    /* Lay out as if the <a> were written directly in the host page, so the
+       surrounding flex/grid containers keep working. */
+    :host {
+      display: contents;
+    }
+
+    .back-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: 0.9rem;
+      padding: 0.5rem;
+      width: fit-content;
+    }
+  `,
+})
+export class BackLinkComponent {
+  private navTree = inject(NavigationTreeService);
+
+  jumpTo = input<string>('');
+
+  protected parent = computed(() => {
+    const p = this.navTree.parent();
+    if (!p) return null;
+    const jumpTo = this.jumpTo();
+    if (!jumpTo) return p;
+    const [path, query] = p.url.split('?');
+    const params = new URLSearchParams(query ?? '');
+    params.set('jumpTo', jumpTo);
+    return { ...p, url: `${path}?${params.toString()}` };
+  });
+}

--- a/src/app/class-calendar/class-calendar.html
+++ b/src/app/class-calendar/class-calendar.html
@@ -1,10 +1,6 @@
-@if (backLabel()) {
-  <div class="calendar-actions">
-    <button class="back-link subtle-button" (click)="goBack()">
-      <app-icon name="arrow_back"></app-icon> <span>Back to {{ backLabel() }}</span>
-    </button>
-  </div>
-}
+<div class="calendar-actions">
+  <app-back-link></app-back-link>
+</div>
 <div class="calendar-container">
   <div class="calendar-header">
     <div class="date-picker-container">

--- a/src/app/class-calendar/class-calendar.spec.ts
+++ b/src/app/class-calendar/class-calendar.spec.ts
@@ -4,6 +4,7 @@ import { provideZonelessChangeDetection } from '@angular/core';
 import { ClassCalendarComponent } from './class-calendar';
 import { ClassCalendarService } from '../class-calendar.service';
 import { ROUTING_CONFIG, initPathPatterns } from '../app.config';
+import { provideNavigationTreeStub } from '../navigation-tree.testing';
 
 describe('ClassCalendarComponent', () => {
   let component: ClassCalendarComponent;
@@ -20,6 +21,7 @@ describe('ClassCalendarComponent', () => {
       imports: [ClassCalendarComponent],
       providers: [
         provideZonelessChangeDetection(),
+        provideNavigationTreeStub(),
         { provide: ClassCalendarService, useValue: calendarServiceMock },
         {
           provide: ROUTING_CONFIG,

--- a/src/app/class-calendar/class-calendar.ts
+++ b/src/app/class-calendar/class-calendar.ts
@@ -13,7 +13,6 @@ import { IconComponent } from '../icons/icon.component';
 import {
   GoogleCalendarEventItem,
 } from '../../../functions/src/calendar.types';
-import { RoutingService } from '../routing.service';
 
 /**
  * Represents the state of calendar entries, which can be loading,
@@ -25,28 +24,22 @@ export type CalendarEntriesState =
   | { status: 'loaded'; data: GoogleCalendarEventItem[] };
 
 import { SpinnerComponent } from '../spinner/spinner.component';
+import { BackLinkComponent } from '../back-link/back-link';
 
 @Component({
   selector: 'app-class-calendar',
-  imports: [CommonModule, IconComponent, SpinnerComponent],
+  imports: [CommonModule, IconComponent, SpinnerComponent, BackLinkComponent],
   templateUrl: './class-calendar.html',
   styleUrl: './class-calendar.scss',
 })
 export class ClassCalendarComponent {
   private calendarService = inject(ClassCalendarService);
-  private routingService = inject(RoutingService);
 
   /** The Google Calendar ID to display. */
   calendarId = input.required<string>();
 
   /** The name of the calendar owner (instructor or school) for display. */
   calendarOwnerName = input<string>('');
-
-  /** Label for the back button, e.g. "Find an Instructor". If empty, no back button is shown. */
-  backLabel = input<string>('');
-
-  /** URL path to navigate to when the back button is clicked. */
-  backUrl = input<string>('');
 
   // The "card" styling from app.scss is used for the selected day's entries
   // in the forthcoming classes list.
@@ -151,10 +144,4 @@ export class ClassCalendarComponent {
     )}`;
   }
 
-  goBack() {
-    const url = this.backUrl();
-    if (url) {
-      this.routingService.navigateToParts([url]);
-    }
-  }
 }

--- a/src/app/event-edit/event-edit.html
+++ b/src/app/event-edit/event-edit.html
@@ -3,7 +3,7 @@
 } @else if (loadError()) {
   <div class="error-container">
     <span class="error-message">{{ loadError() }}</span>
-    <a class="subtle-button" [href]="routingService.hrefWithParams(backUrl())">
+    <a class="subtle-button" [href]="routingService.hrefWithParams(listUrl())">
       <app-icon name="arrow_back" /> Back
     </a>
   </div>
@@ -654,18 +654,7 @@
         }
       </div>
       <div style="margin-top: 1em; padding-bottom: 1em; display: flex; gap: 1em; align-items: center;">
-        <a
-          class="subtle-button"
-          [href]="routingService.hrefWithParams(backUrl())"
-        >
-          <app-icon name="arrow_back" /> Back
-        </a>
-        <a
-          class="subtle-button"
-          [href]="routingService.hrefWithParams(viewEventUrl())"
-        >
-          <app-icon name="visibility" /> View event page
-        </a>
+        <app-back-link></app-back-link>
       </div>
     </form>
   </div>

--- a/src/app/event-edit/event-edit.spec.ts
+++ b/src/app/event-edit/event-edit.spec.ts
@@ -9,6 +9,7 @@ import { DataManagerService } from '../data-manager.service';
 import { IlcEvent, EventStatus, EventSourceKind } from '../../../functions/src/data-model';
 import { updateDoc } from 'firebase/firestore';
 import { SearchableSet } from '../searchable-set';
+import { provideNavigationTreeStub } from '../navigation-tree.testing';
 
 // Mock firebase/firestore
 vi.mock('firebase/firestore', () => ({
@@ -47,6 +48,7 @@ describe('EventEditComponent', () => {
       imports: [EventEditComponent],
       providers: [
         provideZonelessChangeDetection(),
+        provideNavigationTreeStub(),
         { provide: RoutingService, useValue: mockRoutingService },
         { provide: FIREBASE_APP, useValue: {} }, // Mock app object
         { provide: FirebaseStateService, useValue: createFirebaseStateServiceMock() },

--- a/src/app/event-edit/event-edit.ts
+++ b/src/app/event-edit/event-edit.ts
@@ -48,6 +48,7 @@ import {
 } from 'firebase/storage';
 import { FIREBASE_APP } from '../app.config';
 import { RoutingService } from '../routing.service';
+import { BackLinkComponent } from '../back-link/back-link';
 import { AppPathPatterns, Views } from '../app.config';
 import { FirebaseStateService } from '../firebase-state.service';
 
@@ -155,7 +156,7 @@ function toFormModel(event: IlcEvent): EventFormModel {
 @Component({
   selector: 'app-event-edit',
   standalone: true,
-  imports: [FormField, IconComponent, SpinnerComponent, MarkdownEditor, ImageUploadPreviewComponent, AutocompleteComponent, InstructorSelectorComponent],
+  imports: [FormField, IconComponent, SpinnerComponent, MarkdownEditor, ImageUploadPreviewComponent, AutocompleteComponent, InstructorSelectorComponent, BackLinkComponent],
   templateUrl: './event-edit.html',
   styleUrl: './event-edit.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -316,18 +317,17 @@ export class EventEditComponent implements OnInit {
     return this.isAdmin() || ((this.isOwner() || this.isManager()) && ev.status === EventStatus.Proposed);
   });
 
-  // TODO: do something more diciplined and thoughtful with back urls, and router. 
-  backUrl = computed(() => {
+  /*
+  The events list this editor's subtree hangs off. Normal navigation out of the
+  editor goes one level up the tree — to the event's own page, via the shared
+  back link — but once the event is deleted (or failed to load) that page no
+  longer exists, so those two cases fall back to the list.
+  */
+  listUrl = computed(() => {
     const view = this.routingService.matchedPatternId();
     if (view === Views.MyEventEdit) return 'my-events';
     if (view === Views.ManageEventEdit) return 'manage-events';
-    return 'manage-events'; // Default fallback
-  });
-
-  viewEventUrl = computed(() => {
-    const prefix = this.backUrl();
-    const eventId = this.eventId();
-    return `${prefix}/${eventId}`;
+    return 'events';
   });
   // Change the event status via the chip dropdown. For non-admins only
   // 'cancelled' is allowed, with a confirmation warning.
@@ -382,7 +382,7 @@ export class EventEditComponent implements OnInit {
       const docRef = doc(this.db, 'events', ev.docId);
       await deleteDoc(docRef);
       this.successMessage.set('Event deleted successfully.');
-      setTimeout(() => this.routingService.navigateToParts([this.backUrl()]), 1500);
+      setTimeout(() => this.routingService.navigateToParts([this.listUrl()]), 1500);
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : 'Unknown error';
       console.error('Error deleting event:', error);

--- a/src/app/events-calendar/event-list/event-list.html
+++ b/src/app/events-calendar/event-list/event-list.html
@@ -18,11 +18,7 @@
   <app-spinner>Loading events...</app-spinner>
 } @else if (hasLoaded()) {
   <div class="list-search-header">
-    @if (showBackButton()) {
-      <a class="back-link subtle-button" [href]="backUrl()">
-        <app-icon name="arrow_back"></app-icon> <span>{{ backLabel() }}</span>
-      </a>
-    }
+    <app-back-link></app-back-link>
     <div class="search-box">
       <app-icon class="search-icon" name="search"></app-icon>
       <input

--- a/src/app/events-calendar/event-list/event-list.ts
+++ b/src/app/events-calendar/event-list/event-list.ts
@@ -21,6 +21,7 @@ import {
 } from 'firebase/firestore';
 import { AppPathPatterns, FIREBASE_APP, Views } from '../../app.config';
 import { RoutingService } from '../../routing.service';
+import { BackLinkComponent } from '../../back-link/back-link';
 import { CalendarEvent } from '../event.model';
 import { IlcEvent, EventStatus, eventStatusLabel, initEvent } from '../../../../functions/src/data-model';
 import MiniSearch from 'minisearch';
@@ -56,7 +57,7 @@ type SearchableCalendarEvent = IlcEvent & { id: string };
 @Component({
   selector: 'app-event-list',
   standalone: true,
-  imports: [FormsModule, EventItemComponent, IconComponent, SpinnerComponent],
+  imports: [FormsModule, EventItemComponent, IconComponent, SpinnerComponent, BackLinkComponent],
   templateUrl: './event-list.html',
   styleUrl: './event-list.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -177,10 +178,6 @@ export class EventListComponent implements OnDestroy {
   fromDateDirty = computed(() => this.fromDateInput() !== this.activeFromDate());
 
   // --- Component Inputs ---
-  showBackButton = input<boolean>(false);
-  backLabel = input<string>('Back');
-  backUrl = input<string>('');
-
   // The Firestore collection path to load events from.
   // Defaults to 'events' for the public events list.
   collectionPath = input<string>('events');

--- a/src/app/events-calendar/event-view/event-view.html
+++ b/src/app/events-calendar/event-view/event-view.html
@@ -154,7 +154,5 @@
 </div>
 
 <div class="event-view-actions">
-  <a class="back-link subtle-button" [href]="backHref()">
-    <app-icon name="arrow_back"></app-icon> <span>Back to {{ computedBackLabel() }}</span>
-  </a>
+  <app-back-link></app-back-link>
 </div>

--- a/src/app/events-calendar/event-view/event-view.ts
+++ b/src/app/events-calendar/event-view/event-view.ts
@@ -17,11 +17,12 @@ import { IlcEvent, EventStatus, eventStatusLabel, initEvent, eventContacts } fro
 import { FirebaseStateService } from '../../firebase-state.service';
 import { DataManagerService } from '../../data-manager.service';
 import { MarkdownViewer } from '../../markdown-editor/markdown-viewer';
+import { BackLinkComponent } from '../../back-link/back-link';
 
 @Component({
   selector: 'app-event-view',
   standalone: true,
-  imports: [IconComponent, SpinnerComponent, MarkdownViewer],
+  imports: [IconComponent, SpinnerComponent, MarkdownViewer, BackLinkComponent],
   templateUrl: './event-view.html',
   styleUrl: './event-view.scss',
 })
@@ -101,26 +102,6 @@ export class EventViewComponent implements OnInit {
     }
     return this.routingService.hrefForView(Views.EventEdit, { eventId });
   });
-
-  backHref = computed(() => {
-    const view = this.routingService.matchedPatternId();
-    if (view === Views.MyEventView) {
-      return this.routingService.hrefForView(Views.MyEvents, {});
-    }
-    if (view === Views.ManageEventView) {
-      return this.routingService.hrefForView(Views.ManageEvents, {});
-    }
-    return this.routingService.hrefForView(Views.EventsCalendar, {});
-  });
-
-  computedBackLabel = computed(() => {
-    const view = this.routingService.matchedPatternId();
-    if (view === Views.MyEventView) return 'My Events';
-    if (view === Views.ManageEventView) return 'Manage Events';
-    return 'Events List';
-  });
-
-
 
   ngOnInit() {
     window.scrollTo(0, 0);

--- a/src/app/grading-view/grading-view.html
+++ b/src/app/grading-view/grading-view.html
@@ -1,7 +1,5 @@
 <!-- Back navigation -->
-<a class="subtle-button" [href]="backHref()">
-  <app-icon name="arrow_back"></app-icon> {{ backLabel() }}
-</a>
+<app-back-link></app-back-link>
 
 @if (asyncError(); as errMsg) {
   <div class="error-container">

--- a/src/app/grading-view/grading-view.spec.ts
+++ b/src/app/grading-view/grading-view.spec.ts
@@ -15,6 +15,7 @@ import { initGrading, Grading } from '../../../functions/src/data-model';
 import { GradingEditComponent } from '../grading-edit/grading-edit';
 import { GradingRowHeaderComponent } from '../grading-row-header/grading-row-header';
 import { GradingProgressComponent } from '../grading-progress/grading-progress';
+import { provideNavigationTreeStub } from '../navigation-tree.testing';
 
 @Component({
   selector: 'app-grading-edit',
@@ -96,6 +97,7 @@ describe('GradingViewComponent', () => {
         MockGradingProgressComponent,
       ],
       providers: [
+        provideNavigationTreeStub(),
         { provide: DataManagerService, useValue: mockDataManagerService },
         { provide: FirebaseStateService, useValue: createFirebaseStateServiceMock() },
         { provide: RoutingService, useValue: mockRoutingService },

--- a/src/app/grading-view/grading-view.ts
+++ b/src/app/grading-view/grading-view.ts
@@ -18,7 +18,8 @@ import { SpinnerComponent } from '../spinner/spinner.component';
 import { DataManagerService } from '../data-manager.service';
 import { FirebaseStateService } from '../firebase-state.service';
 import { RoutingService } from '../routing.service';
-import { AppPathPatterns, Views } from '../app.config';
+import { AppPathPatterns } from '../app.config';
+import { BackLinkComponent } from '../back-link/back-link';
 
 @Component({
   selector: 'app-grading-view',
@@ -30,6 +31,7 @@ import { AppPathPatterns, Views } from '../app.config';
     GradingProgressComponent,
     IconComponent,
     SpinnerComponent,
+    BackLinkComponent,
   ],
   templateUrl: './grading-view.html',
   styleUrl: './grading-view.scss',
@@ -68,39 +70,6 @@ export class GradingViewComponent {
       this.dataService.myGradings.loading() ||
       this.dataService.myGradingsAssessed.loading();
   });
-
-  // True when the signed-in user is the student of the grading being viewed
-  // (one of their own member profiles). Such a viewer navigates back to their
-  // own "My Gradings" page, even if they are also an admin.
-  protected isOwnGrading = computed(() => {
-    const user = this.firebaseState.user();
-    const g = this.grading();
-    if (!user || !g) return false;
-    return user.memberProfiles.some((p) => p.docId === g.studentMemberDocId);
-  });
-
-  // True when the grading was opened from the member-facing "My Gradings" page
-  // (any of its tabs), tagged via the `from` URL param on the link.
-  protected cameFromMyGradings = computed(
-    () => this.routingService.signals[Views.GradingView].urlParams.from() === 'my-gradings',
-  );
-
-  // Return to "My Gradings" when the viewer opened this from there or it's their
-  // own grading; otherwise (an admin browsing the global list) to "Manage
-  // Gradings".
-  protected returnsToMyGradings = computed(
-    () => this.cameFromMyGradings() || this.isOwnGrading() || !this.userIsAdmin(),
-  );
-
-  protected backHref = computed(() =>
-    this.returnsToMyGradings()
-      ? this.routingService.hrefForView(Views.MemberGradings)
-      : this.routingService.hrefForView(Views.ManageGradings),
-  );
-
-  protected backLabel = computed(() =>
-    this.returnsToMyGradings() ? 'Back to My Gradings' : 'Back to Gradings',
-  );
 
   // Emit the title when the grading is loaded.
   private _emitTitle = effect(() => {

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -22,7 +22,7 @@
                 ? crumb.shortLabel || crumb.label
                 : crumb.label;
             @if (crumb.url) {
-              <a [href]="crumb.url" class="crumb-link">{{ text }}</a>
+              <a [href]="crumb.url" class="crumb-link" [title]="crumb.label">{{ text }}</a>
             } @else {
               <span class="crumb-label">{{ text }}</span>
             }

--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -86,6 +86,16 @@
     color: inherit;
     padding: 0.2em $crumb-side-padding;
     border-radius: 12px;
+    /* Ancestor crumbs are named after the record they point at (an event, a
+       school, a member), so they can be long. Keep each to one short chip —
+       the full text stays available as the link's tooltip — otherwise a single
+       parent can push the header several lines tall on a phone. */
+    display: inline-block;
+    max-width: 22ch;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    vertical-align: bottom;
     background-color: transparent;
     border: 1px solid transparent;
     transition: all 0.2s ease-in-out;

--- a/src/app/instructor-students/instructor-students.html
+++ b/src/app/instructor-students/instructor-students.html
@@ -1,3 +1,4 @@
+<app-back-link></app-back-link>
 @let s = instructorInUrlPathStatus();
 @if (s.status === InstructorStatusKind.NoInstructorInPath) {
   <p>No valid instructor is specified in the URL path.</p>

--- a/src/app/instructor-students/instructor-students.ts
+++ b/src/app/instructor-students/instructor-students.ts
@@ -4,6 +4,7 @@ import { RoutingService } from '../routing.service';
 import { AppPathPatterns, Views } from '../app.config';
 import { FilteredMembersComponent } from '../filtered-members/filtered-members';
 import { SpinnerComponent } from '../spinner/spinner.component';
+import { BackLinkComponent } from '../back-link/back-link';
 import { InstructorPublicData } from '../../../functions/src/data-model';
 
 export enum InstructorStatusKind {
@@ -30,7 +31,7 @@ type InstructorStatus =
 
 @Component({
   selector: 'app-instructor-students',
-  imports: [FilteredMembersComponent, SpinnerComponent],
+  imports: [FilteredMembersComponent, SpinnerComponent, BackLinkComponent],
   templateUrl: './instructor-students.html',
   styleUrl: './instructor-students.scss',
   standalone: true,

--- a/src/app/instructor-view/instructor-view.html
+++ b/src/app/instructor-view/instructor-view.html
@@ -1,7 +1,5 @@
 <div class="instructor-view">
-  <a class="back-link" [href]="backHref()">
-    <app-icon name="arrow_back" /> Find an Instructor
-  </a>
+  <app-back-link></app-back-link>
 
   @if (isLoading()) {
     <div class="center">

--- a/src/app/instructor-view/instructor-view.spec.ts
+++ b/src/app/instructor-view/instructor-view.spec.ts
@@ -7,6 +7,7 @@ import { DataManagerService } from '../data-manager.service';
 import { RoutingService } from '../routing.service';
 import { FIREBASE_APP, AppPathPatterns } from '../app.config';
 import { SearchableSet } from '../searchable-set';
+import { provideNavigationTreeStub } from '../navigation-tree.testing';
 import {
   InstructorPublicData,
   initInstructor,
@@ -56,6 +57,7 @@ describe('InstructorViewComponent', () => {
       imports: [InstructorViewComponent],
       providers: [
         provideZonelessChangeDetection(),
+        provideNavigationTreeStub(),
         { provide: FindInstructorsService, useValue: mockFindInstructorsService },
         { provide: DataManagerService, useValue: mockDataManagerService },
         { provide: FIREBASE_APP, useValue: {} },

--- a/src/app/instructor-view/instructor-view.ts
+++ b/src/app/instructor-view/instructor-view.ts
@@ -35,11 +35,18 @@ import { IconComponent } from '../icons/icon.component';
 import { SpinnerComponent } from '../spinner/spinner.component';
 import { MarkdownViewer } from '../markdown-editor/markdown-viewer';
 import { EventItemComponent } from '../events-calendar/event-item/event-item';
+import { BackLinkComponent } from '../back-link/back-link';
 
 @Component({
   selector: 'app-instructor-view',
   standalone: true,
-  imports: [IconComponent, SpinnerComponent, MarkdownViewer, EventItemComponent],
+  imports: [
+    IconComponent,
+    SpinnerComponent,
+    MarkdownViewer,
+    EventItemComponent,
+    BackLinkComponent,
+  ],
   templateUrl: './instructor-view.html',
   styleUrl: './instructor-view.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -65,7 +72,6 @@ export class InstructorViewComponent implements OnInit {
   schools = signal<School[]>([]);
   schoolsLoading = signal(false);
 
-  backHref = computed(() => this.routingService.hrefForView(Views.FindAnInstructor, {}));
 
   // Link to the events search page, pre-filtered to this instructor.
   allEventsHref = computed(() => {

--- a/src/app/manage-events/manage-events.ts
+++ b/src/app/manage-events/manage-events.ts
@@ -312,14 +312,11 @@ export class ManageEventsComponent implements OnDestroy {
     }
   }
 
+  // Stays inside the manage-events subtree, so the breadcrumbs and back link on
+  // the editor lead back here rather than into the public events pages.
   editLink(event: IlcEvent): string {
     const id = event.docId || event.sourceId || '';
-    return `/events/${id}/edit`;
-  }
-
-  viewLink(event: IlcEvent): string {
-    const id = event.docId || event.sourceId || '';
-    return `/manage-events/${id}`;
+    return `/manage-events/${id}/edit`;
   }
 
   // Resolve the event creator to a "Name (MemberId)" chip label.

--- a/src/app/member-create/member-create.html
+++ b/src/app/member-create/member-create.html
@@ -1,7 +1,5 @@
 <div class="member-view-actions">
-  <a class="back-link subtle-button" [href]="routingService.hrefWithParams('/' + basePath())">
-    <app-icon name="arrow_back"></app-icon> <span>Back to {{ backLabel() }}</span>
-  </a>
+  <app-back-link></app-back-link>
 </div>
 
 <div class="member-view-content">

--- a/src/app/member-create/member-create.ts
+++ b/src/app/member-create/member-create.ts
@@ -4,29 +4,23 @@ import { RoutingService } from '../routing.service';
 import { DataManagerService } from '../data-manager.service';
 import { AppPathPatterns } from '../app.config';
 import { MemberDetailsComponent } from '../member-details/member-details';
-import { IconComponent } from '../icons/icon.component';
+import { BackLinkComponent } from '../back-link/back-link';
+import { NavigationTreeService } from '../navigation-tree';
 import { initMember, Member } from '../../../functions/src/data-model';
 
 @Component({
   selector: 'app-member-create',
   standalone: true,
-  imports: [CommonModule, MemberDetailsComponent, IconComponent],
+  imports: [CommonModule, MemberDetailsComponent, BackLinkComponent],
   templateUrl: './member-create.html',
   styleUrl: './member-create.scss',
 })
 export class MemberCreateComponent implements OnInit {
   routingService = inject(RoutingService<AppPathPatterns>);
   dataService = inject(DataManagerService);
+  private navTree = inject(NavigationTreeService);
 
   basePath = input.required<string>();
-
-  backLabel = computed(() => {
-    const path = this.basePath();
-    if (path.startsWith('school/')) return 'School Members';
-    if (path.startsWith('instructor/')) return 'Students List';
-    if (path === 'my-students') return 'My Students';
-    return 'Members List';
-  });
 
   newMember = signal<Member>(initMember());
 
@@ -35,6 +29,8 @@ export class MemberCreateComponent implements OnInit {
   }
 
   goBack() {
-    this.routingService.navigateToParts([`/${this.basePath()}`]);
+    this.routingService.navigateTo(
+      this.navTree.parent()?.url ?? `/${this.basePath()}`,
+    );
   }
 }

--- a/src/app/member-view/member-view.html
+++ b/src/app/member-view/member-view.html
@@ -1,9 +1,7 @@
 @let m = member();
 
 <div class="member-view-actions">
-  <a class="back-link subtle-button" [href]="routingService.hrefWithParams('/' + basePath() + '?jumpTo=' + memberId())">
-    <app-icon name="arrow_back"></app-icon> <span>Back to {{ backLabel() }}</span>
-  </a>
+  <app-back-link></app-back-link>
 
   @if (m && allowStudentActions()) {
     <div class="actions-menu-container">

--- a/src/app/member-view/member-view.ts
+++ b/src/app/member-view/member-view.ts
@@ -6,6 +6,8 @@ import { AppPathPatterns } from '../app.config';
 import { MemberDetailsComponent } from '../member-details/member-details';
 import { IconComponent } from '../icons/icon.component';
 import { SpinnerComponent } from '../spinner/spinner.component';
+import { BackLinkComponent } from '../back-link/back-link';
+import { NavigationTreeService } from '../navigation-tree';
 import { canMarkMembershipInactive } from '../../../functions/src/data-model';
 
 /** The actions a primary instructor can take on one of their own students. */
@@ -20,17 +22,23 @@ export enum StudentAction {
 @Component({
   selector: 'app-member-view',
   standalone: true,
-  imports: [CommonModule, MemberDetailsComponent, IconComponent, SpinnerComponent],
+  imports: [
+    CommonModule,
+    MemberDetailsComponent,
+    IconComponent,
+    SpinnerComponent,
+    BackLinkComponent,
+  ],
   templateUrl: './member-view.html',
   styleUrl: './member-view.scss',
 })
 export class MemberViewComponent implements OnInit {
   routingService = inject(RoutingService<AppPathPatterns>);
   dataService = inject(DataManagerService);
+  private navTree = inject(NavigationTreeService);
 
   memberId = input.required<string>();
   basePath = input.required<string>();
-  backLabel = input.required<string>();
 
   // Offers the instructor actions menu. Only set on the My Students route,
   // where the viewer is the member's primary instructor.
@@ -74,8 +82,12 @@ export class MemberViewComponent implements OnInit {
     return canMarkMembershipInactive(m, today);
   });
 
+  // Closing the details goes exactly where the back link goes: up to the list,
+  // scrolled to this member's row.
   goBack() {
-    this.routingService.navigateToParts([`/${this.basePath()}?jumpTo=${this.memberId()}`]);
+    this.routingService.navigateTo(
+      this.navTree.parent()?.url ?? `/${this.basePath()}`,
+    );
   }
 
   /** Closes the menu and asks the instructor to confirm `action`. */
@@ -108,6 +120,8 @@ export class MemberViewComponent implements OnInit {
         await this.dataService.markStudentInactive(m.docId);
       }
       this.pendingAction.set(null);
+      // Back to the plain list — the student has just been taken out of it, so
+      // there is no row left to jump to.
       this.routingService.navigateToParts([`/${this.basePath()}`]);
     } catch (e) {
       console.error(`Failed to run ${action} on student ${m.docId}`, e);

--- a/src/app/navigation-tree.spec.ts
+++ b/src/app/navigation-tree.spec.ts
@@ -1,0 +1,210 @@
+/*
+The navigation tree is what keeps the header breadcrumbs and the in-page "Back
+to ..." links in step: the trail is the ancestors plus the current page, and the
+back link is the last ancestor. These tests pin the shape of the tree, and the
+invariant that the two views of it agree.
+*/
+import { TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection, signal } from '@angular/core';
+import { NavigationTreeService } from './navigation-tree';
+import { RoutingService } from './routing.service';
+import { DataManagerService } from './data-manager.service';
+import { FirebaseStateService, UserDetails } from './firebase-state.service';
+import { FindInstructorsService } from './find-instructors.service';
+import { ROUTING_CONFIG, Views, initPathPatterns, AppPathPatterns } from './app.config';
+
+function searchableSetStub(entries: unknown[] = []) {
+  return {
+    entries: signal(entries),
+    loading: signal(false),
+    loaded: signal(true),
+    get: (id: string) =>
+      entries.find(
+        (e) => (e as { docId?: string; schoolId?: string }).docId === id,
+      ),
+  };
+}
+
+describe('NavigationTreeService', () => {
+  let navTree: NavigationTreeService;
+  let routing: RoutingService<AppPathPatterns>;
+  let user: ReturnType<typeof signal<Partial<UserDetails> | null>>;
+
+  const school = { docId: 'schoolDoc1', schoolId: 'PARIS', schoolName: 'Paris ILC' };
+  const instructor = { instructorId: 'I7', name: 'Sifu Chin', memberId: 'M9' };
+
+  beforeEach(async () => {
+    window.history.replaceState(null, '', '/');
+    user = signal<Partial<UserDetails> | null>({
+      isAdmin: true,
+      schoolsManaged: [],
+      memberProfiles: [],
+      member: { memberId: 'M1', name: 'Test Member' },
+    } as unknown as Partial<UserDetails>);
+
+    await TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        { provide: ROUTING_CONFIG, useValue: { validPathPatterns: initPathPatterns } },
+        {
+          provide: DataManagerService,
+          useValue: {
+            schools: searchableSetStub([school]),
+            members: searchableSetStub(),
+            instructors: {
+              ...searchableSetStub([instructor]),
+              get: (id: string) => (id === instructor.instructorId ? instructor : undefined),
+            },
+            myStudents: searchableSetStub(),
+            gradings: searchableSetStub(),
+            myGradings: searchableSetStub(),
+            myGradingsAssessed: searchableSetStub(),
+            getMember: () => undefined,
+            getMyStudent: () => undefined,
+          },
+        },
+        { provide: FirebaseStateService, useValue: { user } },
+        { provide: FindInstructorsService, useValue: { instructors: searchableSetStub() } },
+      ],
+    }).compileComponents();
+
+    routing = TestBed.inject(RoutingService);
+    navTree = TestBed.inject(NavigationTreeService);
+  });
+
+  /** Point the router at `view`, with the given path variables. */
+  function goTo(view: Views, pathVars: { [key: string]: string } = {}) {
+    routing.matchedPatternId.set(view);
+    const signals = routing.signals[view] as unknown as {
+      pathVars: { [key: string]: { set(v: string): void } };
+    };
+    for (const [key, value] of Object.entries(pathVars)) {
+      signals.pathVars[key].set(value);
+    }
+  }
+
+  function ancestorLabels(): string[] {
+    return navTree.ancestors().map((a) => a.label);
+  }
+
+  it('gives a top-level page no parent, so it shows no back link', () => {
+    goTo(Views.ManageMembers);
+    expect(navTree.ancestors()).toEqual([]);
+    expect(navTree.parent()).toBeNull();
+  });
+
+  it('puts an event under its list, and the event editor under the event', () => {
+    goTo(Views.EventView, { eventId: 'E1' });
+    expect(ancestorLabels()).toEqual(['Events & Workshops']);
+
+    navTree.loadedEventTitle.set('Summer Camp');
+    goTo(Views.EventEdit, { eventId: 'E1' });
+    expect(ancestorLabels()).toEqual(['Events & Workshops', 'Summer Camp']);
+    expect(navTree.parent()?.url).toBe('/events/E1');
+  });
+
+  it('keeps each events subtree separate', () => {
+    navTree.loadedEventTitle.set('Summer Camp');
+    goTo(Views.ManageEventEdit, { eventId: 'E1' });
+    expect(ancestorLabels()).toEqual(['Manage Events', 'Summer Camp']);
+    expect(navTree.parent()?.url).toBe('/manage-events/E1');
+
+    goTo(Views.MyEventEdit, { eventId: 'E1' });
+    expect(ancestorLabels()).toEqual(['My Events', 'Summer Camp']);
+    expect(navTree.parent()?.url).toBe('/my-events/E1');
+  });
+
+  it('puts a class calendar under the instructor whose calendar it is', () => {
+    goTo(Views.ClassCalendarView, { instructorId: 'I7' });
+    expect(navTree.parent()?.url).toBe('/instructors/I7');
+    expect(ancestorLabels()[0]).toBe('Find an Instructor');
+  });
+
+  it('puts settings sub-pages under Settings', () => {
+    goTo(Views.NotificationSettings);
+    expect(navTree.parent()?.url).toBe('/settings');
+  });
+
+  it('links a member back to their list, scrolled to their row', () => {
+    goTo(Views.ManageMemberView, { memberId: 'M42' });
+    expect(navTree.parent()?.url).toBe('/members?jumpTo=M42');
+  });
+
+  it('builds the school chain for a school member list', () => {
+    goTo(Views.SchoolMembers, { schoolId: 'PARIS' });
+    expect(ancestorLabels()).toEqual(['Manage Schools', 'Paris ILC (PARIS)']);
+    expect(navTree.parent()?.url).toBe('/schools/schoolDoc1/edit');
+  });
+
+  it('routes a school manager through My Schools rather than Manage Schools', () => {
+    user.set({
+      isAdmin: false,
+      schoolsManaged: ['PARIS'],
+      memberProfiles: [],
+      member: { memberId: 'M1', name: 'Test Member' },
+    } as unknown as Partial<UserDetails>);
+    goTo(Views.SchoolMembers, { schoolId: 'PARIS' });
+    expect(ancestorLabels()).toEqual(['My Schools', 'Paris ILC (PARIS)']);
+    expect(navTree.parent()?.url).toBe('/my-schools/schoolDoc1/edit');
+  });
+
+  it('builds the instructor chain for a student list', () => {
+    goTo(Views.InstructorStudents, { instructorId: 'I7' });
+    expect(ancestorLabels()).toEqual(['Manage Members', 'Sifu Chin [I7]']);
+    expect(navTree.parent()?.url).toBe('/members/M9');
+  });
+
+  it('sends a non-admin viewing a grading back to My Gradings', () => {
+    user.set({
+      isAdmin: false,
+      schoolsManaged: [],
+      memberProfiles: [],
+      member: { memberId: 'M1', name: 'Test Member' },
+    } as unknown as Partial<UserDetails>);
+    goTo(Views.GradingView, { gradingId: 'G1' });
+    expect(navTree.parent()?.url).toBe('/my-gradings');
+  });
+
+  it('sends an admin browsing the global list back to Manage Gradings', () => {
+    goTo(Views.GradingView, { gradingId: 'G1' });
+    expect(navTree.parent()?.url).toBe('/gradings');
+  });
+
+  it('honours ?from=my-gradings for an admin', () => {
+    goTo(Views.GradingView, { gradingId: 'G1' });
+    routing.signals[Views.GradingView].urlParams.from.set('my-gradings');
+    expect(navTree.parent()?.url).toBe('/my-gradings');
+  });
+
+  it('carries the parent list state into the link back up', () => {
+    routing.signals[Views.ManageMembers].urlParams.q.set('chin');
+    goTo(Views.ManageMemberView, { memberId: 'M42' });
+    const url = navTree.parent()!.url;
+    expect(url).toContain('q=chin');
+    expect(url).toContain('jumpTo=M42');
+  });
+
+  it('ends the breadcrumb trail with the current page, after the ancestors', () => {
+    navTree.loadedEventTitle.set('Summer Camp');
+    goTo(Views.EventEdit, { eventId: 'E1' });
+    const crumbs = navTree.breadcrumbs();
+    expect(crumbs.map((c) => c.label)).toEqual([
+      'I Liq Chuan',
+      'Members Portal App',
+      'Events & Workshops',
+      'Summer Camp',
+      'Edit: Summer Camp',
+    ]);
+    // The back link is the crumb just before the current page — the invariant
+    // this whole service exists to hold.
+    expect(navTree.parent()!.label).toBe(crumbs[crumbs.length - 2].label);
+  });
+
+  it('shows only the two root crumbs on Home', () => {
+    goTo(Views.Home);
+    expect(navTree.breadcrumbs().map((c) => c.label)).toEqual([
+      'I Liq Chuan',
+      'Members Portal App',
+    ]);
+  });
+});

--- a/src/app/navigation-tree.testing.ts
+++ b/src/app/navigation-tree.testing.ts
@@ -1,0 +1,32 @@
+import { Provider, signal } from '@angular/core';
+import { NavigationTreeService } from './navigation-tree';
+
+/**
+ * Stubs the navigation tree for component tests.
+ *
+ * Any page that renders `<app-back-link>` pulls in NavigationTreeService, which
+ * in turn needs the routing config, Firebase and the data services. Component
+ * specs that only care about the page itself can stub it out with this: the
+ * back link then reports no parent and renders nothing.
+ *
+ * The tree's own behaviour — which page sits above which — is covered directly
+ * in navigation-tree.spec.ts.
+ */
+export function provideNavigationTreeStub(): Provider {
+  return {
+    provide: NavigationTreeService,
+    useValue: {
+      parent: signal(null),
+      ancestors: signal([]),
+      breadcrumbs: signal([]),
+      currentView: signal(null),
+      currentTitle: signal(''),
+      currentTitleIsLoading: signal(false),
+      loadedEventTitle: signal(null),
+      loadedOrderTitle: signal(null),
+      loadedSchoolTitle: signal(null),
+      loadedGradingTitle: signal(null),
+      loadedInstructorTitle: signal(null),
+    },
+  };
+}

--- a/src/app/navigation-tree.ts
+++ b/src/app/navigation-tree.ts
@@ -1,0 +1,571 @@
+/*
+NavigationTreeService: the single source of truth for "where am I, and what is
+above me?".
+
+The app is a tree: every page has at most one parent page, and the URL path
+mirrors that shape (`/events/:id/edit` sits under `/events/:id`, which sits
+under `/events`). Two things have to agree with that tree:
+
+  - the breadcrumbs in the header, which show the whole trail from the root, and
+  - the in-page "Back to ..." link, which goes exactly one level up.
+
+They used to be derived separately — breadcrumbs centrally in `App`, back links
+hand-rolled in each page component — and drifted apart. Now both come from
+`ancestors()` here: the breadcrumb trail is the ancestors plus the current page,
+and the back link is simply the last ancestor. They cannot disagree.
+
+Ancestor URLs are built with the routing service, so a parent's list state
+(search text, sort order, tag filter) is preserved when you go back up.
+*/
+import { computed, effect, inject, Injectable, signal } from '@angular/core';
+import { RoutingService } from './routing.service';
+import { AppPathPatterns, Views } from './app.config';
+import { DataManagerService } from './data-manager.service';
+import { FirebaseStateService } from './firebase-state.service';
+import { FindInstructorsService } from './find-instructors.service';
+
+/** One page in the tree, as linked to from a descendant. */
+export interface NavNode {
+  /** Shown as a breadcrumb, and after "Back to " in a back link. */
+  label: string;
+  /** Absolute href, with the target page's own URL params preserved. */
+  url: string;
+}
+
+/** The two fixed crumbs above every page: the main site, then this app. */
+const SITE_ROOT: NavNode & { shortLabel: string } = {
+  label: 'I Liq Chuan',
+  shortLabel: 'ILC',
+  url: 'https://iliqchuan.com',
+};
+
+@Injectable({ providedIn: 'root' })
+export class NavigationTreeService {
+  private routing: RoutingService<AppPathPatterns> = inject(RoutingService);
+  private dataService = inject(DataManagerService);
+  private firebaseState = inject(FirebaseStateService);
+  private findInstructors = inject(FindInstructorsService);
+
+  /*
+  Titles that are only known once the page has fetched its record. Pages report
+  them via their `titleLoaded` output; they live here because an ancestor node
+  needs them too (the parent of `/events/:id/edit` is the event itself), and
+  because the trailing breadcrumb shows a loading bar until they arrive.
+  */
+  public loadedEventTitle = signal<string | null>(null);
+  public loadedOrderTitle = signal<string | null>(null);
+  public loadedSchoolTitle = signal<string | null>(null);
+  public loadedGradingTitle = signal<string | null>(null);
+  public loadedInstructorTitle = signal<string | null>(null);
+
+  /** The matched route, with the two "index" routes mapped to what they render. */
+  public currentView = computed(() => {
+    const view = this.routing.matchedPatternId() as Views | null;
+    if (view === Views.MembersArea) return Views.MembersAreaCategory;
+    if (view === Views.InstructorsArea) return Views.InstructorsAreaCategory;
+    return view;
+  });
+
+  constructor() {
+    // Drop a loaded title as soon as we leave the pages that can show it, so a
+    // stale name never appears in the breadcrumb of the next page.
+    effect(() => {
+      const view = this.currentView();
+      if (!view || !EVENT_VIEWS.has(view)) this.loadedEventTitle.set(null);
+      if (view !== Views.OrderView) this.loadedOrderTitle.set(null);
+      if (!view || !SCHOOL_TITLE_VIEWS.has(view)) this.loadedSchoolTitle.set(null);
+      if (view !== Views.GradingView) this.loadedGradingTitle.set(null);
+      if (view !== Views.InstructorView) this.loadedInstructorTitle.set(null);
+    });
+  }
+
+  /** Title of the page being viewed, also used as the document title. */
+  public currentTitle = computed(() => this.titleOf(this.currentView()));
+
+  /**
+   * The pages above the current one, root-first, excluding the site root and
+   * Home. Empty for a top-level page — those are reached from the menu and have
+   * no "up".
+   */
+  public ancestors = computed<NavNode[]>(() => this.ancestorsOf(this.currentView()));
+
+  /**
+   * The page one level up, or null at the top level. This is what a back link
+   * points at.
+   */
+  public parent = computed<NavNode | null>(() => {
+    const chain = this.ancestors();
+    return chain.length > 0 ? chain[chain.length - 1] : null;
+  });
+
+  /** True while the current page is still fetching the record it is named after. */
+  public currentTitleIsLoading = computed(() => {
+    const view = this.currentView();
+    if (!view) return false;
+    if (EVENT_VIEWS.has(view)) return !this.loadedEventTitle();
+    if (view === Views.OrderView) return !this.loadedOrderTitle();
+    if (view === Views.ManageSchoolEdit || view === Views.MySchoolEdit) {
+      return !this.loadedSchoolTitle();
+    }
+    if (view === Views.GradingView) return !this.loadedGradingTitle();
+    return false;
+  });
+
+  /** Full breadcrumb trail: site root, app root, ancestors, current page. */
+  public breadcrumbs = computed(() => {
+    const view = this.currentView();
+    const appRoot = { label: 'Members Portal App', shortLabel: 'App', url: '/' };
+    if (!view || view === Views.Home) {
+      return [SITE_ROOT, appRoot];
+    }
+    return [
+      SITE_ROOT,
+      appRoot,
+      ...this.ancestors(),
+      { label: this.currentTitle(), isLoading: this.currentTitleIsLoading() },
+    ];
+  });
+
+  // ---------------------------------------------------------------------------
+  // The tree itself.
+  // ---------------------------------------------------------------------------
+
+  private ancestorsOf(view: Views | null): NavNode[] {
+    if (!view) return [];
+    switch (view) {
+      // --- Public: instructors and schools ---
+      case Views.InstructorView:
+        return [this.node(Views.FindAnInstructor, 'Find an Instructor')];
+      case Views.ClassCalendarView: {
+        const instructorId =
+          this.routing.signals[Views.ClassCalendarView].pathVars.instructorId();
+        const instructor = this.findInstructors.instructors.get(instructorId);
+        return [
+          this.node(Views.FindAnInstructor, 'Find an Instructor'),
+          this.node(Views.InstructorView, instructor?.name || instructorId, {
+            instructorId,
+          }),
+        ];
+      }
+      case Views.SchoolView:
+        return [this.node(Views.FindSchool, 'Find a School')];
+      case Views.SchoolCalendarView: {
+        const schoolId =
+          this.routing.signals[Views.SchoolCalendarView].pathVars.schoolId();
+        const school = this.dataService.schools.get(schoolId);
+        return [
+          this.node(Views.FindSchool, 'Find a School'),
+          this.node(Views.SchoolView, school?.schoolName || schoolId, { schoolId }),
+        ];
+      }
+
+      // --- Events. Three parallel subtrees: public, mine, and admin. ---
+      case Views.ProposeEvent:
+      case Views.EventView:
+        return [this.node(Views.EventsCalendar, 'Events & Workshops')];
+      case Views.MyEventView:
+        return [this.node(Views.MyEvents, 'My Events')];
+      case Views.ManageEventView:
+        return [this.node(Views.ManageEvents, 'Manage Events')];
+      case Views.EventEdit:
+      case Views.MyEventEdit:
+      case Views.ManageEventEdit: {
+        // An edit page hangs off the event it edits, not off the list.
+        const parentView = EVENT_EDIT_PARENT[view];
+        const eventId = this.routing.signals[view].pathVars.eventId();
+        return [
+          ...this.ancestorsOf(parentView),
+          this.node(parentView, this.loadedEventTitle() || 'Event Details', {
+            eventId,
+          }),
+        ];
+      }
+
+      // --- Members, students and schools ---
+      case Views.ManageMemberView:
+        return this.memberListChain(
+          'members',
+          this.routing.signals[Views.ManageMemberView].pathVars.memberId(),
+        );
+      case Views.MyStudentView:
+        return this.memberListChain(
+          'my-students',
+          this.routing.signals[Views.MyStudentView].pathVars.memberId(),
+        );
+      case Views.SchoolMemberView: {
+        const s = this.routing.signals[Views.SchoolMemberView];
+        return this.memberListChain(
+          `school/${s.pathVars.schoolId()}/members`,
+          s.pathVars.memberId(),
+        );
+      }
+      case Views.InstructorStudentView: {
+        const s = this.routing.signals[Views.InstructorStudentView];
+        return this.memberListChain(
+          `instructor/${s.pathVars.instructorId()}/students`,
+          s.pathVars.memberId(),
+        );
+      }
+      case Views.NewMember:
+        return this.memberListChain(
+          this.routing.signals[Views.NewMember].urlParams.basePath() || 'members',
+        );
+      case Views.SchoolMembers:
+        return this.schoolChain(
+          this.routing.signals[Views.SchoolMembers].pathVars.schoolId(),
+        );
+      case Views.InstructorStudents:
+        return this.instructorChain(
+          this.routing.signals[Views.InstructorStudents].pathVars.instructorId(),
+        );
+      case Views.ManageSchoolEdit:
+        return [this.node(Views.ManageSchools, 'Manage Schools')];
+      case Views.MySchoolEdit:
+        return [this.node(Views.MySchools, 'My Schools')];
+
+      // --- Gradings ---
+      case Views.GradingView:
+        return this.gradingReturnsToMyGradings()
+          ? [this.node(Views.MemberGradings, 'My Gradings')]
+          : [this.node(Views.ManageGradings, 'Manage Gradings')];
+
+      // --- Orders, articles, settings ---
+      case Views.OrderView:
+        return [this.node(Views.ManageOrders, 'Manage Orders')];
+      case Views.MembersAreaPost:
+        return [{ label: 'Members Area', url: this.routing.hrefWithParams('/members-area') }];
+      case Views.InstructorsAreaPost:
+        return [
+          { label: 'Instructors Area', url: this.routing.hrefWithParams('/instructors-area') },
+        ];
+      case Views.NotificationSettings:
+        return [this.node(Views.Settings, 'Settings')];
+
+      default:
+        return [];
+    }
+  }
+
+  /**
+   * The chain down to (and including) a member list, given the list's base path
+   * — the same `basePath` the member pages are rendered with. When `jumpToId`
+   * is given, the list link scrolls to that member on arrival.
+   */
+  private memberListChain(basePath: string, jumpToId?: string): NavNode[] {
+    const chain = this.memberListChainWithoutJump(basePath);
+    const last = chain[chain.length - 1];
+    if (jumpToId && last) {
+      chain[chain.length - 1] = { ...last, url: withParam(last.url, 'jumpTo', jumpToId) };
+    }
+    return chain;
+  }
+
+  private memberListChainWithoutJump(basePath: string): NavNode[] {
+    if (basePath === 'my-students') {
+      return [this.node(Views.MyStudents, 'My Students')];
+    }
+    const schoolMatch = /^school\/([^/]+)\/members$/.exec(basePath);
+    if (schoolMatch) {
+      const schoolId = decodeURIComponent(schoolMatch[1]);
+      const school = this.dataService.schools
+        .entries()
+        .find((s) => s.schoolId === schoolId);
+      return [
+        ...this.schoolChain(schoolId),
+        this.node(
+          Views.SchoolMembers,
+          school ? `Members of ${school.schoolName}` : `School ${schoolId} Members`,
+          { schoolId },
+        ),
+      ];
+    }
+    const instructorMatch = /^instructor\/([^/]+)\/students$/.exec(basePath);
+    if (instructorMatch) {
+      const instructorId = decodeURIComponent(instructorMatch[1]);
+      const instructor = this.dataService.instructors.get(instructorId);
+      return [
+        ...this.instructorChain(instructorId),
+        this.node(
+          Views.InstructorStudents,
+          instructor
+            ? `Students of ${instructor.name} [${instructorId}]`
+            : `Students of ${instructorId}`,
+          { instructorId },
+        ),
+      ];
+    }
+    return [this.node(Views.ManageMembers, 'Manage Members')];
+  }
+
+  /**
+   * The chain above a school's member list: the schools list the viewer can
+   * actually use, then that school's edit page (which is where the members link
+   * lives).
+   */
+  private schoolChain(schoolId: string): NavNode[] {
+    const school = this.dataService.schools
+      .entries()
+      .find((s) => s.schoolId === schoolId);
+    const user = this.firebaseState.user();
+    const isMine =
+      !user?.isAdmin && !!school && (user?.schoolsManaged ?? []).includes(schoolId);
+    const listNode = isMine
+      ? this.node(Views.MySchools, 'My Schools')
+      : this.node(Views.ManageSchools, 'Manage Schools');
+    if (!school) return [listNode];
+    const editView = isMine ? Views.MySchoolEdit : Views.ManageSchoolEdit;
+    return [
+      listNode,
+      this.node(editView, `${school.schoolName} (${schoolId})`, {
+        schoolId: school.docId || schoolId,
+      }),
+    ];
+  }
+
+  /** The chain above an instructor's student list: their member record. */
+  private instructorChain(instructorId: string): NavNode[] {
+    const membersNode = this.node(Views.ManageMembers, 'Manage Members');
+    const instructor = this.dataService.instructors.get(instructorId);
+    if (!instructor) return [membersNode];
+    return [
+      membersNode,
+      this.node(Views.ManageMemberView, `${instructor.name} [${instructorId}]`, {
+        memberId: instructor.memberId,
+      }),
+    ];
+  }
+
+  /**
+   * Whether a grading detail page belongs to the member-facing "My Gradings"
+   * subtree rather than the admin "Manage Gradings" one: when it was opened
+   * from there (tagged with `?from=my-gradings`), when it is the viewer's own
+   * grading, or when the viewer is not an admin and so has no other list.
+   */
+  public gradingReturnsToMyGradings = computed(() => {
+    if (this.routing.signals[Views.GradingView].urlParams.from() === 'my-gradings') {
+      return true;
+    }
+    if (!this.firebaseState.user()?.isAdmin) return true;
+    const gradingId = this.routing.signals[Views.GradingView].pathVars.gradingId();
+    if (!gradingId) return false;
+    const grading =
+      this.dataService.gradings.get(gradingId) ??
+      this.dataService.myGradings.get(gradingId) ??
+      this.dataService.myGradingsAssessed.get(gradingId);
+    if (!grading) return false;
+    const profiles = this.firebaseState.user()?.memberProfiles ?? [];
+    return profiles.some((p) => p.docId === grading.studentMemberDocId);
+  });
+
+  /** An ancestor link, with the target's own URL params carried forward. */
+  private node(view: Views, label: string, pathVars: PathVars = {}): NavNode {
+    return { label, url: this.hrefFor(view, pathVars) };
+  }
+
+  private hrefFor(view: Views, pathVars: PathVars): string {
+    // `hrefForView` is precisely typed per view; this service dispatches over
+    // all views at once, so the path variables are only known dynamically.
+    // Called on the service (not via a detached reference) so `this` binds.
+    const routing = this.routing as unknown as {
+      hrefForView(view: string, pathVars?: PathVars): string;
+    };
+    return routing.hrefForView(view, pathVars);
+  }
+
+  public titleOf(viewId: Views | null): string {
+    switch (viewId) {
+      case Views.ManageMembers:
+        return 'Manage Members';
+      case Views.FindAnInstructor:
+        return 'Find an Instructor';
+      case Views.InstructorView:
+        return this.loadedInstructorTitle() || 'Instructor';
+      case Views.ManageSchools:
+        return 'Manage Schools';
+      case Views.ManageSchoolEdit:
+        return this.loadedSchoolTitle()
+          ? `Edit: ${this.loadedSchoolTitle()}`
+          : 'Edit School';
+      case Views.MySchoolEdit:
+        return this.loadedSchoolTitle() || 'My School';
+      case Views.FindSchool:
+        return 'Find a School';
+      case Views.SchoolView:
+        return this.loadedSchoolTitle() || 'School';
+      case Views.ClassCalendarView: {
+        const calInstructorId =
+          this.routing.signals[Views.ClassCalendarView].pathVars.instructorId();
+        const calInstructor = calInstructorId
+          ? this.findInstructors.instructors.get(calInstructorId)
+          : undefined;
+        return calInstructor
+          ? `${calInstructor.name} (${calInstructorId})'s Class Calendar`
+          : 'Class Calendar';
+      }
+      case Views.SchoolCalendarView: {
+        const calSchoolId =
+          this.routing.signals[Views.SchoolCalendarView].pathVars.schoolId();
+        const calSchool = calSchoolId
+          ? this.dataService.schools.get(calSchoolId)
+          : undefined;
+        return calSchool ? `${calSchool.schoolName}'s Calendar` : 'School Calendar';
+      }
+      case Views.SchoolMembers: {
+        const schoolId = this.routing.signals[viewId].pathVars.schoolId();
+        const school = this.dataService.schools
+          .entries()
+          .find((s) => s.schoolId === schoolId);
+        return school
+          ? `Members of ${school.schoolName}`
+          : `School ${schoolId} Members`;
+      }
+      case Views.InstructorStudents: {
+        const instructorId = this.routing.signals[viewId].pathVars.instructorId();
+        const instructor = this.dataService.instructors.get(instructorId);
+        return instructor
+          ? `Students of ${instructor.name} [${instructorId}]`
+          : `Students of ${instructorId}`;
+      }
+      case Views.ImportExport:
+        return 'Import/Export';
+      case Views.Home:
+        return 'Home';
+      case Views.MyProfile:
+        return 'My Profile';
+      case Views.MyStudents:
+        return 'My Students';
+      case Views.MyEvents:
+        return 'My Events';
+      case Views.MySchools:
+        return 'My Schools';
+      case Views.MembersArea:
+      case Views.MembersAreaCategory:
+        return 'Members Area';
+      case Views.InstructorsArea:
+      case Views.InstructorsAreaCategory:
+        return 'Instructors Area';
+      case Views.ManageGradings:
+        return 'Manage Gradings';
+      case Views.MemberGradings: {
+        const member = this.firebaseState.user()?.member;
+        if (member) {
+          return `My Gradings: (${member.memberId || 'No ID'}) ${member.name}`;
+        }
+        return 'My Gradings';
+      }
+      case Views.GradingView:
+        return this.loadedGradingTitle() || 'Grading Details';
+      case Views.Settings:
+        return 'Settings';
+      case Views.NotificationSettings:
+        return 'Notification Settings';
+      case Views.Notifications:
+        return 'Notifications';
+      case Views.Statistics:
+        return 'Statistics';
+      case Views.EventsCalendar:
+        return 'Events & Workshops';
+      case Views.EventView:
+      case Views.MyEventView:
+      case Views.ManageEventView:
+        return this.loadedEventTitle() || 'Event Details';
+      case Views.EventEdit:
+      case Views.MyEventEdit:
+      case Views.ManageEventEdit:
+        return this.loadedEventTitle()
+          ? `Edit: ${this.loadedEventTitle()}`
+          : 'Edit Event';
+      case Views.ProposeEvent:
+        return 'Organise Event';
+      case Views.ManageEvents:
+        return 'Manage Events';
+      case Views.ClassVideoLibrary:
+        return 'Class Video Library';
+      case Views.ManageOrders:
+        return 'Manage Orders';
+      case Views.OrderView:
+        return this.loadedOrderTitle() || 'Order Details';
+      case Views.MembersAreaPost:
+      case Views.InstructorsAreaPost:
+        return 'Article';
+      case Views.DownloadResource:
+        return 'Download Resource';
+      case Views.Products:
+        return 'Products';
+      case Views.OrderComplete:
+        return 'Order Complete';
+      case Views.Login:
+        return 'Login';
+      case Views.NewMember:
+        return 'New Member';
+      case Views.MyStudentView: {
+        const mIdOrDocId = this.routing.signals[viewId].pathVars.memberId();
+        const m = this.dataService.getMyStudent(mIdOrDocId);
+        if (!m) {
+          return `Unknown student of yours (${mIdOrDocId})`;
+        }
+        if (m.name?.trim() && m.memberId) {
+          return `${m.name} (${m.memberId})`;
+        }
+        if (m.name?.trim()) {
+          return `${m.name} (Not yet a Member)`;
+        }
+        return `Unknown student of yours (doc:${m.docId})`;
+      }
+      case Views.ManageMemberView:
+      case Views.SchoolMemberView:
+      case Views.InstructorStudentView: {
+        const mIdOrDocId = this.routing.signals[viewId].pathVars.memberId();
+        const m = this.dataService.getMember(mIdOrDocId);
+        if (!m) {
+          return `Unknown (${mIdOrDocId})`;
+        }
+        if (m.name.trim() && m.memberId) {
+          return `${m.name} (${m.memberId})`;
+        }
+        if (m.name.trim() && !m.memberId) {
+          return `${m.name} (Not yet a Member)`;
+        }
+        return `Unnamed and not yet a Member (doc:${m.docId})`;
+      }
+      default:
+        return 'Unknown View';
+    }
+  }
+}
+
+type PathVars = { [key: string]: string };
+
+/** Every page whose title is the event it shows. */
+const EVENT_VIEWS: ReadonlySet<Views> = new Set([
+  Views.EventView,
+  Views.MyEventView,
+  Views.ManageEventView,
+  Views.EventEdit,
+  Views.MyEventEdit,
+  Views.ManageEventEdit,
+]);
+
+/** Every page whose title is the school it shows. */
+const SCHOOL_TITLE_VIEWS: ReadonlySet<Views> = new Set([
+  Views.ManageSchoolEdit,
+  Views.MySchoolEdit,
+  Views.SchoolView,
+]);
+
+/** The event page each edit page hangs off, staying within the same subtree. */
+const EVENT_EDIT_PARENT: {
+  [key in Views.EventEdit | Views.MyEventEdit | Views.ManageEventEdit]: Views;
+} = {
+  [Views.EventEdit]: Views.EventView,
+  [Views.MyEventEdit]: Views.MyEventView,
+  [Views.ManageEventEdit]: Views.ManageEventView,
+};
+
+/** Add (or replace) one query parameter on an already-built href. */
+function withParam(href: string, key: string, value: string): string {
+  const [path, query] = href.split('?');
+  const params = new URLSearchParams(query ?? '');
+  params.set(key, value);
+  return `${path}?${params.toString()}`;
+}

--- a/src/app/order-view/order-view.html
+++ b/src/app/order-view/order-view.html
@@ -1,9 +1,6 @@
 <div class="order-view-container">
   <div class="header-actions">
-    <a [href]="routingService.hrefWithParams('orders')" class="subtle-button back-link">
-      <app-icon name="arrow_back"></app-icon>
-      Back to Orders
-    </a>
+    <app-back-link></app-back-link>
     @if (
       order()?.ilcAppOrderKind ===
       "https://api.squarespace.com/1.0/commerce/orders"

--- a/src/app/order-view/order-view.spec.ts
+++ b/src/app/order-view/order-view.spec.ts
@@ -7,6 +7,7 @@ import { signal } from '@angular/core';
 import { RoutingService } from '../routing.service';
 import { Views } from '../app.config';
 import { vi } from 'vitest';
+import { provideNavigationTreeStub } from '../navigation-tree.testing';
 
 describe('OrderView', () => {
   let component: OrderView;
@@ -16,6 +17,7 @@ describe('OrderView', () => {
     await TestBed.configureTestingModule({
       imports: [OrderView],
       providers: [
+        provideNavigationTreeStub(),
         { provide: RoutingService, useValue: { navigateTo: vi.fn(), hrefWithParams: vi.fn().mockReturnValue('#/orders'), matchedPatternId: signal(''), signals: { [Views.OrderView]: { pathVars: { orderId: signal('123') } } } } },
         { provide: FirebaseStateService, useValue: createFirebaseStateServiceMock() },
         { provide: DataManagerService, useValue: { loadingState: signal('loaded'), getOrderByIdOrRef: vi.fn() } }

--- a/src/app/order-view/order-view.ts
+++ b/src/app/order-view/order-view.ts
@@ -6,6 +6,7 @@ import { RoutingService } from '../routing.service';
 import { AppPathPatterns, Views } from '../app.config';
 import { IconComponent } from '../icons/icon.component';
 import { SpinnerComponent } from '../spinner/spinner.component';
+import { BackLinkComponent } from '../back-link/back-link';
 import { SquarespaceOrderView } from './squarespace-order-view/squarespace-order-view';
 import { SheetOrderView } from './sheet-order-view/sheet-order-view';
 import { StripeOrderView } from './stripe-order-view/stripe-order-view';
@@ -14,7 +15,7 @@ import { FormsModule } from '@angular/forms';
 @Component({
   selector: 'app-order-view',
   standalone: true,
-  imports: [CommonModule, IconComponent, SpinnerComponent, SquarespaceOrderView, SheetOrderView, StripeOrderView, FormsModule],
+  imports: [CommonModule, IconComponent, SpinnerComponent, SquarespaceOrderView, SheetOrderView, StripeOrderView, FormsModule, BackLinkComponent],
   templateUrl: './order-view.html',
   styleUrl: './order-view.scss',
 })
@@ -84,9 +85,6 @@ export class OrderView {
     }
   }
 
-  goBack() {
-    this.routingService.navigateTo('orders');
-  }
 
   async reprocessOrder() {
     const id = this.order()?.docId;

--- a/src/app/routing.service.spec.ts
+++ b/src/app/routing.service.spec.ts
@@ -385,4 +385,39 @@ describe('RoutingService', () => {
       (service as any).hrefForView(Views.SchoolMembers);
     }).toThrowError(/Missing path variable schoolId/);
   });
+
+  it('hrefForView should not attach ephemeral params like from on GradingView', async () => {
+    await configureTestBed(testConfig);
+
+    // Simulate visiting a grading with from=my-gradings
+    setUrl('/gradings/G1?from=my-gradings');
+    await fixture.whenStable();
+    expect(service.signals[Views.GradingView].urlParams.from()).toBe('my-gradings');
+
+    // Generating a link to another grading should not have from=my-gradings attached
+    const href = service.hrefForView(Views.GradingView, { gradingId: 'G2' });
+    expect(href).toBe('/gradings/G2');
+  });
+
+  it('should reset ephemeral params and pathVars when navigating to a different pattern', async () => {
+    await configureTestBed(testConfig);
+
+    // Visit a grading with from=my-gradings
+    setUrl('/gradings/G1?from=my-gradings');
+    await fixture.whenStable();
+    expect(service.signals[Views.GradingView].pathVars.gradingId()).toBe('G1');
+    expect(service.signals[Views.GradingView].urlParams.from()).toBe('my-gradings');
+
+    // Navigate to Manage Gradings (/gradings)
+    setUrl('/gradings');
+    await fixture.whenStable();
+
+    // GradingView signals should be reset
+    expect(service.signals[Views.GradingView].pathVars.gradingId()).toBe('');
+    expect(service.signals[Views.GradingView].urlParams.from()).toBe('');
+
+    // Links generated for gradings on Manage Gradings page must not carry from=my-gradings
+    const href = service.hrefForView(Views.GradingView, { gradingId: 'bx6DELDrgqSu8RRqDv3M' });
+    expect(href).toBe('/gradings/bx6DELDrgqSu8RRqDv3M');
+  });
 });

--- a/src/app/routing.service.ts
+++ b/src/app/routing.service.ts
@@ -242,6 +242,17 @@ export class RoutingService<T extends PathPatterns> {
     const match = matchUrl(urlPart, this.config.validPathPatterns);
     if (match) {
       const patternChanged = this.previousPatternId !== match.patternId;
+      if (patternChanged && this.previousPatternId) {
+        const prevSignals = this.signals[this.previousPatternId];
+        if (prevSignals) {
+          for (const key of prevSignals.ephemeralUrlParams ?? []) {
+            prevSignals.urlParams[key]?.set(prevSignals.urlParamDefaults[key] ?? '');
+          }
+          for (const key of Object.keys(prevSignals.pathVars)) {
+            prevSignals.pathVars[key]?.set('');
+          }
+        }
+      }
       this.previousPatternId = match.patternId;
       this.matchedPatternId.set(match.patternId);
       updateSignalsFromSubsts(
@@ -306,11 +317,16 @@ export class RoutingService<T extends PathPatterns> {
     if (!match) return pathAndParams;
 
     // Carry forward current signal values for the matched pattern's URL params.
+    // Ephemeral params (e.g. 'from', 'returnUrl') are skipped so they are not
+    // accidentally carried into newly constructed links.
     const patternSignals = this.signals[match.patternId as keyof T];
     const defaults = patternSignals.urlParamDefaults;
     for (const [key, sig] of Object.entries<WritableSignal<string>>(
       patternSignals.urlParams,
     )) {
+      if (patternSignals.ephemeralUrlParams?.has(key)) {
+        continue;
+      }
       if (!existingParams.has(key)) {
         const val = sig();
         if (val !== (defaults[key] ?? '')) {

--- a/src/app/routing.utils.spec.ts
+++ b/src/app/routing.utils.spec.ts
@@ -5,6 +5,10 @@ import {
   mergeSubsts,
   matchUrl,
   updateSignalsFromSubsts,
+  pathPattern,
+  pv,
+  addUrlParams,
+  PatternSignals,
 } from './routing.utils';
 
 describe('Routing Utils', () => {
@@ -169,6 +173,22 @@ describe('Routing Utils', () => {
       };
       const remaining = updateSignalsFromSubsts(substs, signals);
       expect(remaining).toEqual({ invalid: 'param' });
+    });
+  });
+
+  describe('addUrlParams and PatternSignals with ephemeral params', () => {
+    it('should record ephemeralUrlParams in PathPattern and PatternSignals', () => {
+      const pattern = addUrlParams(pathPattern`gradings/${pv('gradingId')}`, [
+        { name: 'from', ephemeral: true },
+        'tab',
+      ]);
+      expect(pattern.ephemeralUrlParams).toBeDefined();
+      expect(pattern.ephemeralUrlParams?.has('from')).toBe(true);
+      expect(pattern.ephemeralUrlParams?.has('tab')).toBe(false);
+
+      const signals = new PatternSignals(pattern);
+      expect(signals.ephemeralUrlParams.has('from')).toBe(true);
+      expect(signals.ephemeralUrlParams.has('tab')).toBe(false);
     });
   });
 });

--- a/src/app/routing.utils.ts
+++ b/src/app/routing.utils.ts
@@ -15,6 +15,10 @@ export type PathPattern<T1 extends string, T2 extends string> = {
   urlParams: {
     [key in T2]: string;
   };
+
+  // Keys that are ephemeral navigation tags (e.g. 'from', 'returnUrl').
+  // These are not persisted or carried forward when constructing links.
+  ephemeralUrlParams?: Set<string>;
 };
 
 // The main type for specifing path patterns in a router.
@@ -43,14 +47,19 @@ export function makeUrlParams<T extends string>(
 }
 
 // A URL param definition: either a plain string name (default='') or an
-// object with a name and a non-empty default value.
-export type UrlParamDef<T extends string> = T | { name: T; default: string };
+// object with a name and options (e.g. non-empty default, ephemeral flag).
+// Ephemeral params (like 'from' or 'returnUrl') are transient navigation tags
+// and are never carried forward when constructing links to a page.
+export type UrlParamDef<T extends string> =
+  | T
+  | { name: T; default?: string; ephemeral?: boolean };
 
 // Add URL params to a PathPattern that doesn't have them.
-// Accepts plain strings (default '') or { name, default } objects.
+// Accepts plain strings (default '') or { name, default, ephemeral } objects.
 //
 //   addUrlParams(pattern, ['q', 'tab'])
 //   addUrlParams(pattern, ['q', { name: 'sortDir', default: 'asc' }])
+//   addUrlParams(pattern, [{ name: 'from', ephemeral: true }])
 export function addUrlParams<
   P1 extends string,
   U1 extends string,
@@ -63,11 +72,15 @@ export function addUrlParams<
     ...(pathPattern as PathPattern<P1, U1 | U2>),
   };
   newPathPattern.urlParams = { ...newPathPattern.urlParams };
+  newPathPattern.ephemeralUrlParams = new Set(pathPattern.ephemeralUrlParams ?? []);
   for (const def of urlParamDefs) {
     if (typeof def === 'string') {
       newPathPattern.urlParams[def] = '';
     } else {
-      newPathPattern.urlParams[def.name] = def.default;
+      newPathPattern.urlParams[def.name] = def.default ?? '';
+      if (def.ephemeral) {
+        newPathPattern.ephemeralUrlParams.add(def.name);
+      }
     }
   }
   return newPathPattern;
@@ -206,6 +219,8 @@ export class PatternSignals<PathVars extends string, UrlParams extends string> {
   urlParams: { [key in UrlParams]: WritableSignal<string> };
   // Stored defaults so the routing service can skip writing default values to the URL.
   urlParamDefaults: { [key: string]: string };
+  // Keys of urlParams that are ephemeral navigation tags (not carried forward in links).
+  ephemeralUrlParams: Set<string>;
 
   constructor(pattern: PathPattern<PathVars, UrlParams>) {
     this.pathVars = {} as {
@@ -218,6 +233,7 @@ export class PatternSignals<PathVars extends string, UrlParams extends string> {
 
     pattern.urlParams ??= {} as { [key in UrlParams]: string };
     this.urlParamDefaults = {};
+    this.ephemeralUrlParams = new Set(pattern.ephemeralUrlParams ?? []);
     this.urlParams = {} as {
       [key in UrlParams]: WritableSignal<string>;
     };

--- a/src/app/school-edit/school-edit.html
+++ b/src/app/school-edit/school-edit.html
@@ -3,9 +3,7 @@
   <app-spinner>Loading school...</app-spinner>
 } @else {
   <div class="back-link-container">
-    <a class="back-link subtle-button" [href]="backUrl()">
-      <app-icon name="arrow_back"></app-icon> <span>Back to {{ backLabel() }}</span>
-    </a>
+    <app-back-link></app-back-link>
     @if (publicListingHref(); as href) {
       <a class="subtle-button" [href]="href" target="_blank" rel="noopener noreferrer">
         <app-icon name="link"></app-icon> <span>View public listing</span>
@@ -67,7 +65,7 @@
     <form (submit)="saveSchool($event)">
       <div class="form-section">
         @if (userIsAdmin() || userIsSchoolManager()) {
-          <a class="subtle-button" href="/school/{{ s.schoolId }}/members" (click)="gotoMembers(); $event.preventDefault()">
+          <a class="subtle-button" href="/school/{{ s.schoolId }}/members">
             <app-icon name="salut" /> Students</a>
         }
         <h3>School Details</h3>

--- a/src/app/school-edit/school-edit.spec.ts
+++ b/src/app/school-edit/school-edit.spec.ts
@@ -18,6 +18,7 @@ import { SearchableSet } from '../searchable-set';
 import { ROUTING_CONFIG, initPathPatterns, FIREBASE_APP } from '../app.config';
 import { User } from 'firebase/auth';
 import { CountryCode } from '../country-codes';
+import { provideNavigationTreeStub } from '../navigation-tree.testing';
 
 describe('SchoolEditComponent', () => {
   let component: SchoolEditComponent;
@@ -68,6 +69,7 @@ describe('SchoolEditComponent', () => {
       imports: [SchoolEditComponent],
       providers: [
         provideZonelessChangeDetection(),
+        provideNavigationTreeStub(),
         { provide: DataManagerService, useValue: dataManagerServiceMock },
         { provide: FirebaseStateService, useValue: firebaseStateServiceMock },
         { provide: FIREBASE_APP, useValue: {} },

--- a/src/app/school-edit/school-edit.ts
+++ b/src/app/school-edit/school-edit.ts
@@ -35,6 +35,8 @@ import { IconComponent } from '../icons/icon.component';
 import { DataManagerService } from '../data-manager.service';
 import { SpinnerComponent } from '../spinner/spinner.component';
 import { RoutingService } from '../routing.service';
+import { BackLinkComponent } from '../back-link/back-link';
+import { NavigationTreeService } from '../navigation-tree';
 import { AppPathPatterns, Views, FIREBASE_APP } from '../app.config';
 import { getStorage, ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 import { ImageUploadPreviewComponent } from '../image-upload-preview/image-upload-preview';
@@ -59,6 +61,7 @@ import { FirebaseStateService } from '../firebase-state.service';
     IdAssignmentComponent,
     ImageUploadPreviewComponent,
     MarkdownEditor,
+    BackLinkComponent,
   ],
   templateUrl: './school-edit.html',
   styleUrl: './school-edit.scss',
@@ -70,6 +73,7 @@ export class SchoolEditComponent {
   private firebaseApp = inject(FIREBASE_APP);
   private routingService: RoutingService<AppPathPatterns> =
     inject(RoutingService);
+  private navTree = inject(NavigationTreeService);
 
   // The schoolId comes from the route path variable, passed in by app.html.
   schoolId = input.required<string>();
@@ -393,23 +397,6 @@ export class SchoolEditComponent {
     this.form.publicBioMarkdown().markAsDirty();
   }
 
-  // Build the back navigation URL based on context.
-  backUrl = computed(() => {
-    const match = this.routingService.matchedPatternId();
-    if (match === Views.MySchoolEdit) {
-      return '/my-schools';
-    }
-    return '/schools';
-  });
-
-  backLabel = computed(() => {
-    const match = this.routingService.matchedPatternId();
-    if (match === Views.MySchoolEdit) {
-      return 'My Schools';
-    }
-    return 'Manage Schools';
-  });
-
   // Link to this school's public profile page. Only available for an existing,
   // saved school that has a human-readable schoolId.
   publicListingHref = computed(() => {
@@ -496,20 +483,10 @@ export class SchoolEditComponent {
     this.navigateBack();
   }
 
+  // Leaving the editor goes where the back link goes: one level up the
+  // navigation tree (the schools list this school was opened from).
   private navigateBack() {
-    const match = this.routingService.matchedPatternId();
-    if (match === Views.MySchoolEdit) {
-      this.routingService.navigateTo('/my-schools');
-    } else {
-      this.routingService.navigateTo('/schools');
-    }
-  }
-
-  gotoMembers() {
-    const s = this.school() || this.editableSchool();
-    this.routingService.matchedPatternId.set(Views.SchoolMembers);
-    const signals = this.routingService.signals[Views.SchoolMembers];
-    signals.pathVars.schoolId.set(s.schoolId);
+    this.routingService.navigateTo(this.navTree.parent()?.url ?? '/');
   }
 
   isDupSchoolId = computed(() => {

--- a/src/app/school-members/school-members.html
+++ b/src/app/school-members/school-members.html
@@ -1,3 +1,4 @@
+<app-back-link></app-back-link>
 @let s = schoolInUrlPathStatus();
 @if (s.status === SchoolStatusKind.NoSchoolInPath) {
   <p>No valid school is specified in the URL path.</p>

--- a/src/app/school-members/school-members.spec.ts
+++ b/src/app/school-members/school-members.spec.ts
@@ -3,6 +3,7 @@ import { SchoolMembersComponent } from './school-members';
 import { DataManagerService } from '../data-manager.service';
 import { RoutingService } from '../routing.service';
 import { signal, provideZonelessChangeDetection } from '@angular/core';
+import { provideNavigationTreeStub } from '../navigation-tree.testing';
 
 describe('SchoolMembers', () => {
   let component: SchoolMembersComponent;
@@ -13,6 +14,7 @@ describe('SchoolMembers', () => {
       imports: [SchoolMembersComponent],
       providers: [
         provideZonelessChangeDetection(),
+        provideNavigationTreeStub(),
         {
           provide: DataManagerService,
           useValue: {

--- a/src/app/school-members/school-members.ts
+++ b/src/app/school-members/school-members.ts
@@ -4,6 +4,7 @@ import { RoutingService } from '../routing.service';
 import { AppPathPatterns, Views } from '../app.config';
 import { FilteredMembersComponent } from '../filtered-members/filtered-members';
 import { SpinnerComponent } from '../spinner/spinner.component';
+import { BackLinkComponent } from '../back-link/back-link';
 import { School } from '../../../functions/src/data-model';
 
 export enum SchoolStatusKind {
@@ -30,7 +31,7 @@ type SchoolStatus =
 
 @Component({
   selector: 'app-school-members',
-  imports: [FilteredMembersComponent, SpinnerComponent],
+  imports: [FilteredMembersComponent, SpinnerComponent, BackLinkComponent],
   templateUrl: './school-members.html',
   styleUrl: './school-members.scss',
   standalone: true,

--- a/src/app/school-view/school-view.html
+++ b/src/app/school-view/school-view.html
@@ -1,7 +1,5 @@
 <div class="school-view">
-  <a class="back-link" [href]="backHref()">
-    <app-icon name="arrow_back" /> Find a School
-  </a>
+  <app-back-link></app-back-link>
 
   @if (isLoading()) {
     <div class="center">

--- a/src/app/school-view/school-view.spec.ts
+++ b/src/app/school-view/school-view.spec.ts
@@ -6,6 +6,7 @@ import { DataManagerService } from '../data-manager.service';
 import { RoutingService } from '../routing.service';
 import { FIREBASE_APP, AppPathPatterns } from '../app.config';
 import { SearchableSet } from '../searchable-set';
+import { provideNavigationTreeStub } from '../navigation-tree.testing';
 import {
   School,
   initSchool,
@@ -67,6 +68,7 @@ describe('SchoolViewComponent', () => {
       imports: [SchoolViewComponent],
       providers: [
         provideZonelessChangeDetection(),
+        provideNavigationTreeStub(),
         { provide: DataManagerService, useValue: mockDataManagerService },
         { provide: FIREBASE_APP, useValue: {} },
         {

--- a/src/app/school-view/school-view.ts
+++ b/src/app/school-view/school-view.ts
@@ -33,11 +33,18 @@ import { IconComponent } from '../icons/icon.component';
 import { SpinnerComponent } from '../spinner/spinner.component';
 import { MarkdownViewer } from '../markdown-editor/markdown-viewer';
 import { EventItemComponent } from '../events-calendar/event-item/event-item';
+import { BackLinkComponent } from '../back-link/back-link';
 
 @Component({
   selector: 'app-school-view',
   standalone: true,
-  imports: [IconComponent, SpinnerComponent, MarkdownViewer, EventItemComponent],
+  imports: [
+    IconComponent,
+    SpinnerComponent,
+    MarkdownViewer,
+    EventItemComponent,
+    BackLinkComponent,
+  ],
   templateUrl: './school-view.html',
   styleUrl: './school-view.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -61,7 +68,6 @@ export class SchoolViewComponent implements OnInit {
   pastEventsTotal = signal(0);
   eventsLoading = signal(false);
 
-  backHref = computed(() => this.routingService.hrefForView(Views.FindSchool, {}));
 
   // Link to the events search page, pre-filtered to this school.
   allEventsHref = computed(() => {

--- a/src/app/settings/notification-settings/notification-settings.component.html
+++ b/src/app/settings/notification-settings/notification-settings.component.html
@@ -1,4 +1,5 @@
 <div class="notifications-settings-container">
+  <app-back-link></app-back-link>
   <div class="settings-card">
     <div class="card-header">
       <h2>Local Notification Settings</h2>

--- a/src/app/settings/notification-settings/notification-settings.component.spec.ts
+++ b/src/app/settings/notification-settings/notification-settings.component.spec.ts
@@ -6,6 +6,7 @@ import { NotificationService } from '../../notification.service';
 import { FirebaseStateService } from '../../firebase-state.service';
 import { DataManagerService } from '../../data-manager.service';
 import { NotificationKind } from '../../../../functions/src/data-model';
+import { provideNavigationTreeStub } from '../../navigation-tree.testing';
 
 describe('NotificationSettingsComponent', () => {
   let component: NotificationSettingsComponent;
@@ -46,6 +47,7 @@ describe('NotificationSettingsComponent', () => {
       imports: [NotificationSettingsComponent],
       providers: [
         provideZonelessChangeDetection(),
+        provideNavigationTreeStub(),
         { provide: NotificationService, useValue: mockNotificationService },
         { provide: FirebaseStateService, useValue: mockFirebaseService },
         {

--- a/src/app/settings/notification-settings/notification-settings.component.ts
+++ b/src/app/settings/notification-settings/notification-settings.component.ts
@@ -19,11 +19,12 @@ import { FirebaseStateService } from '../../firebase-state.service';
 import { DataManagerService } from '../../data-manager.service';
 import { Member, NotificationKind } from '../../../../functions/src/data-model';
 import { IconComponent } from '../../icons/icon.component';
+import { BackLinkComponent } from '../../back-link/back-link';
 
 @Component({
   selector: 'app-notification-settings',
   standalone: true,
-  imports: [CommonModule, IconComponent],
+  imports: [CommonModule, IconComponent, BackLinkComponent],
   templateUrl: './notification-settings.component.html',
   styleUrl: './notification-settings.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/squarespace/squarespace-article.component.html
+++ b/src/app/squarespace/squarespace-article.component.html
@@ -1,5 +1,6 @@
 <div class="squarespace-container">
     <div class="content-wrapper">
+        <app-back-link></app-back-link>
         @if (loading()) {
         <div class="loading-state">
             <app-spinner>Fetching article...</app-spinner>

--- a/src/app/squarespace/squarespace-article.component.ts
+++ b/src/app/squarespace/squarespace-article.component.ts
@@ -14,11 +14,12 @@ import { FirebaseStateService } from '../firebase-state.service';
 import { SpinnerComponent } from '../spinner/spinner.component';
 import { MembershipType, CachedBlogPost, initCachedBlogPost } from '../../../functions/src/data-model';
 import { ProcessedBlogEntry } from './squarespace-content.component';
+import { BackLinkComponent } from '../back-link/back-link';
 
 @Component({
     selector: 'app-squarespace-article',
     standalone: true,
-    imports: [CommonModule, SpinnerComponent],
+    imports: [CommonModule, SpinnerComponent, BackLinkComponent],
     templateUrl: './squarespace-article.component.html',
     styleUrls: ['./squarespace-content.component.scss'],
     encapsulation: ViewEncapsulation.None,


### PR DESCRIPTION
## Why

The app is a tree — the URL path already says so (`/events/:id/edit` under `/events/:id` under `/events`). But the two things that show that tree were derived separately: breadcrumbs centrally in `App`, back links hand-rolled in each page component. They had drifted apart.

## What changed

Both now come from `NavigationTreeService`: the breadcrumb trail is a page's ancestors plus the page itself, and the back link is the last ancestor. They cannot disagree.

### Mismatches fixed

- **Gradings.** A non-admin instructor opening a student's grading got a back link to My Gradings and a breadcrumb to Manage Gradings — a page they cannot use. `grading-view` counted `!isAdmin` as own-subtree; `app.ts` did not.
- **Manage Events.** Its cards linked to `/events/:id/edit`, the *public* edit route, while the breadcrumb claimed "Manage Events". They now stay in the manage-events subtree. (`viewLink()`, which was dead, is gone.)
- **`/school/:id/members`** and **`/settings/notifications`** had no parent crumb at all — they fell off the end of the `if` chain — and no back link.
- **Members-area / instructors-area articles** had a parent crumb but no back link.

### Tree depth

Edit pages and calendars now sit under the record they belong to, matching the URL. Back from `/events/:id/edit` goes to the event; back from `/calendar/instructor/:id` goes to that instructor's profile. Both previously skipped straight to the list.

### List state

Breadcrumb links were plain strings (`'/members'`), so they reset the list's search, sort and tag filters where the back link preserved them. They now go through the routing service. A link back to a list also carries `jumpTo`, so it scrolls to the row you came from.

### One back link component

`<app-back-link>` renders the parent link — same look and wording everywhere, and nothing at all on a top-level page. It replaces the ad-hoc "Back to Home" button on My Events and the click-handler button on the calendar, which was the only back control not using an `<a href>`.

### Also

`school-edit`'s members link set the routing signals directly instead of navigating. That is a `replaceState`, so browser Back could not return to the editor.

## Note on appearance

The back links on the public instructor and school profile pages were plain underlined text; they now match the subtle-button style used by every other back link.

## Testing

- `navigation-tree.spec.ts` — 15 new tests pinning the tree's shape, including the invariant that the back link equals the second-to-last breadcrumb.
- Full suite: 456 passing (was 441).
- Walked the running app against the seeded emulator as an admin — events, manage-events, members, schools, school members, settings, calendars, new-member — confirming for each page that the back link target equals the last breadcrumb parent, and that top-level pages show no back link.
- Checked the header at mobile width: an ancestor crumb named after a record (a long event title) used to push the header three lines tall, so `.crumb-link` now truncates with an ellipsis and keeps the full text as a tooltip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)