### PR TITLE
Fix the Pages deploy broken by the pnpm packageManager pin

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -25,10 +25,12 @@ jobs:
         with:
           node-version: '22'
 
+      # No `version:` here on purpose. pnpm/action-setup errors out if a
+      # version is given *and* package.json has a "packageManager" field, even
+      # when the two agree, so the pin in package.json is the single source of
+      # truth for which pnpm CI uses.
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Install Dependencies for Logo Maker
         run: pnpm install


### PR DESCRIPTION
The GitHub Pages deploy failed on the merge of #69:

```
Error: Multiple versions of pnpm specified:
  - version 9 in the GitHub Action config with the key "version"
  - version pnpm@11.22.0 in the package.json with the key "packageManager"
```

My fault — I added the root `packageManager` pin in #69 without checking
this workflow, which was still passing `version: 9` to
`pnpm/action-setup`.

## The fix

Remove the `version:` key so the action reads the pin from `package.json`.

Note that **bumping it to `version: 11` would not work**: the action errors
whenever a version is given in both places, even when the two agree. One of
them has to go, and `package.json` is the right one to keep.

The workflow had been on pnpm 9 while the repo moved to 10 and then 11 — a
long-standing mismatch that the pin exposed rather than caused.

## Blast radius

The only install this workflow runs is
`ghpages-site/mini-tools/logo-maker`, which:

- has no `packageManager` of its own, so it picks up the root pin;
- has a `lockfileVersion: '9.0'` lockfile, which pnpm 11 reads without
  regenerating;
- has only `concurrently`, `http-server` and `typescript` as devDeps, none
  with install scripts, so it needs no `allowBuilds` entry.

Merging this re-runs the Pages deploy and publishes the new HTML docs from
#69, which are currently unpublished.

🤖 Generated with [Claude Code](https://claude.com/claude-code)