### PR TITLE
Let a signed-in user move on from the account step

### DIFF
--- a/src/app/class-video-library-purchase/class-video-library-purchase.html
+++ b/src/app/class-video-library-purchase/class-video-library-purchase.html
@@ -183,6 +183,18 @@
             >
               <span stepSummary>{{ accountSummary() }}</span>
               <app-inline-auth></app-inline-auth>
+
+              @if (isLoggedIn()) {
+                <!-- Signed in already: the step is satisfied, so offer the way forward.
+                     Without this, reopening this step from the track stranded the user on
+                     a card whose only action was Log Out. -->
+                <div class="step-footer">
+                  <button type="button" class="next-btn" (click)="flow.next()">
+                    <span>Continue</span>
+                    <app-icon name="arrow_forward"></app-icon>
+                  </button>
+                </div>
+              }
             </app-step-card>
 
             <!-- Step 2: Choose Subscription Option -->
@@ -285,6 +297,18 @@
         }
 
         <app-inline-auth></app-inline-auth>
+
+        @if (isLoggedIn()) {
+          <!-- Signed in already: the step is satisfied, so offer the way forward.
+               Without this, reopening this step from the track stranded the user on
+               a card whose only action was Log Out. -->
+          <div class="step-footer">
+            <button type="button" class="next-btn" (click)="flow.next()">
+              <span>Continue</span>
+              <app-icon name="arrow_forward"></app-icon>
+            </button>
+          </div>
+        }
       </app-step-card>
 
       <!-- Step 2: Choose Subscription Option -->

--- a/src/app/instructor-license-purchase/instructor-license-purchase.html
+++ b/src/app/instructor-license-purchase/instructor-license-purchase.html
@@ -268,6 +268,18 @@
       }
 
       <app-inline-auth></app-inline-auth>
+
+      @if (isLoggedIn()) {
+        <!-- Signed in already: the step is satisfied, so offer the way forward.
+             Without this, reopening this step from the track stranded the user on
+             a card whose only action was Log Out. -->
+        <div class="step-footer">
+          <button type="button" class="next-btn" (click)="flow.next()">
+            <span>Continue</span>
+            <app-icon name="arrow_forward"></app-icon>
+          </button>
+        </div>
+      }
     </app-step-card>
 
     <!-- Step 2: Instructor / Group Leader Qualifications & Status -->

--- a/src/app/next-grading/next-grading.html
+++ b/src/app/next-grading/next-grading.html
@@ -112,6 +112,18 @@
     }
 
     <app-inline-auth></app-inline-auth>
+
+    @if (isLoggedIn()) {
+      <!-- Signed in already: the step is satisfied, so offer the way forward.
+           Without this, reopening this step from the track stranded the user on
+           a card whose only action was Log Out. -->
+      <div class="step-footer">
+        <button type="button" class="next-btn" (click)="flow.next()">
+          <span>Continue</span>
+          <app-icon name="arrow_forward"></app-icon>
+        </button>
+      </div>
+    }
   </app-step-card>
 
   <!-- Step 2: Progression & Eligibility -->

--- a/src/app/next-grading/next-grading.spec.ts
+++ b/src/app/next-grading/next-grading.spec.ts
@@ -470,4 +470,27 @@ describe('NextGradingComponent', () => {
       'https://checkout.stripe.com/pay/cs_test_grading',
     );
   });
+
+  it('should offer a way forward when the account step is reopened while signed in', async () => {
+    await createComponent();
+    expect(component.isLoggedIn()).toBe(true);
+
+    // The user clicks back to step 1 from the track to check which account
+    // they are on. Nothing has changed, so they must be able to go forward.
+    component.flow.goTo(component.StepAccount);
+    fixture.detectChanges();
+    expect(component.flow.current()).toBe(component.StepAccount);
+
+    const card = (fixture.nativeElement as HTMLElement).querySelector(
+      'app-step-card .step-card.current',
+    )!;
+    const forward = card.querySelector<HTMLButtonElement>('.next-btn');
+    // Previously a dead end: the only action was inline-auth's Log Out.
+    expect(forward).toBeTruthy();
+    expect(forward!.textContent).toContain('Continue');
+
+    forward!.click();
+    fixture.detectChanges();
+    expect(component.flow.current()).not.toBe(component.StepAccount);
+  });
 });

