### PR TITLE
Keep logo-maker out of the root pnpm workspace

### DIFF
--- a/ghpages-site/mini-tools/logo-maker/pnpm-workspace.yaml
+++ b/ghpages-site/mini-tools/logo-maker/pnpm-workspace.yaml
@@ -1,0 +1,9 @@
+# Marks this mini-tool as its own pnpm root.
+#
+# Without this, pnpm walks up looking for a pnpm-workspace.yaml, finds the
+# repo root's, and treats logo-maker as part of that workspace — so
+# `pnpm install` here installs the whole Angular app and the Cloud Functions
+# instead of these three devDependencies.
+#
+# No members are listed: this tool has its own lockfile and no sub-packages.
+packages: []


### PR DESCRIPTION
The Pages deploy is still failing after #70, and my diagnosis there was
wrong. This is the real cause.

## What is actually happening

Committing a `pnpm-workspace.yaml` at the repo root (in #69) made the whole
tree a pnpm workspace. So `pnpm install` inside
`ghpages-site/mini-tools/logo-maker` now walks **up**, finds that file, and
installs the repo root instead of the mini-tool.

The CI log shows it unmistakably — the step named *"Install Dependencies for
Logo Maker"* was resolving `firebase-admin`, `stripe` and
`@google-cloud/video-transcoder`, and running the root's postinstall
(`../../.. postinstall$ cd functions && pnpm install`).

`ERR_PNPM_IGNORED_BUILDS` was the symptom, not the disease. I chased the
symptom in #70.

## Why I did not catch it locally

Running the same command on my machine succeeded, because the root
`node_modules` was already fully built — nothing needed to run an install
script. CI starts from an empty `node_modules`, so the builds actually had to
execute there. I reproduced it properly this time by deleting `node_modules`
first.

## The fix

Give `logo-maker` its own `pnpm-workspace.yaml` so pnpm stops walking up and
treats it as its own root. It already has its own lockfile, and its three
devDependencies (`concurrently`, `http-server`, `typescript`) have no install
scripts.

## Verified the way CI does it

From an empty `node_modules`:

- install resolves **68 packages** instead of the entire monorepo, with no
  ignored-builds error;
- `pnpm run build` emits to `build/` as before;
- the repo root install is unaffected.

#70 is still correct on its own terms — the `version: 9` and `packageManager`
conflict was a real error that had to be removed regardless. It just was not
the whole story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)