--- a/src/app/school-license-purchase/school-license-purchase.html
+++ b/src/app/school-license-purchase/school-license-purchase.html
@@ -116,6 +116,18 @@
     }
 
     <app-inline-auth></app-inline-auth>
+
+    @if (isLoggedIn()) {
+      <!-- Signed in already: the step is satisfied, so offer the way forward.
+           Without this, reopening this step from the track stranded the user on
+           a card whose only action was Log Out. -->
+      <div class="step-footer">
+        <button type="button" class="next-btn" (click)="flow.next()">
+          <span>Continue</span>
+          <app-icon name="arrow_forward"></app-icon>
+        </button>
+      </div>
+    }
   </app-step-card>
 
   <!-- Step 2: School Selection & Affiliation -->

--- a/src/app/school-license-purchase/school-license-purchase.spec.ts
+++ b/src/app/school-license-purchase/school-license-purchase.spec.ts
@@ -333,4 +333,27 @@ describe('SchoolLicensePurchaseComponent', () => {
       'Host and advertise events for licensed instructors to conduct gradings.',
     );
   });
+
+  it('should offer a way forward when the account step is reopened while signed in', async () => {
+    await createComponent();
+    expect(component.isLoggedIn()).toBe(true);
+
+    // The user clicks back to step 1 from the track to check which account
+    // they are on. Nothing has changed, so they must be able to go forward.
+    component.flow.goTo(component.StepAccount);
+    fixture.detectChanges();
+    expect(component.flow.current()).toBe(component.StepAccount);
+
+    const card = (fixture.nativeElement as HTMLElement).querySelector(
+      'app-step-card .step-card.current',
+    )!;
+    const forward = card.querySelector<HTMLButtonElement>('.next-btn');
+    // Previously a dead end: the only action was inline-auth's Log Out.
+    expect(forward).toBeTruthy();
+    expect(forward!.textContent).toContain('Continue');
+
+    forward!.click();
+    fixture.detectChanges();
+    expect(component.flow.current()).not.toBe(component.StepAccount);
+  });
 });


### PR DESCRIPTION
Reported on `/school-license`, and it affected four of the five purchase
flows.

## The bug

Click back to step 1 — say to check which account you are signed in as — and
the card shows inline-auth's signed-in box, whose only action is **Log Out**.
Nothing has changed, so you should be able to go forward again, but there is
no control to do it.

You can still click a later step in the track, since completed steps stay
clickable, but that is not an obvious affordance and it is not where you are
looking.

## Why only four pages

`become-a-member` already had this footer; the other four never got it. That
asymmetry was mine, from the original rollout.

| Page | Before |
|---|---|
| `become-a-member` | ✅ had Continue |
| `next-grading` | ❌ dead end |
| `class-video-library-purchase` | ❌ dead end (**two** copies of the step) |
| `instructor-license-purchase` | ❌ dead end |
| `school-license-purchase` | ❌ dead end — the one reported |

## The fix

Give all four the same footer `become-a-member` has: when `isLoggedIn()`, the
account step ends with **Continue**. Log Out stays where it is, as the escape
hatch rather than the only option.

The class video library page renders the account step twice — a folded
variant for members who already have access and an unfolded one for everyone
else — and both are covered.

## Tests

Regression tests on `school-license-purchase` and `next-grading` reopen the
account step while signed in, assert the control exists and says Continue,
click it, and assert the flow moves on.

Both were **confirmed to fail with the fix reverted** — I temporarily removed
the block and watched the test go red before restoring it, so these are not
tests that would pass either way.

873 tests passing (up from 871), clean build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)