### PR TITLE
Sign-in that reports its own failures, checkout on the choice step, wider backups

### DIFF
--- a/functions/src/backup.ts
+++ b/functions/src/backup.ts
@@ -3,7 +3,17 @@ import { onSchedule } from 'firebase-functions/v2/scheduler';
 import * as logger from 'firebase-functions/logger';
 import * as admin from 'firebase-admin';
 import { assertAdmin, allowedOrigins } from './common';
+import { BlogPostSourceKind, blogPostSourceKind } from './data-model';
 
+// Top-level collections holding authored (non-derived) data.
+//
+// Deliberately excluded, because every document is regenerable:
+//   'instructors'      — public projection of /members, rebuilt by
+//                        updateInstructorPublicProfile on member writes.
+//   'mail'             — transient send queue for the Trigger Email extension.
+//
+// The blog-post collections are partly cached and partly authored; see
+// BACKUP_MIXED_COLLECTIONS below.
 const BACKUP_COLLECTIONS = [
   'members',
   'schools',
@@ -12,6 +22,43 @@ const BACKUP_COLLECTIONS = [
   'acl',
   'system',
   'events',
+  'videos',
+  'video_grants',
+  'statistics',
+];
+
+// Sub-collections holding authored data. A `db.collection(name).get()` returns
+// only top-level documents, so these need their own collection-group queries.
+// Each group below lives under /members/{memberDocId}/, and the full document
+// path is recorded on every record so the parent is recoverable.
+//
+// Deliberately excluded, because they mirror a top-level collection:
+//   members/{id}/orders, members/{id}/events,
+//   schools/{id}/members, schools/{id}/gradings,
+//   instructors/{id}/members, instructors/{id}/gradings,
+//   system/deletions/{collection} (sync tombstones).
+const BACKUP_SUBCOLLECTION_GROUPS = [
+  'notifications',
+  'uploads',
+  'videoProgress',
+  'videoGrants',
+  'pushSubscriptions',
+];
+
+// Collections where cached and authored documents coexist. The blog-post
+// collections are refilled from Squarespace by the content-cache sync, but
+// that sync only prunes posts from its own source, so posts written from
+// anywhere else are durable, authored data and must be backed up.
+//
+// A post is regenerable precisely when it came from the source that syncs the
+// collection, since that sync will rewrite it. Reading the kind through
+// blogPostSourceKind keeps this decision identical to the sync's own.
+const BACKUP_MIXED_COLLECTIONS: {
+  name: string;
+  cachedFrom: BlogPostSourceKind;
+}[] = [
+  { name: 'members-post', cachedFrom: BlogPostSourceKind.Squarespace },
+  { name: 'instructors-post', cachedFrom: BlogPostSourceKind.Squarespace },
 ];
 
 /**
@@ -35,6 +82,35 @@ async function performBackup(): Promise<string> {
       }));
       backupData[collectionName] = records;
       logger.info(`Backed up ${records.length} records for ${collectionName}`);
+    }
+
+    for (const groupName of BACKUP_SUBCOLLECTION_GROUPS) {
+      logger.info(`Fetching sub-collection group: ${groupName}`);
+      const snapshot = await db.collectionGroup(groupName).get();
+      const records = snapshot.docs.map((doc) => ({
+        id: doc.id,
+        // Full Firestore path, e.g. members/{memberDocId}/notifications/{id}.
+        path: doc.ref.path,
+        ...doc.data(),
+      }));
+      backupData[groupName] = records;
+      logger.info(`Backed up ${records.length} records for ${groupName}`);
+    }
+
+    for (const { name, cachedFrom } of BACKUP_MIXED_COLLECTIONS) {
+      logger.info(`Fetching authored documents from: ${name}`);
+      const snapshot = await db.collection(name).get();
+      const records = snapshot.docs
+        .filter((doc) => blogPostSourceKind(doc.data()) !== cachedFrom)
+        .map((doc) => ({
+          id: doc.id,
+          ...doc.data(),
+        }));
+      backupData[name] = records;
+      logger.info(
+        `Backed up ${records.length} authored records for ${name} ` +
+          `(skipped ${snapshot.size - records.length} cached)`,
+      );
     }
 
     const timestamp = new Date().toISOString();
@@ -63,20 +139,28 @@ async function performBackup(): Promise<string> {
  * Scheduled Cloud Function that runs once a month (on the 1st at midnight)
  * to automatically backup the database.
  */
-export const scheduledBackup = onSchedule('0 0 1 * *', async (event) => {
-  try {
-    const fileName = await performBackup();
-    logger.info(`Scheduled backup finished successfully. File: ${fileName}`);
-  } catch (error) {
-    logger.error('Scheduled backup failed:', error);
-  }
-});
+export const scheduledBackup = onSchedule(
+  {
+    schedule: '0 0 1 * *',
+    // The whole database is assembled in memory before being stringified.
+    memory: '1GiB',
+    timeoutSeconds: 540,
+  },
+  async (event) => {
+    try {
+      const fileName = await performBackup();
+      logger.info(`Scheduled backup finished successfully. File: ${fileName}`);
+    } catch (error) {
+      logger.error('Scheduled backup failed:', error);
+    }
+  },
+);
 
 /**
  * Callable Cloud Function that allows admins to trigger a backup manually.
  */
 export const manualBackup = onCall(
-  { cors: allowedOrigins },
+  { cors: allowedOrigins, memory: '1GiB', timeoutSeconds: 540 },
   async (request) => {
     logger.info('manualBackup called by user.');
 

--- a/functions/src/content-cache.spec.ts
+++ b/functions/src/content-cache.spec.ts
@@ -5,6 +5,7 @@ import {
   mapToCachedBlogPost,
   contentChanged,
 } from './content-cache';
+import { BlogPostSourceKind, blogPostSourceKind } from './data-model';
 import {
   squarespaceBaseUrl,
   memberBlogItem,
@@ -282,5 +283,56 @@ describe('contentChanged', () => {
     const existing = { publishOn: 1000 };
     const incoming = { publishOn: 2000 };
     expect(contentChanged(existing, incoming)).toBe(true);
+  });
+});
+
+// ==================================================================
+// blogPostSourceKind
+// ==================================================================
+// This is the only place an untyped stored `kind` becomes a typed one, and it
+// decides what the sync may delete: prune, clearContentCache, and the backup's
+// cached/authored split all read through it. Getting it wrong either destroys
+// authored posts or silently omits them from backups, so the boundary is
+// pinned down here.
+describe('blogPostSourceKind', () => {
+  it('reads an explicit squarespace kind', () => {
+    expect(blogPostSourceKind({ kind: 'squarespace' }))
+      .toBe(BlogPostSourceKind.Squarespace);
+  });
+
+  it('reads an explicit firebase-sourced kind', () => {
+    expect(blogPostSourceKind({ kind: 'firebase-sourced' }))
+      .toBe(BlogPostSourceKind.FirebaseSourced);
+  });
+
+  it('treats a legacy post with no kind as squarespace-sourced', () => {
+    // These collections had no other writer before the field existed.
+    expect(blogPostSourceKind({})).toBe(BlogPostSourceKind.Squarespace);
+    expect(blogPostSourceKind({ kind: undefined }))
+      .toBe(BlogPostSourceKind.Squarespace);
+    expect(blogPostSourceKind({ kind: null }))
+      .toBe(BlogPostSourceKind.Squarespace);
+    expect(blogPostSourceKind({ kind: '' }))
+      .toBe(BlogPostSourceKind.Squarespace);
+  });
+
+  it('reports an unrecognised kind as firebase-sourced, so it is never deleted', () => {
+    expect(blogPostSourceKind({ kind: 'some-future-source' }))
+      .toBe(BlogPostSourceKind.FirebaseSourced);
+    expect(blogPostSourceKind({ kind: 42 }))
+      .toBe(BlogPostSourceKind.FirebaseSourced);
+  });
+
+  it('always returns a defined kind', () => {
+    for (const data of [{}, { kind: 'squarespace' }, { kind: 'nonsense' }]) {
+      expect(Object.values(BlogPostSourceKind)).toContain(blogPostSourceKind(data));
+    }
+  });
+});
+
+describe('mapToCachedBlogPost source kind', () => {
+  it('stamps posts it maps as squarespace-sourced', () => {
+    const post = mapToCachedBlogPost(memberBlogItem, squarespaceBaseUrl);
+    expect(post.kind).toBe(BlogPostSourceKind.Squarespace);
   });
 });

--- a/functions/src/content-cache.ts
+++ b/functions/src/content-cache.ts
@@ -19,7 +19,7 @@
  *   carries a `lastUpdated` timestamp set only when content
  *   meaningfully changes.
  *
- *   Blog posts carry a `kind` field (e.g. 'squarespace') so that
+ *   Blog posts carry a `kind` field (BlogPostSourceKind) so that
  *   pruning only removes posts from the same source, allowing other
  *   kinds of posts to coexist safely in the same collection.
  *
@@ -40,7 +40,12 @@ import * as logger from 'firebase-functions/logger';
 import * as admin from 'firebase-admin';
 import axios from 'axios';
 import { assertAdmin, allowedOrigins } from './common';
-import { EventSourceKind, CachedBlogPost, CacheMetadata } from './data-model';
+import {
+  BlogPostSourceKind,
+  blogPostSourceKind,
+  CachedBlogPost,
+  CacheMetadata,
+} from './data-model';
 
 // Squarespace configuration
 const SQUARESPACE_BASE_URL = 'https://lute-denim-99n2.squarespace.com';
@@ -132,7 +137,7 @@ export function cleanAssetUrl(assetUrl: string | undefined, baseUrl: string): st
 
 // Map a raw Squarespace blog item (from their JSON API) to our lean
 // CachedBlogPost format. The `baseUrl` is used to resolve relative
-// asset/image URLs. Sets `kind` to 'squarespace' to identify the source.
+// asset/image URLs. Stamps `kind` with the source that produced it.
 // Note: `lastUpdated` is NOT set here — it is managed by the sync logic.
 export function mapToCachedBlogPost(
   item: Record<string, unknown>,
@@ -153,7 +158,7 @@ export function mapToCachedBlogPost(
     categories: (item.categories as string[]) || [],
     tags: (item.tags as string[]) || [],
     author: ((item.author as Record<string, unknown>)?.displayName as string) || '',
-    kind: 'squarespace',
+    kind: BlogPostSourceKind.Squarespace,
   };
 }
 
@@ -178,10 +183,25 @@ export function contentChanged(
   return false;
 }
 
+// Whether a stored blog post came from `source`, and is therefore that
+// source's to prune or clear. A post from any other source was authored
+// elsewhere and must be left alone.
+//
+// This is the single definition of "disposable" in this module: prune and
+// clearContentCache both go through it, so they cannot disagree about what is
+// safe to delete. An undefined `source` means the caller opted out entirely.
+function isFromSource(
+  data: Partial<Record<'kind', unknown>>,
+  source: BlogPostSourceKind | undefined,
+): boolean {
+  if (!source) return true;
+  return blogPostSourceKind(data) === source;
+}
+
 // Sync a Firestore collection with fresh source data using
 // upsert-and-prune. Firestore document IDs remain auto-generated;
 // items are matched by a designated source ID field within each
-// document (e.g. `sourceId` for calendar events, `id` for blog posts).
+// document (`id` for blog posts, the only content synced today).
 //
 //   1. Write items that are new or whose content has changed
 //      (bumping `lastUpdated` only on actual changes).
@@ -194,12 +214,13 @@ export function contentChanged(
 // field matches the filter (or have no `kind` at all, treating them
 // as legacy entries from the same source). This allows documents
 // from other sources to coexist safely in the same collection.
+
 async function syncCollection(
   db: admin.firestore.Firestore,
   collectionPath: string,
   freshItems: Record<string, unknown>[],
   sourceIdField: string,
-  options?: { kindFilter?: string },
+  options?: { kindFilter?: BlogPostSourceKind },
 ): Promise<SyncResult> {
   const colRef = db.collection(collectionPath);
   const now = new Date().toISOString();
@@ -244,7 +265,10 @@ async function syncCollection(
       const newData = freshMap.get(sourceId)!;
       const existing = existingBySourceId.get(sourceId);
 
-      if (existing && existing.data.kind === EventSourceKind.FirebaseSourced) {
+      if (
+        existing &&
+        blogPostSourceKind(existing.data) === BlogPostSourceKind.FirebaseSourced
+      ) {
         unchanged++;
         continue;
       }
@@ -276,27 +300,16 @@ async function syncCollection(
   for (const [sourceId, existing] of existingBySourceId) {
     if (freshMap.has(sourceId)) continue;
 
-    // If kindFilter is specified, only prune docs from the same source.
-    // Documents with no `kind` are treated as legacy entries from the
-    // filtered source (safe for initial migration).
-    if (options?.kindFilter) {
-      const docKind = existing.data.kind as string | undefined;
-      if (docKind && docKind !== options.kindFilter) {
-        continue; // Different source — leave untouched.
-      }
-    }
+    // Only prune docs from the same source; anything authored elsewhere is
+    // left untouched.
+    if (!isFromSource(existing.data, options?.kindFilter)) continue;
 
     staleIds.push(existing.docId);
   }
 
   // Legacy orphan docs without a source ID are also pruned (respecting kindFilter).
   for (const orphan of orphans) {
-    if (options?.kindFilter) {
-      const docKind = orphan.data.kind as string | undefined;
-      if (docKind && docKind !== options.kindFilter) {
-        continue;
-      }
-    }
+    if (!isFromSource(orphan.data, options?.kindFilter)) continue;
     staleIds.push(orphan.docId);
   }
 
@@ -314,26 +327,37 @@ async function syncCollection(
   return { total: freshMap.size, updated, removed, unchanged };
 }
 
-// Delete all documents in a collection. Used only by the explicit
+// Delete the cached documents in a collection. Used only by the explicit
 // "clear cache" admin action, not during normal sync.
+//
+// `kindFilter` names the source whose content is being cleared. Only documents
+// that source owns are deleted — posts authored elsewhere live in the same
+// collection and are not cache, so clearing the cache must not destroy them.
+// Returns the number deleted and the number left in place.
 async function deleteCollection(
   db: admin.firestore.Firestore,
   collectionPath: string,
-): Promise<number> {
+  kindFilter: BlogPostSourceKind,
+): Promise<{ deleted: number; kept: number }> {
   const colRef = db.collection(collectionPath);
-  const docs = await colRef.listDocuments();
+  // Read the documents rather than listDocuments(), because deciding what is
+  // disposable requires each document's `kind` field.
+  const snapshot = await colRef.get();
+  const disposable = snapshot.docs.filter((doc) =>
+    isFromSource(doc.data(), kindFilter),
+  );
   let deleted = 0;
 
-  for (let i = 0; i < docs.length; i += 400) {
+  for (let i = 0; i < disposable.length; i += 400) {
     const batch = db.batch();
-    const chunk = docs.slice(i, i + 400);
-    for (const docRef of chunk) {
-      batch.delete(docRef);
+    const chunk = disposable.slice(i, i + 400);
+    for (const doc of chunk) {
+      batch.delete(doc.ref);
     }
     await batch.commit();
     deleted += chunk.length;
   }
-  return deleted;
+  return { deleted, kept: snapshot.size - deleted };
 }
 
 // ------------------------------------------------------------------
@@ -368,7 +392,7 @@ async function refreshBlogCache(db: admin.firestore.Firestore): Promise<SyncResu
 
       // Sync with kindFilter so only squarespace-sourced posts are pruned.
       const result = await syncCollection(db, blogConfig.collection, freshItems, 'id', {
-        kindFilter: 'squarespace',
+        kindFilter: BlogPostSourceKind.Squarespace,
       });
 
       totalResult = {
@@ -470,10 +494,21 @@ export const clearContentCache = onCall(
     const collectionsToDelete = BLOG_CONFIGS.map((c) => c.collection);
 
     let totalDeleted = 0;
+    let totalKept = 0;
     for (const collection of collectionsToDelete) {
-      const deleted = await deleteCollection(db, collection);
+      // Scoped to Squarespace-sourced posts: these collections may also hold
+      // posts authored in the app, which are not cache and must survive.
+      const { deleted, kept } = await deleteCollection(
+        db,
+        collection,
+        BlogPostSourceKind.Squarespace,
+      );
       totalDeleted += deleted;
-      logger.info(`Cleared ${deleted} documents from ${collection}.`);
+      totalKept += kept;
+      logger.info(
+        `Cleared ${deleted} cached documents from ${collection} ` +
+          `(kept ${kept} authored).`,
+      );
     }
 
     await updateCacheMetadata(db, {
@@ -483,7 +518,10 @@ export const clearContentCache = onCall(
       blogsLastSyncRemoved: 0,
     });
 
-    logger.info(`Cache cleared: ${totalDeleted} total documents deleted.`);
-    return { success: true, deletedCount: totalDeleted };
+    logger.info(
+      `Cache cleared: ${totalDeleted} cached documents deleted, ` +
+        `${totalKept} authored documents kept.`,
+    );
+    return { success: true, deletedCount: totalDeleted, keptCount: totalKept };
   },
 );

--- a/functions/src/data-model.ts
+++ b/functions/src/data-model.ts
@@ -2219,13 +2219,6 @@ export function eventStatusLabel(status: EventStatus | undefined): string {
   }
 }
 
-// Event source kind — used by sync pruning so that calendar-sourced
-// events can be pruned without deleting Firebase-sourced events.
-export enum EventSourceKind {
-  CalendarSourced = 'calendar-sourced',
-  FirebaseSourced = 'firebase-sourced',
-}
-
 // A document attached to an event (e.g. flyer, schedule, waiver).
 export type EventDocument = {
   name: string;   // Display name for the document
@@ -2260,8 +2253,13 @@ export function initEventContact(): EventContact {
 }
 
 // A single unified event type. All events live in /events/{docId}.
-// Calendar-synced events have kind='calendar-sourced' and status='listed'.
-// Member-proposed events have kind='firebase-sourced' and status='proposed'.
+// Every event is authored in the app; member-proposed events start at
+// status='proposed'.
+//
+// Events predating the removal of the Google Calendar sync still carry a
+// `kind` field in Firestore ('calendar-sourced' or 'firebase-sourced'). It is
+// deliberately not modelled here: nothing reads it, and all events are now
+// treated identically regardless of how they originally arrived.
 export type IlcEvent = {
   docId: string;          // Firestore document ID (not stored in doc, added on read)
   title: string;
@@ -2275,11 +2273,8 @@ export type IlcEvent = {
   heroImageOriginalUrl?: string; // URL of the original uncropped image
   location: string;
   status: EventStatus;
-  // Google Calendar sync fields
-  sourceId?: string;       // Google Calendar event ID; used by sync for upsert matching
   googleMapsUrl?: string;
   googleCalEventLink?: string;
-  kind: EventSourceKind;  // used by sync pruning
   createdAt?: string;      // ISO date-time
   // The event creator (historically called the owner; the field names are kept).
   // `ownerDocId` is the member's Firestore doc ID and stays the authoritative
@@ -2327,7 +2322,6 @@ export function initEvent(): IlcEvent {
     heroImageThumbUrl: '',
     heroImageOriginalUrl: '',
     location: '',
-    kind: EventSourceKind.FirebaseSourced,
     status: EventStatus.Proposed,
     ownerDocId: '',
     ownerEmails: [],
@@ -2430,6 +2424,38 @@ export function eventContacts(event: EventContactFields): EventContact[] {
 // The `body` and `excerpt` fields contain pre-processed HTML where
 // Squarespace-specific quirks (lazy images, protocol-relative URLs,
 // video embeds) have already been resolved.
+// Which source wrote a blog post in /members-post or /instructors-post.
+//
+// The two collections mix cached and authored content, so this is what lets
+// the Squarespace sync tell them apart: it only prunes and clears posts it
+// wrote itself, leaving app-authored posts alone.
+export enum BlogPostSourceKind {
+  // Written in the app. Never pruned or cleared by the Squarespace sync.
+  FirebaseSourced = 'firebase-sourced',
+  // Mirrored from the Squarespace blog; regenerable on the next sync.
+  Squarespace = 'squarespace',
+}
+
+// Read a post's source kind from a raw Firestore document.
+//
+// This is the single place where an untyped stored value becomes a
+// BlogPostSourceKind, so CachedBlogPost.kind can be non-optional everywhere
+// else. Documents written before the field existed have no `kind`; they came
+// from the Squarespace sync, which is the only writer these collections had
+// at the time, so that is what they are reported as. An unrecognised value is
+// reported as FirebaseSourced: the sync must never delete content it cannot
+// identify.
+export function blogPostSourceKind(
+  data: Partial<Record<'kind', unknown>>,
+): BlogPostSourceKind {
+  if (data.kind === undefined || data.kind === null || data.kind === '') {
+    return BlogPostSourceKind.Squarespace;
+  }
+  return data.kind === BlogPostSourceKind.Squarespace
+    ? BlogPostSourceKind.Squarespace
+    : BlogPostSourceKind.FirebaseSourced;
+}
+
 export type CachedBlogPost = {
   id: string;            // Squarespace item ID
   urlId: string;         // URL-friendly slug for routing
@@ -2442,7 +2468,9 @@ export type CachedBlogPost = {
   categories: string[];
   tags: string[];
   author: string;        // display name
-  kind: string;          // source identifier, e.g. 'squarespace'
+  // Which source wrote this post. Always set; read stored documents through
+  // blogPostSourceKind so legacy documents without the field are normalised.
+  kind: BlogPostSourceKind;
   lastUpdated?: string;  // ISO date-time; managed by sync logic
 };
 
@@ -2459,7 +2487,8 @@ export function initCachedBlogPost(): CachedBlogPost {
     categories: [],
     tags: [],
     author: '',
-    kind: '',
+    // These collections had no other writer when the field was introduced.
+    kind: BlogPostSourceKind.Squarespace,
   };
 }
 

--- a/functions/src/proposed-events.ts
+++ b/functions/src/proposed-events.ts
@@ -12,7 +12,7 @@ import { onCall, HttpsError, CallableRequest } from 'firebase-functions/v2/https
 import { onDocumentCreated, onDocumentUpdated, onDocumentDeleted } from 'firebase-functions/v2/firestore';
 import * as admin from 'firebase-admin';
 import * as logger from 'firebase-functions/logger';
-import { IlcEvent, EventStatus, EventSourceKind, Member, EventDocument, EventContact, initEvent, initEventContact, contactFromCreator, NotificationKind } from './data-model';
+import { IlcEvent, EventStatus, Member, EventDocument, EventContact, initEvent, initEventContact, contactFromCreator, NotificationKind } from './data-model';
 import { getMemberByEmail, allowedOrigins, hasActiveMembership, recordTombstone } from './common';
 import { createMemberNotification } from './notifications';
 import { contentChanged } from './content-cache';
@@ -266,7 +266,6 @@ export const submitProposedEvent = onCall(
       description: data.description || '',
       location: data.location || '',
       status: EventStatus.Proposed,
-      kind: EventSourceKind.FirebaseSourced,
       createdAt: new Date().toISOString(),
       ownerDocId,
       managerDocIds,
@@ -401,10 +400,6 @@ export const onEventUpdated = onDocumentUpdated('/events/{docId}', async (event)
     logger.info(`Cleaning up ${removedUrls.length} removed document(s) for event ${event.params.docId}.`);
     await deleteStorageFiles(removedUrls);
   }
-  // Legacy events imported from Google Calendar before that sync was removed
-  // are left untouched; only app-authored events are processed here.
-  if (after.kind === EventSourceKind.CalendarSourced) return;
-
   const becameListed = before.status !== EventStatus.Listed && after.status === EventStatus.Listed;
   const contentFieldsChanged = contentChanged(
     before as unknown as Record<string, unknown>,

--- a/functions/src/social-preview.ts
+++ b/functions/src/social-preview.ts
@@ -158,7 +158,8 @@ async function loadPreview(path: string, host: string): Promise<Preview | null> 
   if (route === 'events') {
     const db = admin.firestore();
     const byId = await db.collection('events').doc(id).get();
-    const data = byId.exists ? byId.data() : await firstWhere('events', 'sourceId', id);
+    if (!byId.exists) return null;
+    const data = byId.data();
     if (!data) return null;
     return buildEventPreview(data, host);
   }

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -109,113 +109,117 @@
       ) {
         <app-spinner>Initialising app...</app-spinner>
       } @else {
-        @if (firebaseService.loginStatus() !== LoginStatus.LoggingIn) {
-          @if (isLoginPage()) {
-            <div class="login-page-top-section">
-              <div class="login-box-container">
-                <app-login></app-login>
-              </div>
-
-              <div class="app-info">
-                <p>
-                  Welcome to the ILC App for Management of Members and Instructors of
-                  <a href="https://iliqchuan.com" target="_blank" rel="noopener noreferrer">Zhong Xin Dao I Liq Chuan</a>. It
-                  acts as a portal for members to manage their profile, membership
-                  status, licenses, gradings, public instructor listing, and other
-                  records related to the practice.
-                </p>
-              </div>
+        <!-- The sign-in UI stays mounted while a sign-in is in flight. It used
+             to be swapped out for the whole time loginStatus was LoggingIn,
+             which destroyed <app-inline-auth> on every attempt: the page
+             flashed, and a rejected password took its own error message down
+             with the component before anyone could read it. The in-flight
+             spinner belongs inside the auth box, which renders it itself. -->
+        @if (isLoginPage()) {
+          <div class="login-page-top-section">
+            <div class="login-box-container">
+              <app-login></app-login>
             </div>
 
-            <div class="login-site-links">
-              <div class="services-links-grid">
-                <a class="service-link-card" [href]="routingService.hrefForView(Views.EventsCalendar)">
-                  <app-icon name="event" width="32px" height="32px"></app-icon>
-                  <div class="service-link-text">
-                    <div class="service-link-title">Events &amp; Workshops</div>
-                    <div class="service-link-sub">View upcoming workshops, seminars, and training camps.</div>
-                  </div>
-                </a>
-                <a class="service-link-card" [href]="routingService.hrefForView(Views.FindSchool)">
-                  <app-icon name="map" width="32px" height="32px"></app-icon>
-                  <div class="service-link-text">
-                    <div class="service-link-title">Find a School</div>
-                    <div class="service-link-sub">Search for licensed schools and study groups in your area.</div>
-                  </div>
-                </a>
-                <a class="service-link-card" [href]="routingService.hrefForView(Views.FindAnInstructor)">
-                  <app-icon name="search" width="32px" height="32px"></app-icon>
-                  <div class="service-link-text">
-                    <div class="service-link-title">Find an Instructor</div>
-                    <div class="service-link-sub">Search for licensed instructors worldwide.</div>
-                  </div>
-                </a>
-                <a class="service-link-card" [href]="routingService.hrefForView(Views.ClassVideoLibraryPurchase)">
-                  <app-icon name="video_library" width="32px" height="32px"></app-icon>
-                  <div class="service-link-text">
-                    <div class="service-link-title">Class Video Library</div>
-                    <div class="service-link-sub">Subscribe to recorded Saturday classes and global library archive.</div>
-                  </div>
-                </a>
-                <a class="service-link-card" [href]="routingService.hrefForView(Views.BecomeAMember)">
-                  <app-icon name="hands_lotus" width="32px" height="32px"></app-icon>
-                  <div class="service-link-text">
-                    <div class="service-link-title">Become a Member</div>
-                    <div class="service-link-sub">Join as an annual or life member, or renew your existing membership.</div>
-                  </div>
-                </a>
-              </div>
+            <div class="app-info">
+              <p>
+                Welcome to the ILC App for Management of Members and Instructors of
+                <a href="https://iliqchuan.com" target="_blank" rel="noopener noreferrer">Zhong Xin Dao I Liq Chuan</a>. It
+                acts as a portal for members to manage their profile, membership
+                status, licenses, gradings, public instructor listing, and other
+                records related to the practice.
+              </p>
             </div>
-          } @else {
-            <div class="restricted-page-prompt">
-              <p>This page requires you to be logged in.</p>
-            </div>
+          </div>
 
-            <app-login></app-login>
-
-            <div class="other-pages-section">
-              <div class="section-title">
-                <h2>Other pages you might be looking for</h2>
-              </div>
-              <div class="services-links-grid">
-                <a class="service-link-card" [href]="routingService.hrefForView(Views.EventsCalendar)">
-                  <app-icon name="event" width="32px" height="32px"></app-icon>
-                  <div class="service-link-text">
-                    <div class="service-link-title">Events &amp; Workshops</div>
-                    <div class="service-link-sub">View upcoming workshops, seminars, and training camps.</div>
-                  </div>
-                </a>
-                <a class="service-link-card" [href]="routingService.hrefForView(Views.FindSchool)">
-                  <app-icon name="map" width="32px" height="32px"></app-icon>
-                  <div class="service-link-text">
-                    <div class="service-link-title">Find a School</div>
-                    <div class="service-link-sub">Search for licensed schools and study groups in your area.</div>
-                  </div>
-                </a>
-                <a class="service-link-card" [href]="routingService.hrefForView(Views.FindAnInstructor)">
-                  <app-icon name="search" width="32px" height="32px"></app-icon>
-                  <div class="service-link-text">
-                    <div class="service-link-title">Find an Instructor</div>
-                    <div class="service-link-sub">Search for licensed instructors worldwide.</div>
-                  </div>
-                </a>
-                <a class="service-link-card" [href]="routingService.hrefForView(Views.ClassVideoLibraryPurchase)">
-                  <app-icon name="video_library" width="32px" height="32px"></app-icon>
-                  <div class="service-link-text">
-                    <div class="service-link-title">Class Video Library</div>
-                    <div class="service-link-sub">Subscribe to recorded Saturday classes and global library archive.</div>
-                  </div>
-                </a>
-                <a class="service-link-card" [href]="routingService.hrefForView(Views.BecomeAMember)">
-                  <app-icon name="hands_lotus" width="32px" height="32px"></app-icon>
-                  <div class="service-link-text">
-                    <div class="service-link-title">Become a Member</div>
-                    <div class="service-link-sub">Join as an annual or life member, or renew your existing membership.</div>
-                  </div>
-                </a>
-              </div>
+          <div class="login-site-links">
+            <div class="services-links-grid">
+              <a class="service-link-card" [href]="routingService.hrefForView(Views.EventsCalendar)">
+                <app-icon name="event" width="32px" height="32px"></app-icon>
+                <div class="service-link-text">
+                  <div class="service-link-title">Events &amp; Workshops</div>
+                  <div class="service-link-sub">View upcoming workshops, seminars, and training camps.</div>
+                </div>
+              </a>
+              <a class="service-link-card" [href]="routingService.hrefForView(Views.FindSchool)">
+                <app-icon name="map" width="32px" height="32px"></app-icon>
+                <div class="service-link-text">
+                  <div class="service-link-title">Find a School</div>
+                  <div class="service-link-sub">Search for licensed schools and study groups in your area.</div>
+                </div>
+              </a>
+              <a class="service-link-card" [href]="routingService.hrefForView(Views.FindAnInstructor)">
+                <app-icon name="search" width="32px" height="32px"></app-icon>
+                <div class="service-link-text">
+                  <div class="service-link-title">Find an Instructor</div>
+                  <div class="service-link-sub">Search for licensed instructors worldwide.</div>
+                </div>
+              </a>
+              <a class="service-link-card" [href]="routingService.hrefForView(Views.ClassVideoLibraryPurchase)">
+                <app-icon name="video_library" width="32px" height="32px"></app-icon>
+                <div class="service-link-text">
+                  <div class="service-link-title">Class Video Library</div>
+                  <div class="service-link-sub">Subscribe to recorded Saturday classes and global library archive.</div>
+                </div>
+              </a>
+              <a class="service-link-card" [href]="routingService.hrefForView(Views.BecomeAMember)">
+                <app-icon name="hands_lotus" width="32px" height="32px"></app-icon>
+                <div class="service-link-text">
+                  <div class="service-link-title">Become a Member</div>
+                  <div class="service-link-sub">Join as an annual or life member, or renew your existing membership.</div>
+                </div>
+              </a>
             </div>
-          }
+          </div>
+        } @else {
+          <div class="restricted-page-prompt">
+            <p>This page requires you to be logged in.</p>
+          </div>
+
+          <app-login></app-login>
+
+          <div class="other-pages-section">
+            <div class="section-title">
+              <h2>Other pages you might be looking for</h2>
+            </div>
+            <div class="services-links-grid">
+              <a class="service-link-card" [href]="routingService.hrefForView(Views.EventsCalendar)">
+                <app-icon name="event" width="32px" height="32px"></app-icon>
+                <div class="service-link-text">
+                  <div class="service-link-title">Events &amp; Workshops</div>
+                  <div class="service-link-sub">View upcoming workshops, seminars, and training camps.</div>
+                </div>
+              </a>
+              <a class="service-link-card" [href]="routingService.hrefForView(Views.FindSchool)">
+                <app-icon name="map" width="32px" height="32px"></app-icon>
+                <div class="service-link-text">
+                  <div class="service-link-title">Find a School</div>
+                  <div class="service-link-sub">Search for licensed schools and study groups in your area.</div>
+                </div>
+              </a>
+              <a class="service-link-card" [href]="routingService.hrefForView(Views.FindAnInstructor)">
+                <app-icon name="search" width="32px" height="32px"></app-icon>
+                <div class="service-link-text">
+                  <div class="service-link-title">Find an Instructor</div>
+                  <div class="service-link-sub">Search for licensed instructors worldwide.</div>
+                </div>
+              </a>
+              <a class="service-link-card" [href]="routingService.hrefForView(Views.ClassVideoLibraryPurchase)">
+                <app-icon name="video_library" width="32px" height="32px"></app-icon>
+                <div class="service-link-text">
+                  <div class="service-link-title">Class Video Library</div>
+                  <div class="service-link-sub">Subscribe to recorded Saturday classes and global library archive.</div>
+                </div>
+              </a>
+              <a class="service-link-card" [href]="routingService.hrefForView(Views.BecomeAMember)">
+                <app-icon name="hands_lotus" width="32px" height="32px"></app-icon>
+                <div class="service-link-text">
+                  <div class="service-link-title">Become a Member</div>
+                  <div class="service-link-sub">Join as an annual or life member, or renew your existing membership.</div>
+                </div>
+              </a>
+            </div>
+          </div>
         }
       }
     } @else if (dataService.loadingState() !== DataServiceState.Loaded) {

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -96,6 +96,21 @@ describe('App', () => {
     expect(compiled.querySelector('.title')?.textContent).toContain('ILC Portal');
   });
 
+  it('should keep the sign-in box mounted while a sign-in is in flight', async () => {
+    // Tearing it down destroyed <app-inline-auth> on every failed attempt: the
+    // page flashed and took the "that password didn't work" message with it.
+    const fixture = TestBed.createComponent(App);
+    const app = fixture.componentInstance;
+
+    firebaseStateServiceMock.loginStatus!.set(LoginStatus.LoggingIn);
+    app.routingService.matchedPatternId.set(Views.Login);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('app-login')).not.toBeNull();
+  });
+
   it('should not redirect logged-out users on Home to login', async () => {
     const fixture = TestBed.createComponent(App);
     const app = fixture.componentInstance;

--- a/src/app/become-a-member/become-a-member.html
+++ b/src/app/become-a-member/become-a-member.html
@@ -291,10 +291,10 @@
       </div>
     </app-step-card>
 
-    <!-- Step 3: Choose Membership Option -->
+    <!-- Step 3: Choose a membership option and pay for it -->
     <app-step-card
       [number]="StepMembership"
-      title="Choose Membership Option"
+      title="Select and Purchase Membership"
       [state]="flow.stateOf(StepMembership)"
       [expanded]="flow.current() === StepMembership"
       (editRequested)="flow.goTo(StepMembership)"
@@ -432,67 +432,44 @@
           </div>
         }
 
-        <div class="step-footer">
+        <div class="step-footer checkout">
           @if (!membershipSelectionComplete()) {
             <p class="step-todo-hint">
               @if (isSpouseOptionSelected()) {
                 Your spouse's name, email and date of birth are needed before you
-                can continue.
+                can pay.
               } @else {
                 Choose a membership option to continue.
               }
             </p>
           }
-          <button
-            type="button"
-            class="next-btn"
-            [disabled]="!membershipSelectionComplete()"
-            (click)="continueFromMembershipStep()"
-          >
-            <span>Continue</span>
-            <app-icon name="arrow_forward"></app-icon>
-          </button>
-        </div>
-      }
-    </app-step-card>
 
-    <!-- Step 4: Checkout -->
-    <app-step-card
-      [number]="StepPayment"
-      title="Payment"
-      [state]="flow.stateOf(StepPayment)"
-      [expanded]="flow.current() === StepPayment"
-      [editable]="false"
-    >
-      @if (selectedOptionDetails(); as opt) {
-        <div class="payment-recap">
-          <div class="payment-recap-row">
-            <span class="payment-recap-label">{{ opt.title }}</span>
-            <span class="payment-recap-value">{{ formatPrice(opt.price) }}</span>
+          @if (checkoutError()) {
+            <div class="error-container">
+              <span class="error-message">{{ checkoutError() }}</span>
+              <button class="icon-only-button" (click)="checkoutError.set(null)">
+                <app-icon name="close"></app-icon>
+              </button>
+            </div>
+          }
+
+          <div class="checkout-actions">
+            @if (isRedirecting()) {
+              <app-spinner>Redirecting to secure Stripe Checkout…</app-spinner>
+            } @else {
+              <button
+                type="button"
+                class="pay-btn"
+                [disabled]="!membershipSelectionComplete()"
+                (click)="onProceedToPayment()"
+              >
+                <app-icon name="link"></app-icon>
+                <span>Proceed to Secure Payment</span>
+              </button>
+            }
           </div>
-          <p class="payment-recap-note">{{ opt.note }}</p>
         </div>
       }
-
-      @if (checkoutError()) {
-        <div class="error-container">
-          <span class="error-message">{{ checkoutError() }}</span>
-          <button class="icon-only-button" (click)="checkoutError.set(null)">
-            <app-icon name="close"></app-icon>
-          </button>
-        </div>
-      }
-
-      <div class="checkout-actions">
-        @if (isRedirecting()) {
-          <app-spinner>Redirecting to secure Stripe Checkout…</app-spinner>
-        } @else {
-          <button type="button" class="pay-btn" (click)="onProceedToPayment()">
-            <app-icon name="link"></app-icon>
-            <span>Proceed to Secure Payment</span>
-          </button>
-        }
-      </div>
     </app-step-card>
   }
 </div>

--- a/src/app/become-a-member/become-a-member.scss
+++ b/src/app/become-a-member/become-a-member.scss
@@ -143,42 +143,6 @@ app-step-track {
   }
 }
 
-.payment-recap {
-  padding: 1rem 1.25rem;
-  margin-bottom: 1.25rem;
-  background: v.$separator-color;
-  border: 1px solid v.$border-color-light;
-  border-left: 4px solid v.$primary-color;
-  border-radius: 6px;
-
-  .payment-recap-row {
-    display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    gap: 1rem;
-    flex-wrap: wrap;
-  }
-
-  .payment-recap-label {
-    font-size: 1.05rem;
-    font-weight: 600;
-    color: v.$text-primary;
-  }
-
-  .payment-recap-value {
-    font-size: 1.25rem;
-    font-weight: 700;
-    color: v.$text-primary;
-  }
-
-  .payment-recap-note {
-    margin: 0.4rem 0 0;
-    font-size: 0.9rem;
-    color: v.$text-secondary;
-    line-height: 1.45;
-  }
-}
-
 .account-welcome-note {
   margin: 1em 0 0;
   color: v.$text-muted;

--- a/src/app/become-a-member/become-a-member.spec.ts
+++ b/src/app/become-a-member/become-a-member.spec.ts
@@ -480,18 +480,6 @@ describe('BecomeAMemberComponent', () => {
     expect(component.flow.stateOf(component.StepAccount)).toBe('done');
     expect(component.flow.stateOf(component.StepDetails)).toBe('done');
     expect(component.flow.stateOf(component.StepMembership)).toBe('current');
-    expect(component.flow.stateOf(component.StepPayment)).toBe('todo');
-  });
-
-  it('should not send the user to pay for a membership they never confirmed', async () => {
-    await createComponent();
-    // The annual option is preselected and valid on its own...
-    expect(component.membershipSelectionComplete()).toBe(true);
-    // ...but the payment step stays out of reach until it is confirmed.
-    expect(component.flow.current()).toBe(component.StepMembership);
-
-    component.continueFromMembershipStep();
-    expect(component.flow.current()).toBe(component.StepPayment);
   });
 
   it('should reopen an earlier step on request and step forward again', async () => {
@@ -524,8 +512,7 @@ describe('BecomeAMemberComponent', () => {
 
   it('should pull the user back when an earlier step stops being complete', async () => {
     await createComponent();
-    component.continueFromMembershipStep();
-    expect(component.flow.current()).toBe(component.StepPayment);
+    expect(component.flow.current()).toBe(component.StepMembership);
 
     // Clearing a required field must not strand the user further along.
     component.name.set('');

--- a/src/app/become-a-member/become-a-member.ts
+++ b/src/app/become-a-member/become-a-member.ts
@@ -7,9 +7,9 @@
  *
  *  1. Account   — sign in, or create an account, to link the new membership.
  *  2. Details   — name, date of birth, country, phone, address.
- *  3. Membership— Annual vs Lifetime (with Senior & Under 21 rates) from Stripe.
- *  4. Payment   — redirect to Stripe Checkout, returning to the Home page with a
- *                 welcome notification on success.
+ *  3. Membership— Annual vs Lifetime (with Senior & Under 21 rates) from Stripe,
+ *                 then straight on to Stripe Checkout, returning to the Home
+ *                 page with a welcome notification on success.
  *
  * Members who already have a membership see their status banner instead, along
  * with cancel/resume auto-renewal.
@@ -206,7 +206,6 @@ export class BecomeAMemberComponent {
   readonly StepAccount = 1;
   readonly StepDetails = 2;
   readonly StepMembership = 3;
-  readonly StepPayment = 4;
 
   membershipSelectionComplete = computed(() => {
     if (!this.selectedPriceId()) return false;
@@ -218,29 +217,14 @@ export class BecomeAMemberComponent {
     );
   });
 
-  /**
-   * The annual option is preselected and immediately valid, so without an
-   * explicit Continue the membership step would be skipped and the user would
-   * be sent to pay for something they never chose.
-   */
-  private membershipStepAcknowledged = signal(false);
-
   flow = new StepFlow(
     computed(() => {
       if (!this.isLoggedIn()) return this.StepAccount;
       if (!this.hasCompletedBasicInfo()) return this.StepDetails;
-      if (!this.membershipSelectionComplete()) return this.StepMembership;
-      if (!this.membershipStepAcknowledged()) return this.StepMembership;
-      return this.StepPayment;
+      return this.StepMembership;
     }),
-    ['Account', 'Details', 'Membership', 'Payment'],
+    ['Account', 'Details', 'Membership'],
   );
-
-  /** "Continue" on the membership step: lock in the choice and go to payment. */
-  continueFromMembershipStep(): void {
-    this.membershipStepAcknowledged.set(true);
-    this.flow.resume();
-  }
 
   /** One-line recap of the signed-in account, shown when step 1 is collapsed. */
   accountSummary = computed(() => {

--- a/src/app/data-manager.service.ts
+++ b/src/app/data-manager.service.ts
@@ -977,17 +977,6 @@ export class DataManagerService {
       if (docSnap.exists()) {
         return { ...initEvent(), ...docSnap.data(), docId: docSnap.id } as IlcEvent;
       }
-
-      const q = query(
-        this.eventsCollection,
-        where('sourceId', '==', id)
-      );
-      const querySnap = await getDocs(q);
-
-      if (!querySnap.empty) {
-        const d = querySnap.docs[0];
-        return { ...initEvent(), ...d.data(), docId: d.id } as IlcEvent;
-      }
       return undefined;
     } catch (error) {
       console.error('Error getting event by ID:', error);

--- a/src/app/event-edit/event-edit.html
+++ b/src/app/event-edit/event-edit.html
@@ -596,12 +596,6 @@
             </div>
           }
 
-          @if (ev.sourceId) {
-            <label>Source ID</label>
-            <div class="rhs">
-              <span class="readonly-value timestamp">{{ ev.sourceId }}</span>
-            </div>
-          }
         }
       </div>
 

--- a/src/app/event-edit/event-edit.spec.ts
+++ b/src/app/event-edit/event-edit.spec.ts
@@ -6,7 +6,7 @@ import { FIREBASE_APP, AppPathPatterns, Views } from '../app.config';
 import { EventEditComponent } from './event-edit';
 import { FirebaseStateService, createFirebaseStateServiceMock } from '../firebase-state.service';
 import { DataManagerService } from '../data-manager.service';
-import { IlcEvent, EventStatus, EventSourceKind } from '../../../functions/src/data-model';
+import { IlcEvent, EventStatus } from '../../../functions/src/data-model';
 import { updateDoc } from 'firebase/firestore';
 import { SearchableSet } from '../searchable-set';
 import { provideNavigationTreeStub } from '../navigation-tree.testing';
@@ -129,7 +129,6 @@ describe('EventEditComponent', () => {
       expect.anything(),
       expect.objectContaining({
         heroImageUrl: 'http://example.com/image.jpg',
-        kind: EventSourceKind.FirebaseSourced
       })
     );
   });
@@ -565,7 +564,6 @@ describe('EventEditComponent', () => {
   it('does not render Kind or Doc ID fields at the bottom', async () => {
     await renderEvent({
       docId: 'test-doc-id',
-      kind: EventSourceKind.FirebaseSourced,
     });
 
     const labels = Array.from(fixture.nativeElement.querySelectorAll('label')).map(

--- a/src/app/event-edit/event-edit.ts
+++ b/src/app/event-edit/event-edit.ts
@@ -2,8 +2,8 @@
  *
  * Component for editing an event's details. Used by admins to edit
  * any event (both proposed and listed). Loads the event from Firestore
- * by docId or sourceId, then presents an edit form following the
- * same pattern as member-details.
+ * by docId, then presents an edit form following the same pattern as
+ * member-details.
  */
 
 import {
@@ -26,7 +26,7 @@ import {
   required,
   FieldTree,
 } from '@angular/forms/signals';
-import { IlcEvent, EventStatus, EventSourceKind, eventStatusLabel, initEvent, initEventContact, InstructorPublicData, Member, EventContact, EventDocument, School, UploadItem, UploadItemSource } from '../../../functions/src/data-model';
+import { IlcEvent, EventStatus, eventStatusLabel, initEvent, initEventContact, InstructorPublicData, Member, EventContact, EventDocument, School, UploadItem, UploadItemSource } from '../../../functions/src/data-model';
 import { IconComponent } from '../icons/icon.component';
 import { DataManagerService } from '../data-manager.service';
 import { SpinnerComponent } from '../spinner/spinner.component';
@@ -1230,7 +1230,6 @@ export class EventEditComponent implements OnInit {
         schoolId: formData.schoolId,
         schoolDocId: formData.schoolDocId,
         documents: formData.documents,
-        kind: EventSourceKind.FirebaseSourced,
         lastUpdated: new Date().toISOString(),
         updatedByEmail: this.firebaseState.user()?.firebaseUser.email || '',
       });
@@ -1251,7 +1250,6 @@ export class EventEditComponent implements OnInit {
         heroImageThumbUrl: formData.heroImageThumbUrl,
         heroImageOriginalUrl: formData.heroImageOriginalUrl,
         documents: formData.documents,
-        kind: EventSourceKind.FirebaseSourced,
         lastUpdated: new Date().toISOString(),
         updatedByEmail: this.firebaseState.user()?.firebaseUser.email || '',
       });

--- a/src/app/events-calendar/event-view/event-view.ts
+++ b/src/app/events-calendar/event-view/event-view.ts
@@ -1,7 +1,7 @@
 /* event-view.ts
  *
  * Component for viewing the full details of a single event.
- * Loads the event by sourceId or docId from the /events collection.
+ * Loads the event by docId from the /events collection.
  */
 
 import { Component, computed, inject, input, OnInit, output, signal } from '@angular/core';

--- a/src/app/inline-auth/auth-error-messages.ts
+++ b/src/app/inline-auth/auth-error-messages.ts
@@ -1,0 +1,120 @@
+/* auth-error-messages.ts
+ *
+ * Firebase auth error codes turned into something a member can act on.
+ *
+ * A raw code like `auth/invalid-credential` tells the user nothing, and the
+ * one thing that actually unblocks most sign-in failures — sending themselves
+ * a password reset link — is exactly what the code fails to suggest. So each
+ * message names what went wrong and, where a reset would fix it, says so; the
+ * caller pairs that with the reset action via `isPasswordResettable`.
+ *
+ * The code is kept in the fallback text on purpose: an unrecognised failure is
+ * something the user will report to us, and the code is what makes it
+ * diagnosable.
+ */
+
+/**
+ * Failures a password reset can actually fix.
+ *
+ * With email-enumeration protection enabled (as it is on this project) a wrong
+ * password, an unknown email and a password-less account all arrive as the
+ * single code `auth/invalid-credential`; the older, more specific codes are
+ * listed too because the setting can be turned off per project.
+ */
+const PASSWORD_RESETTABLE = new Set<string>([
+  'auth/invalid-credential',
+  'auth/invalid-login-credentials',
+  'auth/wrong-password',
+  'auth/user-not-found',
+  'auth/missing-password',
+  // Rate limiting is triggered by repeated wrong passwords, so the user who
+  // hits it is precisely the one who should stop guessing and reset instead.
+  'auth/too-many-requests',
+]);
+
+export function isPasswordResettable(code: string | undefined): boolean {
+  return !!code && PASSWORD_RESETTABLE.has(code);
+}
+
+/** A human explanation of a failed password sign-in. */
+export function signInErrorMessage(code: string | undefined): string {
+  switch (code) {
+    case 'auth/invalid-credential':
+    case 'auth/invalid-login-credentials':
+    case 'auth/wrong-password':
+    case 'auth/user-not-found':
+      return "That email and password don't match an account. If you're not sure of your password, send yourself a reset link below.";
+    case 'auth/missing-password':
+      return 'Please enter your password.';
+    case 'auth/invalid-email':
+      return "That doesn't look like a valid email address. Please check it and try again.";
+    case 'auth/user-disabled':
+      return 'This account has been disabled. Please contact us for help.';
+    case 'auth/too-many-requests':
+      return 'Too many sign-in attempts from this device. Please wait a few minutes, or send yourself a password reset link below.';
+    case 'auth/network-request-failed':
+      return 'We could not reach the server. Please check your connection and try again.';
+    case 'auth/operation-not-allowed':
+      return 'Password sign-in is not enabled for this account. Please try signing in with Google, or contact us for help.';
+    default:
+      return `Sign in failed (${code || 'unknown error'}). Please check your connection and try again.`;
+  }
+}
+
+/** A human explanation of a failed account creation. */
+export function signUpErrorMessage(code: string | undefined): string {
+  switch (code) {
+    case 'auth/email-already-in-use':
+      return 'An account already exists for this email. Please sign in with your password, or reset it below.';
+    case 'auth/weak-password':
+      return 'That password is too short. Please use at least 6 characters.';
+    case 'auth/invalid-email':
+      return "That doesn't look like a valid email address. Please check it and try again.";
+    case 'auth/too-many-requests':
+      return 'Too many attempts from this device. Please wait a few minutes and try again.';
+    case 'auth/network-request-failed':
+      return 'We could not reach the server. Please check your connection and try again.';
+    case 'auth/operation-not-allowed':
+      return 'Creating an account with a password is not available right now. Please try signing in with Google, or contact us for help.';
+    default:
+      return `Account creation failed (${code || 'unknown error'}). Please check your connection and try again.`;
+  }
+}
+
+/** A human explanation of a failed Google sign-in. */
+export function googleSignInErrorMessage(code: string | undefined): string {
+  switch (code) {
+    case 'auth/popup-blocked':
+      return 'Your browser blocked the Google sign-in window. Please allow pop-ups for this site and try again.';
+    case 'auth/popup-closed-by-user':
+      return 'The Google sign-in window was closed before sign-in finished. Please try again.';
+    case 'auth/account-exists-with-different-credential':
+      return 'An account already exists for this email with a different sign-in method. Please use a password instead.';
+    case 'auth/user-disabled':
+      return 'This account has been disabled. Please contact us for help.';
+    case 'auth/network-request-failed':
+      return 'We could not reach the server. Please check your connection and try again.';
+    case 'auth/operation-not-allowed':
+      return 'Google sign-in is not available right now. Please use a password instead.';
+    default:
+      return `Google sign-in failed (${code || 'unknown error'}). Please try again, or use a password instead.`;
+  }
+}
+
+/** A human explanation of a failed password reset request. */
+export function passwordResetErrorMessage(code: string | undefined): string {
+  switch (code) {
+    case 'auth/invalid-email':
+      return "That doesn't look like a valid email address. Please check it and try again.";
+    case 'auth/user-not-found':
+      // Only reachable with email-enumeration protection off; the wording
+      // still avoids confirming whether the address is registered.
+      return 'If an account exists for that email, a reset link is on its way. Please check your inbox and spam folder.';
+    case 'auth/too-many-requests':
+      return 'Too many reset requests from this device. Please wait a few minutes and try again.';
+    case 'auth/network-request-failed':
+      return 'We could not reach the server. Please check your connection and try again.';
+    default:
+      return `We could not send the reset link (${code || 'unknown error'}). Please try again in a moment.`;
+  }
+}

--- a/src/app/inline-auth/inline-auth.component.html
+++ b/src/app/inline-auth/inline-auth.component.html
@@ -13,6 +13,45 @@
   </button>
 </ng-template>
 
+<!-- The way out of a forgotten password, plus whatever the last reset attempt
+     had to say. Offered wherever a password is the obstacle: the sign-in step
+     always, and the create-account steps once we know the account exists. -->
+<ng-template #passwordResetOffer>
+  <p
+    class="help-text reset-password-offer"
+    [class.emphasised]="highlightPasswordReset()"
+  >
+    Forgotten your password?
+    <button
+      id="reset-password-btn"
+      class="inline-link-button"
+      [disabled]="resetPasswordSending()"
+      (click)="resetPassword()"
+    >
+      {{
+        resetPasswordSending() ? "Sending…" : "Email me a password reset link"
+      }}</button
+    >.
+  </p>
+  @if (resetPasswordSuccess(); as message) {
+    <div class="success-message">{{ message }}</div>
+  }
+  @if (resetPasswordError(); as message) {
+    <div class="error-container">
+      <span class="error-message">{{ message }}</span>
+    </div>
+  }
+</ng-template>
+
+<!-- Progress for an auth request in flight. It replaces only the messages and
+     the buttons of the current step, so the email and password the user typed
+     stay on screen and in place instead of the whole box blinking out. -->
+<ng-template #busySpinner>
+  <div class="spinner-row">
+    <app-spinner>{{ progressMessage() }}</app-spinner>
+  </div>
+</ng-template>
+
 @if (isLoggedIn()) {
   <div class="logged-in-box">
     <div class="user-info">
@@ -91,27 +130,26 @@
   </div>
 } @else {
   <div class="inline-auth-form">
-    @if (firebaseService.loginStatus() === LoginStatus.LoggingIn || authLoading()) {
-      <div class="spinner-row">
-        <app-spinner>{{ progressMessage() }}</app-spinner>
-      </div>
-    } @else {
-      @switch (step()) {
-        <!-- ──────────── STEP: ENTER EMAIL ──────────── -->
-        @case (InlineAuthStep.Email) {
-          <div class="input-field">
-            <label for="email-input">Login with Email:</label>
-            <input
-              id="email-input"
-              autocomplete="email"
-              type="email"
-              name="email"
-              [ngModel]="email()"
-              (ngModelChange)="email.set($event)"
-              (keyup.enter)="checkEmail()"
-              placeholder="you@example.com"
-            />
-          </div>
+    @switch (step()) {
+      <!-- ──────────── STEP: ENTER EMAIL ──────────── -->
+      @case (InlineAuthStep.Email) {
+        <div class="input-field">
+          <label for="email-input">Login with Email:</label>
+          <input
+            id="email-input"
+            autocomplete="email"
+            type="email"
+            name="email"
+            [ngModel]="email()"
+            (ngModelChange)="email.set($event)"
+            (keyup.enter)="checkEmail()"
+            [disabled]="busy()"
+            placeholder="you@example.com"
+          />
+        </div>
+        @if (busy()) {
+          <ng-container *ngTemplateOutlet="busySpinner"></ng-container>
+        } @else {
           @if (checkEmailError(); as message) {
             <div class="error-container">
               <span class="error-message">{{ message }}</span>
@@ -130,18 +168,22 @@
             </button>
           </div>
         }
+      }
 
-        <!-- ──────────── STEP: CHECKING ──────────── -->
-        @case (InlineAuthStep.Checking) {
-          <div class="checking-step">
-            <app-spinner>Checking your email…</app-spinner>
-          </div>
-        }
+      <!-- ──────────── STEP: CHECKING ──────────── -->
+      @case (InlineAuthStep.Checking) {
+        <div class="checking-step">
+          <app-spinner>Checking your email…</app-spinner>
+        </div>
+      }
 
-        <!-- ──────────── STEP: GOOGLE SIGN-IN ──────────── -->
-        @case (InlineAuthStep.GoogleSignin) {
-          <div class="google-signin-step">
-            <ng-container *ngTemplateOutlet="emailChip"></ng-container>
+      <!-- ──────────── STEP: GOOGLE SIGN-IN ──────────── -->
+      @case (InlineAuthStep.GoogleSignin) {
+        <div class="google-signin-step">
+          <ng-container *ngTemplateOutlet="emailChip"></ng-container>
+          @if (busy()) {
+            <ng-container *ngTemplateOutlet="busySpinner"></ng-container>
+          } @else {
             @if (loginWithGoogleError(); as message) {
               <div class="error-container">
                 <span class="error-message">{{ message }}</span>
@@ -169,39 +211,44 @@
                 {{ hasKnownAuthAccount() ? "Use a password" : "Set a password" }}
               </button>
             </div>
+          }
+        </div>
+      }
+
+      <!-- ──────────── STEP: PASSWORD LOGIN ──────────── -->
+      @case (InlineAuthStep.PasswordLogin) {
+        <ng-container *ngTemplateOutlet="emailChip"></ng-container>
+
+        <div class="input-field">
+          <label for="password-input">Password</label>
+          <div class="password-input-row">
+            <input
+              id="password-input"
+              autocomplete="current-password"
+              [type]="showPassword() ? 'text' : 'password'"
+              name="password"
+              [ngModel]="password()"
+              (ngModelChange)="password.set($event)"
+              (keyup.enter)="loginWithEmail()"
+              [disabled]="busy()"
+              placeholder="Password"
+            />
+            <button
+              class="icon-only-button"
+              type="button"
+              (click)="showPassword.set(!showPassword())"
+              [title]="showPassword() ? 'Hide password' : 'Show password'"
+            >
+              <app-icon
+                [name]="showPassword() ? 'visibility_off' : 'visibility'"
+              ></app-icon>
+            </button>
           </div>
-        }
+        </div>
 
-        <!-- ──────────── STEP: PASSWORD LOGIN ──────────── -->
-        @case (InlineAuthStep.PasswordLogin) {
-          <ng-container *ngTemplateOutlet="emailChip"></ng-container>
-
-          <div class="input-field">
-            <label for="password-input">Password</label>
-            <div class="password-input-row">
-              <input
-                id="password-input"
-                autocomplete="current-password"
-                [type]="showPassword() ? 'text' : 'password'"
-                name="password"
-                [ngModel]="password()"
-                (ngModelChange)="password.set($event)"
-                (keyup.enter)="loginWithEmail()"
-                placeholder="Password"
-              />
-              <button
-                class="icon-only-button"
-                type="button"
-                (click)="showPassword.set(!showPassword())"
-                [title]="showPassword() ? 'Hide password' : 'Show password'"
-              >
-                <app-icon
-                  [name]="showPassword() ? 'visibility_off' : 'visibility'"
-                ></app-icon>
-              </button>
-            </div>
-          </div>
-
+        @if (busy()) {
+          <ng-container *ngTemplateOutlet="busySpinner"></ng-container>
+        } @else {
           @if (loginError(); as message) {
             <div class="error-container">
               <span class="error-message">{{ message }}</span>
@@ -210,21 +257,7 @@
               </button>
             </div>
           }
-          @if (invalidLoginCredentials()) {
-            <p class="help-text">
-              That password didn't work. Would you like to
-              <button class="inline-link-button" (click)="resetPassword()">
-                reset your password</button>?
-            </p>
-          }
-          @if (resetPasswordSuccess(); as message) {
-            <div class="success-message">{{ message }}</div>
-          }
-          @if (resetPasswordError(); as message) {
-            <div class="error-container">
-              <span class="error-message">{{ message }}</span>
-            </div>
-          }
+          <ng-container *ngTemplateOutlet="passwordResetOffer"></ng-container>
 
           <div class="step-actions">
             <button
@@ -248,46 +281,51 @@
             }
           </div>
         }
+      }
 
-        <!-- ──────────── STEP: CREATE ACCOUNT ──────────── -->
-        @case (InlineAuthStep.CreateAccount) {
-          <ng-container *ngTemplateOutlet="emailChip"></ng-container>
+      <!-- ──────────── STEP: CREATE ACCOUNT ──────────── -->
+      @case (InlineAuthStep.CreateAccount) {
+        <ng-container *ngTemplateOutlet="emailChip"></ng-container>
 
-          <p class="step-guidance">
-            @if (emailStatus()?.hasMemberRecord) {
-              We found your membership record. Create a password to get started.
-            } @else {
-              Create a password to finish setting up your account (minimum 6
-              characters).
-            }
-          </p>
+        <p class="step-guidance">
+          @if (emailStatus()?.hasMemberRecord) {
+            We found your membership record. Create a password to get started.
+          } @else {
+            Create a password to finish setting up your account (minimum 6
+            characters).
+          }
+        </p>
 
-          <div class="input-field">
-            <label for="new-password-input">Password</label>
-            <div class="password-input-row">
-              <input
-                id="new-password-input"
-                autocomplete="new-password"
-                [type]="showPassword() ? 'text' : 'password'"
-                name="password"
-                [ngModel]="password()"
-                (ngModelChange)="password.set($event)"
-                (keyup.enter)="signupWithEmail()"
-                placeholder="Create a password (min. 6 characters)"
-              />
-              <button
-                class="icon-only-button"
-                type="button"
-                (click)="showPassword.set(!showPassword())"
-                [title]="showPassword() ? 'Hide password' : 'Show password'"
-              >
-                <app-icon
-                  [name]="showPassword() ? 'visibility_off' : 'visibility'"
-                ></app-icon>
-              </button>
-            </div>
+        <div class="input-field">
+          <label for="new-password-input">Password</label>
+          <div class="password-input-row">
+            <input
+              id="new-password-input"
+              autocomplete="new-password"
+              [type]="showPassword() ? 'text' : 'password'"
+              name="password"
+              [ngModel]="password()"
+              (ngModelChange)="password.set($event)"
+              (keyup.enter)="signupWithEmail()"
+              [disabled]="busy()"
+              placeholder="Create a password (min. 6 characters)"
+            />
+            <button
+              class="icon-only-button"
+              type="button"
+              (click)="showPassword.set(!showPassword())"
+              [title]="showPassword() ? 'Hide password' : 'Show password'"
+            >
+              <app-icon
+                [name]="showPassword() ? 'visibility_off' : 'visibility'"
+              ></app-icon>
+            </button>
           </div>
+        </div>
 
+        @if (busy()) {
+          <ng-container *ngTemplateOutlet="busySpinner"></ng-container>
+        } @else {
           @if (signupError(); as message) {
             <div class="error-container">
               <span class="error-message">{{ message }}</span>
@@ -295,6 +333,18 @@
                 <app-icon name="close"></app-icon>
               </button>
             </div>
+          }
+          <!-- "An account already exists" is only useful next to the two ways
+               of getting into it. -->
+          @if (signupFoundExistingAccount()) {
+            <button
+              type="button"
+              class="secondary-action"
+              (click)="signInInstead()"
+            >
+              Sign in with your password
+            </button>
+            <ng-container *ngTemplateOutlet="passwordResetOffer"></ng-container>
           }
 
           <div class="step-actions">
@@ -307,41 +357,46 @@
             </button>
           </div>
         }
+      }
 
-        <!-- ──────────── STEP: GUEST CREATE ACCOUNT ──────────── -->
-        @case (InlineAuthStep.GuestCreateAccount) {
-          <ng-container *ngTemplateOutlet="emailChip"></ng-container>
+      <!-- ──────────── STEP: GUEST CREATE ACCOUNT ──────────── -->
+      @case (InlineAuthStep.GuestCreateAccount) {
+        <ng-container *ngTemplateOutlet="emailChip"></ng-container>
 
-          <p class="step-guidance">
-            You are creating an account without a linked membership.
-          </p>
+        <p class="step-guidance">
+          You are creating an account without a linked membership.
+        </p>
 
-          <div class="input-field">
-            <label for="guest-password-input">Password</label>
-            <div class="password-input-row">
-              <input
-                id="guest-password-input"
-                autocomplete="new-password"
-                [type]="showPassword() ? 'text' : 'password'"
-                name="password"
-                [ngModel]="password()"
-                (ngModelChange)="password.set($event)"
-                (keyup.enter)="signupWithEmail()"
-                placeholder="Create a password (min. 6 characters)"
-              />
-              <button
-                class="icon-only-button"
-                type="button"
-                (click)="showPassword.set(!showPassword())"
-                [title]="showPassword() ? 'Hide password' : 'Show password'"
-              >
-                <app-icon
-                  [name]="showPassword() ? 'visibility_off' : 'visibility'"
-                ></app-icon>
-              </button>
-            </div>
+        <div class="input-field">
+          <label for="guest-password-input">Password</label>
+          <div class="password-input-row">
+            <input
+              id="guest-password-input"
+              autocomplete="new-password"
+              [type]="showPassword() ? 'text' : 'password'"
+              name="password"
+              [ngModel]="password()"
+              (ngModelChange)="password.set($event)"
+              (keyup.enter)="signupWithEmail()"
+              [disabled]="busy()"
+              placeholder="Create a password (min. 6 characters)"
+            />
+            <button
+              class="icon-only-button"
+              type="button"
+              (click)="showPassword.set(!showPassword())"
+              [title]="showPassword() ? 'Hide password' : 'Show password'"
+            >
+              <app-icon
+                [name]="showPassword() ? 'visibility_off' : 'visibility'"
+              ></app-icon>
+            </button>
           </div>
+        </div>
 
+        @if (busy()) {
+          <ng-container *ngTemplateOutlet="busySpinner"></ng-container>
+        } @else {
           @if (signupError(); as message) {
             <div class="error-container">
               <span class="error-message">{{ message }}</span>
@@ -349,6 +404,18 @@
                 <app-icon name="close"></app-icon>
               </button>
             </div>
+          }
+          <!-- "An account already exists" is only useful next to the two ways
+               of getting into it. -->
+          @if (signupFoundExistingAccount()) {
+            <button
+              type="button"
+              class="secondary-action"
+              (click)="signInInstead()"
+            >
+              Sign in with your password
+            </button>
+            <ng-container *ngTemplateOutlet="passwordResetOffer"></ng-container>
           }
 
           <div class="step-actions">
@@ -361,43 +428,43 @@
             </button>
           </div>
         }
+      }
 
-        <!-- ──────────── STEP: NO MEMBER RECORD ──────────── -->
-        @case (InlineAuthStep.NoMember) {
-          <ng-container *ngTemplateOutlet="emailChip"></ng-container>
+      <!-- ──────────── STEP: NO MEMBER RECORD ──────────── -->
+      @case (InlineAuthStep.NoMember) {
+        <ng-container *ngTemplateOutlet="emailChip"></ng-container>
 
-          <div class="step-guidance">
-            <p>We don't have a membership record linked to this email.</p>
-            <p>
-              This could mean you used a different email address when
-              registering, or your membership hasn't been set up yet.
-            </p>
-          </div>
-          <div class="step-actions">
-            <button
-              id="become-member-btn"
-              (click)="routingService.navigateToParts(['become-a-member'])"
-            >
-              Become a Member
-            </button>
-            <button
-              id="create-guest-account-btn"
-              class="secondary-action"
-              (click)="step.set(InlineAuthStep.GuestCreateAccount)"
-            >
-              Create account without membership
-            </button>
-          </div>
-          <!-- After the actions: this is the path for someone who believes
-               they are already a member, not the expected next step. -->
-          <p class="step-guidance step-footnote">
-            If you think you already have an account, you can try another email,
-            or contact
-            <a [href]="'mailto:' + adminEmail">{{ adminEmail }}</a>
-            for help. To help us verify your past membership, please include a
-            picture of your passbook.
+        <div class="step-guidance">
+          <p>We don't have a membership record linked to this email.</p>
+          <p>
+            This could mean you used a different email address when
+            registering, or your membership hasn't been set up yet.
           </p>
-        }
+        </div>
+        <div class="step-actions">
+          <button
+            id="become-member-btn"
+            (click)="routingService.navigateToParts(['become-a-member'])"
+          >
+            Become a Member
+          </button>
+          <button
+            id="create-guest-account-btn"
+            class="secondary-action"
+            (click)="step.set(InlineAuthStep.GuestCreateAccount)"
+          >
+            Create account without membership
+          </button>
+        </div>
+        <!-- After the actions: this is the path for someone who believes
+             they are already a member, not the expected next step. -->
+        <p class="step-guidance step-footnote">
+          If you think you already have an account, you can try another email,
+          or contact
+          <a [href]="'mailto:' + adminEmail">{{ adminEmail }}</a>
+          for help. To help us verify your past membership, please include a
+          picture of your passbook.
+        </p>
       }
     }
 

--- a/src/app/inline-auth/inline-auth.component.scss
+++ b/src/app/inline-auth/inline-auth.component.scss
@@ -256,6 +256,16 @@
   margin: 0;
 }
 
+// The standing "forgotten your password?" offer. It is quiet until the sign-in
+// actually failed for a reason a reset would fix, at which point it becomes the
+// obvious next step rather than one more line of grey help text.
+.reset-password-offer {
+  &.emphasised {
+    color: $text-primary;
+    font-weight: 600;
+  }
+}
+
 .success-message {
   color: #2e7d32;
   background-color: #e8f5e9;

--- a/src/app/inline-auth/inline-auth.component.spec.ts
+++ b/src/app/inline-auth/inline-auth.component.spec.ts
@@ -389,7 +389,7 @@ describe('InlineAuthComponent', () => {
       await component.loginWithEmail();
 
       expect(readRemembered()).toBeNull();
-      expect(component.invalidLoginCredentials()).toBe(true);
+      expect(component.highlightPasswordReset()).toBe(true);
     });
 
     it('should remember a successful password sign-in', async () => {
@@ -730,6 +730,32 @@ describe('InlineAuthComponent', () => {
       expect(text).toContain('Signing in…');
     });
 
+    it('should keep the typed password on screen while signing in', async () => {
+      // The spinner replaces the messages and buttons of the step, not the
+      // step itself: a page that blinks out mid-sign-in loses the user's place
+      // and, when it comes back, whatever the attempt had to say.
+      remember({ email: 'jane@example.com', method: 'password' });
+      await createComponent();
+      component.password.set('correct-horse');
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const held = suspend('loginWithEmail');
+      const inFlight = component.loginWithEmail();
+      fixture.detectChanges();
+      // NgModel applies a disabled binding in a microtask.
+      await Promise.resolve();
+
+      const field = html().querySelector<HTMLInputElement>('#password-input');
+      expect(field).not.toBeNull();
+      expect(field!.value).toBe('correct-horse');
+      expect(field!.disabled).toBe(true);
+      // ...while the action it replaced is gone for the duration.
+      expect(html().querySelector('#login-btn')).toBeNull();
+
+      await held.finish(inFlight);
+    });
+
     it('should name Google while its popup is open', async () => {
       remember({ email: 'jane@gmail.com', method: 'google', canUseGoogle: true });
       await createComponent();
@@ -776,7 +802,7 @@ describe('InlineAuthComponent', () => {
   //  Errors surfaced to the user
   // ---------------------------------------------------------------------------
   describe('error handling', () => {
-    it('should offer a password reset after a rejected password', async () => {
+    it('should explain a rejected password and point at the reset link', async () => {
       vi.spyOn(mockService, 'loginWithEmail').mockResolvedValue({
         success: false,
         errorCode: AuthErrorCodes.INVALID_LOGIN_CREDENTIALS,
@@ -786,11 +812,41 @@ describe('InlineAuthComponent', () => {
       component.password.set('nope');
       await component.loginWithEmail();
 
-      expect(component.invalidLoginCredentials()).toBe(true);
-      expect(component.loginError()).toBeNull();
+      // The raw code says nothing to a member; the message must.
+      expect(component.loginError()).toContain("don't match an account");
+      expect(component.loginError()).not.toContain('auth/');
+      expect(component.highlightPasswordReset()).toBe(true);
     });
 
-    it('should report other sign-in failures verbatim', async () => {
+    it('should send a rate-limited user to the reset link too', async () => {
+      vi.spyOn(mockService, 'loginWithEmail').mockResolvedValue({
+        success: false,
+        errorCode: 'auth/too-many-requests',
+      });
+      await createComponent();
+      component.email.set('jane@example.com');
+      component.password.set('nope');
+      await component.loginWithEmail();
+
+      expect(component.loginError()).toContain('Too many sign-in attempts');
+      expect(component.highlightPasswordReset()).toBe(true);
+    });
+
+    it('should offer the reset link even before a failed attempt', async () => {
+      vi.spyOn(mockService, 'checkEmailStatus').mockResolvedValue(
+        status({ hasAuthAccount: true, hasPasswordProvider: true }),
+      );
+      await createComponent();
+      component.email.set('jane@example.com');
+      await component.checkEmail();
+      fixture.detectChanges();
+
+      expect(component.step()).toBe(InlineAuthStep.PasswordLogin);
+      expect(html().querySelector('#reset-password-btn')).not.toBeNull();
+      expect(component.highlightPasswordReset()).toBe(false);
+    });
+
+    it('should explain failures a reset cannot fix, without offering one', async () => {
       vi.spyOn(mockService, 'loginWithEmail').mockResolvedValue({
         success: false,
         errorCode: 'auth/network-request-failed',
@@ -800,8 +856,8 @@ describe('InlineAuthComponent', () => {
       component.password.set('whatever');
       await component.loginWithEmail();
 
-      expect(component.loginError()).toContain('auth/network-request-failed');
-      expect(component.invalidLoginCredentials()).toBe(false);
+      expect(component.loginError()).toContain('could not reach the server');
+      expect(component.highlightPasswordReset()).toBe(false);
     });
 
     it('should point an existing account at signing in instead', async () => {
@@ -815,6 +871,12 @@ describe('InlineAuthComponent', () => {
       await component.signupWithEmail();
 
       expect(component.signupError()).toContain('An account already exists');
+      expect(component.signupFoundExistingAccount()).toBe(true);
+
+      // ...and the way there keeps the password already typed.
+      component.signInInstead();
+      expect(component.step()).toBe(InlineAuthStep.PasswordLogin);
+      expect(component.password()).toBe('abcdef');
     });
 
     it('should confirm where a reset link was sent', async () => {

--- a/src/app/inline-auth/inline-auth.component.ts
+++ b/src/app/inline-auth/inline-auth.component.ts
@@ -21,7 +21,13 @@ import { Component, OnInit, computed, inject, input, signal } from '@angular/cor
 import { NgTemplateOutlet } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { FirebaseStateService, LoginStatus } from '../firebase-state.service';
-import { AuthErrorCodes } from 'firebase/auth';
+import {
+  googleSignInErrorMessage,
+  isPasswordResettable,
+  passwordResetErrorMessage,
+  signInErrorMessage,
+  signUpErrorMessage,
+} from './auth-error-messages';
 import { IconComponent } from '../icons/icon.component';
 import { SpinnerComponent } from '../spinner/spinner.component';
 import { environment } from '../../environments/environment';
@@ -162,6 +168,18 @@ export class InlineAuthComponent implements OnInit {
    */
   private pendingAuth = signal<{ creating: boolean; google: boolean } | null>(null);
 
+  /**
+   * Whether an auth request is in flight — ours, or a session the service is
+   * restoring. Only the messages and buttons of the current step give way to
+   * the spinner: what the user typed stays on screen, and the component itself
+   * is never torn down, so an error has somewhere to land afterwards.
+   */
+  busy = computed(
+    () =>
+      this.firebaseService.loginStatus() === LoginStatus.LoggingIn ||
+      this.authLoading(),
+  );
+
   progressMessage = computed(() => {
     const pending = this.pendingAuth();
     // No pending action of ours: the session is being restored on load.
@@ -177,12 +195,25 @@ export class InlineAuthComponent implements OnInit {
   // Error & message signals
   checkEmailError = signal<string | null>(null);
   loginError = signal<string | null>(null);
-  invalidLoginCredentials = signal<boolean>(false);
   loginWithGoogleError = signal<string | null>(null);
   signupError = signal<string | null>(null);
   resetPasswordError = signal<string | null>(null);
   resetPasswordSuccess = signal<string | null>(null);
   resendSuccess = signal<string | null>(null);
+  /** True while a reset email is being requested, so the link can say so. */
+  resetPasswordSending = signal<boolean>(false);
+  /**
+   * Whether the failure the user just hit is one a password reset would fix.
+   * The reset link is always on the password step; this only draws the eye to
+   * it when it is the actual next step.
+   */
+  highlightPasswordReset = signal<boolean>(false);
+  /**
+   * Set when account creation reported that the account already exists — a
+   * lookup that said otherwise is out of date, and the user needs signing in,
+   * not signing up.
+   */
+  signupFoundExistingAccount = signal<boolean>(false);
 
   /**
    * Whether an auth account is known to exist: either a lookup said so, or the
@@ -242,6 +273,7 @@ export class InlineAuthComponent implements OnInit {
 
     this.dismissMessages();
     // A fresh lookup supersedes anything remembered from a previous visit.
+    this.signupFoundExistingAccount.set(false);
     this.remembered.set(null);
     this.emailStatus.set(null);
     this.step.set(InlineAuthStep.Checking);
@@ -306,7 +338,7 @@ export class InlineAuthComponent implements OnInit {
       if (result.success) {
         this.rememberSuccessfulLogin('google');
       } else if (result.errorCode !== 'auth/cancelled-popup-request') {
-        this.loginWithGoogleError.set(result.errorCode);
+        this.loginWithGoogleError.set(googleSignInErrorMessage(result.errorCode));
       }
     } finally {
       this.authLoading.set(false);
@@ -326,12 +358,11 @@ export class InlineAuthComponent implements OnInit {
       const result = await this.firebaseService.loginWithEmail(passVal, emailVal);
       if (result.success) {
         this.rememberSuccessfulLogin('password');
-      } else if (result.errorCode === AuthErrorCodes.INVALID_LOGIN_CREDENTIALS) {
-        this.invalidLoginCredentials.set(true);
       } else {
-        this.loginError.set(
-          `${result.errorCode}: please check your connection and credentials.`,
-        );
+        this.loginError.set(signInErrorMessage(result.errorCode));
+        // A rejected password is the common case, and the reset link below is
+        // the way out of it; make it unmissable rather than merely present.
+        this.highlightPasswordReset.set(isPasswordResettable(result.errorCode));
       }
     } finally {
       this.authLoading.set(false);
@@ -351,12 +382,11 @@ export class InlineAuthComponent implements OnInit {
       const result = await this.firebaseService.signupWithEmail(passVal, emailVal);
       if (result.success) {
         this.rememberSuccessfulLogin('password');
-      } else if (result.errorCode === 'auth/email-already-in-use') {
-        this.signupError.set(
-          'An account already exists for this email. Please sign in with your password, or reset it below.',
-        );
       } else {
-        this.signupError.set(result.errorCode);
+        this.signupError.set(signUpErrorMessage(result.errorCode));
+        this.signupFoundExistingAccount.set(
+          result.errorCode === 'auth/email-already-in-use',
+        );
       }
     } finally {
       this.authLoading.set(false);
@@ -371,14 +401,33 @@ export class InlineAuthComponent implements OnInit {
       this.resetPasswordError.set('Please enter your email address.');
       return;
     }
-    const result = await this.firebaseService.resetPassword(emailVal);
-    if (result.success) {
-      this.resetPasswordSuccess.set(
-        `A password reset link has been sent to ${emailVal} from ${environment.passwordResetEmailSender}.`,
-      );
-    } else {
-      this.resetPasswordError.set(result.errorMessage);
+    this.resetPasswordSending.set(true);
+    try {
+      const result = await this.firebaseService.resetPassword(emailVal);
+      if (result.success) {
+        this.resetPasswordSuccess.set(
+          `A password reset link has been sent to ${emailVal} from ` +
+          `${environment.passwordResetEmailSender}. It can take a minute to ` +
+          `arrive — please check your spam folder too.`,
+        );
+      } else {
+        this.resetPasswordError.set(passwordResetErrorMessage(result.errorMessage));
+      }
+    } finally {
+      this.resetPasswordSending.set(false);
     }
+  }
+
+  /**
+   * Go to the password step after account creation found an existing account.
+   * Unlike `usePasswordInstead` this does not consult the email lookup, which
+   * we now know was out of date, and it keeps the typed password: it may well
+   * be the account's real one.
+   */
+  signInInstead(): void {
+    this.dismissMessages();
+    this.signupFoundExistingAccount.set(false);
+    this.step.set(InlineAuthStep.PasswordLogin);
   }
 
   usePasswordInstead(): void {
@@ -402,6 +451,7 @@ export class InlineAuthComponent implements OnInit {
   goBackToEmail(): void {
     this.password.set('');
     this.emailStatus.set(null);
+    this.signupFoundExistingAccount.set(false);
     this.remembered.set(null);
     this.signInFlow.clear();
     this.step.set(InlineAuthStep.Email);
@@ -415,6 +465,7 @@ export class InlineAuthComponent implements OnInit {
     this.email.set('');
     this.password.set('');
     this.emailStatus.set(null);
+    this.signupFoundExistingAccount.set(false);
     this.remembered.set(null);
     this.signInFlow.clear();
     this.step.set(InlineAuthStep.Email);
@@ -450,7 +501,7 @@ export class InlineAuthComponent implements OnInit {
   dismissMessages(): void {
     this.checkEmailError.set(null);
     this.loginError.set(null);
-    this.invalidLoginCredentials.set(false);
+    this.highlightPasswordReset.set(false);
     this.loginWithGoogleError.set(null);
     this.signupError.set(null);
     this.resetPasswordError.set(null);

--- a/src/app/instructor-license-purchase/instructor-license-purchase.html
+++ b/src/app/instructor-license-purchase/instructor-license-purchase.html
@@ -285,7 +285,7 @@
     <!-- Step 2: Instructor / Group Leader Qualifications & Status -->
     <app-step-card
       [number]="StepEligibility"
-      title="License Qualifications & Status"
+      title="License Qualifications &amp; Purchase"
       [state]="flow.stateOf(StepEligibility)"
       [expanded]="flow.current() === StepEligibility"
       (editRequested)="flow.goTo(StepEligibility)"
@@ -399,90 +399,67 @@
       }
 
       @if (isLoggedIn() && isActiveMember() && isEligibleForLicense()) {
-        <div class="step-footer">
-          <button
-            type="button"
-            class="next-btn"
-            (click)="continueFromEligibilityStep()"
-          >
-            <span>Continue</span>
-            <app-icon name="arrow_forward"></app-icon>
-          </button>
+        <div class="step-footer checkout">
+          @if (productsLoading()) {
+            <app-spinner>Loading license rates...</app-spinner>
+          } @else if (productsError()) {
+            <div class="error-container">
+              <span class="error-message">{{ productsError() }}</span>
+              <button class="icon-only-button" (click)="loadProducts()">
+                <app-icon name="refresh"></app-icon>
+              </button>
+            </div>
+          } @else if (selectedPrice(); as price) {
+            <div class="membership-options-grid">
+              <div class="option-card selected">
+                <div class="option-title">{{ productOptionTitle() }}</div>
+                <div class="rate-price">
+                  {{ formatPrice(price.unitAmount, price.currency) }} / year
+                </div>
+                <div class="rate-desc">
+                  {{ productOptionDescription() }}
+                </div>
+              </div>
+            </div>
+
+            <div class="checkout-section">
+              @if (checkoutError()) {
+                <div class="error-container">
+                  <span class="error-message">{{ checkoutError() }}</span>
+                  <button
+                    class="icon-only-button"
+                    (click)="checkoutError.set(null)"
+                  >
+                    <app-icon name="close"></app-icon>
+                  </button>
+                </div>
+              }
+
+              <div class="checkout-actions">
+                @if (isRedirecting()) {
+                  <app-spinner>Redirecting to secure Stripe Checkout…</app-spinner>
+                } @else {
+                  <button
+                    type="button"
+                    class="button pay-btn"
+                    (click)="onPurchaseInstructorLicense()"
+                  >
+                    <span>{{ checkoutButtonText() }}</span>
+                    <app-icon name="arrow_forward"></app-icon>
+                  </button>
+                }
+              </div>
+            </div>
+          } @else {
+            <div class="empty-notice">
+              <p>
+                License rates are currently being configured. Please check back
+                shortly.
+              </p>
+            </div>
+          }
         </div>
       }
-    </app-step-card>
-
-    <!-- Step 3: Annual License Fee & Checkout -->
-    <app-step-card
-      [number]="StepPayment"
-      [title]="
-        'Annual ' +
-        (isGroupLeaderTier() ? 'Group Leader' : 'Instructor') +
-        ' License'
-      "
-      [state]="flow.stateOf(StepPayment)"
-      [expanded]="flow.current() === StepPayment"
-      [editable]="false"
-    >
-
-        @if (productsLoading()) {
-          <app-spinner>Loading license rates...</app-spinner>
-        } @else if (productsError()) {
-          <div class="error-container">
-            <span class="error-message">{{ productsError() }}</span>
-            <button class="icon-only-button" (click)="loadProducts()">
-              <app-icon name="refresh"></app-icon>
-            </button>
-          </div>
-        } @else if (selectedPrice(); as price) {
-          <div class="membership-options-grid">
-            <div class="option-card selected">
-              <div class="option-title">{{ productOptionTitle() }}</div>
-              <div class="rate-price">
-                {{ formatPrice(price.unitAmount, price.currency) }} / year
-              </div>
-              <div class="rate-desc">
-                {{ productOptionDescription() }}
-              </div>
-            </div>
-          </div>
-
-          <div class="checkout-section">
-            @if (checkoutError()) {
-              <div class="error-container">
-                <span class="error-message">{{ checkoutError() }}</span>
-                <button
-                  class="icon-only-button"
-                  (click)="checkoutError.set(null)"
-                >
-                  <app-icon name="close"></app-icon>
-                </button>
-              </div>
-            }
-
-            <div class="checkout-actions">
-              @if (isRedirecting()) {
-                <app-spinner>Redirecting to secure Stripe Checkout…</app-spinner>
-              } @else {
-                <button
-                  type="button"
-                  class="button pay-btn"
-                  (click)="onPurchaseInstructorLicense()"
-                >
-                  <span>{{ checkoutButtonText() }}</span>
-                  <app-icon name="arrow_forward"></app-icon>
-                </button>
-              }
-            </div>
-          </div>
-        } @else {
-          <div class="empty-notice">
-            <p>
-              License rates are currently being configured. Please check back
-              shortly.
-            </p>
-          </div>
-        }
     </app-step-card>
   }
 </div>

--- a/src/app/instructor-license-purchase/instructor-license-purchase.scss
+++ b/src/app/instructor-license-purchase/instructor-license-purchase.scss
@@ -343,8 +343,6 @@ app-step-track {
 
 .checkout-section {
   margin-top: 1rem;
-  border-top: 1px solid v.$separator-color;
-  padding-top: 1.25rem;
 }
 
 .checkout-actions {

--- a/src/app/instructor-license-purchase/instructor-license-purchase.ts
+++ b/src/app/instructor-license-purchase/instructor-license-purchase.ts
@@ -88,29 +88,17 @@ export class InstructorLicensePurchaseComponent {
   isLoggedIn = computed(() => !!this.user());
 
   // ── Guided flow. See step-flow.ts. Step 2 shows the licence status the user
-  //    should read before paying, so it waits for an explicit Continue. ──
+  //    should read, and the fee and payment button for it. ──
   readonly StepAccount = 1;
   readonly StepEligibility = 2;
-  readonly StepPayment = 3;
-
-  private eligibilityStepAcknowledged = signal(false);
 
   flow = new StepFlow(
     computed(() => {
       if (!this.isLoggedIn()) return this.StepAccount;
-      if (!this.isActiveMember()) return this.StepEligibility;
-      if (!this.isEligibleForLicense()) return this.StepEligibility;
-      if (!this.eligibilityStepAcknowledged()) return this.StepEligibility;
-      return this.StepPayment;
+      return this.StepEligibility;
     }),
-    ['Account', 'Eligibility', 'Payment'],
+    ['Account', 'Eligibility'],
   );
-
-  /** "Continue" on step 2: the user has read their status, move on to payment. */
-  continueFromEligibilityStep(): void {
-    this.eligibilityStepAcknowledged.set(true);
-    this.flow.resume();
-  }
 
   accountSummary = computed(() => {
     const u = this.user();

--- a/src/app/manage-events/manage-events.html
+++ b/src/app/manage-events/manage-events.html
@@ -131,7 +131,7 @@
     </div>
   } @else {
     <div class="event-cards">
-      @for (ev of eventsList; track ev.docId || ev.sourceId) {
+      @for (ev of eventsList; track ev.docId) {
         <a class="event-management-card event-card-link selectable-card" [href]="editLink(ev)" (click)="onCardClick($event)">
           <div class="event-card-header">
             <span class="event-status-chip" [class]="'event-status-chip status-' + ev.status">{{ statusLabel(ev) }}</span>
@@ -153,9 +153,6 @@
             }
           </div>
           <app-event-item [event]="ev" />
-          @if (ev.kind) {
-            <div class="kind-label">{{ ev.kind }}</div>
-          }
         </a>
       }
 

--- a/src/app/manage-events/manage-events.scss
+++ b/src/app/manage-events/manage-events.scss
@@ -206,14 +206,6 @@
 // Event status chip styles are now defined globally in styles.scss.
 // See: .event-status-chip and .status-proposed / .status-listed / etc.
 
-.kind-label {
-  font-size: 0.75em;
-  color: #999;
-  text-align: right;
-  padding-right: 0.5em;
-  padding-bottom: 0.25em;
-}
-
 .event-cards {
   display: flex;
   flex-direction: column;

--- a/src/app/manage-events/manage-events.ts
+++ b/src/app/manage-events/manage-events.ts
@@ -28,7 +28,7 @@ import {
   updateDoc,
 } from 'firebase/firestore';
 import { FIREBASE_APP, Views } from '../app.config';
-import { IlcEvent, EventStatus, eventStatusLabel, EventSourceKind, initEvent } from '../../../functions/src/data-model';
+import { IlcEvent, EventStatus, eventStatusLabel, initEvent } from '../../../functions/src/data-model';
 import { IconComponent } from '../icons/icon.component';
 import { SpinnerComponent } from '../spinner/spinner.component';
 import { RoutingService } from '../routing.service';
@@ -315,8 +315,7 @@ export class ManageEventsComponent implements OnDestroy {
   // Stays inside the manage-events subtree, so the breadcrumbs and back link on
   // the editor lead back here rather than into the public events pages.
   editLink(event: IlcEvent): string {
-    const id = event.docId || event.sourceId || '';
-    return `/manage-events/${id}/edit`;
+    return `/manage-events/${event.docId}/edit`;
   }
 
   // Resolve the event creator to a "Name (MemberId)" chip label.

--- a/src/app/next-grading/next-grading.html
+++ b/src/app/next-grading/next-grading.html
@@ -126,10 +126,10 @@
     }
   </app-step-card>
 
-  <!-- Step 2: Progression & Eligibility -->
+  <!-- Step 2: Progression, eligibility, and the grading fee -->
   <app-step-card
     [number]="StepLevel"
-    title="Next Grading Level"
+    title="Select and Purchase Grading"
     [state]="flow.stateOf(StepLevel)"
     [expanded]="flow.current() === StepLevel"
     (editRequested)="flow.goTo(StepLevel)"
@@ -203,23 +203,6 @@
               You previously did not pass your <strong>{{ retakeEligibleLevel() }}</strong> grading.
               You can retake this grading examination without having to repay the headquarters registration fee.
             </p>
-            @if (retakeError()) {
-              <div class="error-container">
-                <span class="error-message">{{ retakeError() }}</span>
-              </div>
-            }
-            @if (isCreatingRetake()) {
-              <app-spinner>Creating your retake grading record...</app-spinner>
-            } @else {
-              <button
-                type="button"
-                class="button retake-action-btn"
-                (click)="onStartRetake()"
-              >
-                <app-icon name="refresh"></app-icon>
-                <span>Start Free Retake for {{ retakeEligibleLevel() }}</span>
-              </button>
-            }
           </div>
         </div>
       }
@@ -268,117 +251,100 @@
         </div>
       }
 
-      <div class="step-footer">
-        @if (!targetLevel()) {
+      <div class="step-footer checkout">
+        @if (retakeEligible() && !buyingAdvanceLevel()) {
+          <div class="retake-fee-notice">
+            <app-icon name="check" width="24px" height="24px" fill="#155724"></app-icon>
+            <div>
+              <h3>No Headquarters Fee Required</h3>
+              <p>
+                Because you are retaking <strong>{{ retakeEligibleLevel() }}</strong>, no headquarters grading registration fee is required.
+              </p>
+              @if (retakeError()) {
+                <div class="error-container">
+                  <span class="error-message">{{ retakeError() }}</span>
+                </div>
+              }
+              @if (isCreatingRetake()) {
+                <app-spinner>Creating your retake grading...</app-spinner>
+              } @else {
+                <button
+                  type="button"
+                  class="button pay-btn"
+                  (click)="onStartRetake()"
+                >
+                  <span>Start Free Retake for {{ retakeEligibleLevel() }}</span>
+                  <app-icon name="arrow_forward"></app-icon>
+                </button>
+              }
+            </div>
+          </div>
+        } @else if (!targetLevel()) {
           <p class="step-todo-hint">
             You have reached the highest level, so there is no grading to
             purchase.
           </p>
-        }
-        <button
-          type="button"
-          class="next-btn"
-          [disabled]="!targetLevel()"
-          (click)="continueFromLevelStep()"
-        >
-          <span>Continue</span>
-          <app-icon name="arrow_forward"></app-icon>
-        </button>
-      </div>
-    }
-  </app-step-card>
-
-  <!-- Step 3: Grading Fee & Purchase Action -->
-  <app-step-card
-    [number]="StepPayment"
-    title="HQ Grading Fee"
-    [state]="flow.stateOf(StepPayment)"
-    [expanded]="flow.current() === StepPayment"
-    [editable]="false"
-  >
-    @if (retakeEligible() && !buyingAdvanceLevel()) {
-      <div class="retake-fee-notice">
-        <app-icon name="check" width="24px" height="24px" fill="#155724"></app-icon>
-        <div>
-          <h3>No Headquarters Fee Required</h3>
-          <p>
-            Because you are retaking <strong>{{ retakeEligibleLevel() }}</strong>, no headquarters grading registration fee is required.
-          </p>
-          @if (isCreatingRetake()) {
-            <app-spinner>Creating your retake grading...</app-spinner>
-          } @else {
-            <button
-              type="button"
-              class="button pay-btn"
-              (click)="onStartRetake()"
-            >
-              <span>Start Free Retake for {{ retakeEligibleLevel() }}</span>
-              <app-icon name="arrow_forward"></app-icon>
+        } @else if (productsLoading()) {
+          <app-spinner>Looking up grading fee...</app-spinner>
+        } @else if (productsError()) {
+          <div class="error-container">
+            <span class="error-message">{{ productsError() }}</span>
+            <button class="icon-only-button" (click)="loadProducts()">
+              <app-icon name="refresh"></app-icon>
             </button>
-          }
-        </div>
-      </div>
-    } @else {
-      @if (productsLoading()) {
-        <app-spinner>Looking up grading fee...</app-spinner>
-      } @else if (productsError()) {
-        <div class="error-container">
-          <span class="error-message">{{ productsError() }}</span>
-          <button class="icon-only-button" (click)="loadProducts()">
-            <app-icon name="refresh"></app-icon>
-          </button>
-        </div>
-      } @else if (matchingGradingPrice(); as match) {
-        <div class="membership-options-grid">
-          <div class="option-card selected">
-            <div class="option-title">{{ targetLevel() }}</div>
-            <div class="rate-price">
-              {{ formatPrice(match.price.unitAmount, match.price.currency) }}
+          </div>
+        } @else if (matchingGradingPrice(); as match) {
+          <div class="membership-options-grid">
+            <div class="option-card selected">
+              <div class="option-title">{{ targetLevel() }}</div>
+              <div class="rate-price">
+                {{ formatPrice(match.price.unitAmount, match.price.currency) }}
+              </div>
+              <div class="rate-desc">
+                One-time examination fee for {{ targetLevel() }}.
+                @if (isPayingForExistingGrading()) {
+                  <span class="option-subtext">
+                    This settles the outstanding fee on the {{ targetLevel() }} grading you already have — no extra grading record is created.
+                  </span>
+                }
+              </div>
             </div>
-            <div class="rate-desc">
-              One-time examination fee for {{ targetLevel() }}.
-              @if (isPayingForExistingGrading()) {
-                <span class="option-subtext">
-                  This settles the outstanding fee on the {{ targetLevel() }} grading you already have — no extra grading record is created.
-                </span>
+          </div>
+
+          <div class="checkout-section">
+            @if (checkoutError()) {
+              <div class="error-container">
+                <span class="error-message">{{ checkoutError() }}</span>
+                <button class="icon-only-button" (click)="checkoutError.set(null)">
+                  <app-icon name="close"></app-icon>
+                </button>
+              </div>
+            }
+
+            <div class="checkout-actions">
+              @if (isRedirecting()) {
+                <app-spinner>Redirecting to secure Stripe Checkout…</app-spinner>
+              } @else {
+                <button
+                  type="button"
+                  class="button pay-btn"
+                  (click)="onPurchaseNextGrading()"
+                >
+                  <span>Purchase {{ targetLevel() }} Grading</span>
+                  <app-icon name="arrow_forward"></app-icon>
+                </button>
               }
             </div>
           </div>
-        </div>
-
-        <div class="checkout-section">
-          @if (checkoutError()) {
-            <div class="error-container">
-              <span class="error-message">{{ checkoutError() }}</span>
-              <button class="icon-only-button" (click)="checkoutError.set(null)">
-                <app-icon name="close"></app-icon>
-              </button>
-            </div>
-          }
-
-          <div class="checkout-actions">
-            @if (isRedirecting()) {
-              <app-spinner>Redirecting to secure Stripe Checkout…</app-spinner>
-            } @else {
-              <button
-                type="button"
-                class="button pay-btn"
-                (click)="onPurchaseNextGrading()"
-              >
-                <span>Purchase {{ targetLevel() }} Grading</span>
-                <app-icon name="arrow_forward"></app-icon>
-              </button>
-            }
+        } @else {
+          <div class="empty-notice">
+            <p>
+              Grading fee information for <strong>{{ targetLevel() }}</strong> is currently being updated.
+              Please contact your instructor or headquarters.
+            </p>
           </div>
-        </div>
-      } @else {
-        <div class="empty-notice">
-          <p>
-            Grading fee information for <strong>{{ targetLevel() }}</strong> is currently being updated.
-            Please contact your instructor or headquarters.
-          </p>
-        </div>
-      }
+        }
+      </div>
     }
   </app-step-card>
 </div>

--- a/src/app/next-grading/next-grading.scss
+++ b/src/app/next-grading/next-grading.scss
@@ -257,15 +257,6 @@ app-step-track {
     line-height: 1.45;
     color: #92400e;
   }
-
-  .retake-action-btn {
-    align-self: flex-start;
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5em;
-    padding: 0.55em 1.3em;
-    font-weight: 600;
-  }
 }
 
 .advance-purchase-toggle {
@@ -472,8 +463,6 @@ app-step-track {
 
 .checkout-section {
   margin-top: 1rem;
-  border-top: 1px solid v.$separator-color;
-  padding-top: 1.25rem;
 }
 
 .checkout-actions {

--- a/src/app/next-grading/next-grading.ts
+++ b/src/app/next-grading/next-grading.ts
@@ -92,33 +92,18 @@ export class NextGradingComponent {
   // ──────────────────────────────────────────────────────────────────────────
   //  Wizard state — see become-a-member.ts for the same pattern.
   //
-  //  Step 2 is informational but carries a real choice (free retake vs. buying
-  //  the next level in advance), so it waits for an explicit Continue rather
-  //  than collapsing the moment membership is confirmed.
+  //  Step 2 carries a real choice (free retake vs. buying the next level in
+  //  advance) and the fee for it, so the grading is chosen and paid for in the
+  //  one place.
   // ──────────────────────────────────────────────────────────────────────────
 
   readonly StepAccount = 1;
   readonly StepLevel = 2;
-  readonly StepPayment = 3;
-
-  private levelStepAcknowledged = signal(false);
 
   flow = new StepFlow(
-    computed(() => {
-      if (!this.isLoggedIn()) return this.StepAccount;
-      if (!this.isActiveMember()) return this.StepLevel;
-      if (!this.targetLevel()) return this.StepLevel;
-      if (!this.levelStepAcknowledged()) return this.StepLevel;
-      return this.StepPayment;
-    }),
-    ['Account', 'Your Level', 'Payment'],
+    computed(() => (this.isLoggedIn() ? this.StepLevel : this.StepAccount)),
+    ['Account', 'Your Level'],
   );
-
-  /** "Continue" on step 2: accept the shown level and move on to payment. */
-  continueFromLevelStep(): void {
-    this.levelStepAcknowledged.set(true);
-    this.flow.resume();
-  }
 
   accountSummary = computed(() => {
     const u = this.user();

--- a/src/app/school-license-purchase/school-license-purchase.html
+++ b/src/app/school-license-purchase/school-license-purchase.html
@@ -130,10 +130,10 @@
     }
   </app-step-card>
 
-  <!-- Step 2: School Selection & Affiliation -->
+  <!-- Step 2: School selection, affiliation details, and checkout -->
   <app-step-card
     [number]="StepSchool"
-    title="School Affiliation Details"
+    title="School Details & License Purchase"
     [state]="flow.stateOf(StepSchool)"
     [expanded]="flow.current() === StepSchool"
     (editRequested)="flow.goTo(StepSchool)"
@@ -402,93 +402,74 @@
         </div>
       }
 
-      <div class="step-footer">
+      <div class="step-footer checkout">
         @if (!schoolDetailsComplete()) {
           <p class="step-todo-hint">
             @if (licenseAction() === 'renew') {
               Choose the school whose license you are renewing.
             } @else {
               The school's name, city and country are needed before you can
-              continue.
+              pay.
             }
           </p>
         }
-        <button
-          type="button"
-          class="next-btn"
-          [disabled]="!schoolDetailsComplete()"
-          (click)="continueFromSchoolStep()"
-        >
-          <span>Continue</span>
-          <app-icon name="arrow_forward"></app-icon>
-        </button>
+
+        @if (productsLoading()) {
+          <app-spinner>Loading school license rates...</app-spinner>
+        } @else if (productsError()) {
+          <div class="error-container">
+            <span class="error-message">{{ productsError() }}</span>
+            <button class="icon-only-button" (click)="loadProducts()">
+              <app-icon name="refresh"></app-icon>
+            </button>
+          </div>
+        } @else if (selectedPrice(); as price) {
+          <div class="membership-options-grid">
+            <div class="option-card selected">
+              <div class="option-title">1-Year School Affiliation License</div>
+              <div class="rate-price">
+                {{ formatPrice(price) }}
+              </div>
+              <div class="rate-desc">
+                Annual school affiliation fee. Valid for 1 full year from current expiration date (or starting today for new schools).
+              </div>
+            </div>
+          </div>
+
+          <div class="checkout-section">
+            @if (checkoutError()) {
+              <div class="error-container">
+                <span class="error-message">{{ checkoutError() }}</span>
+                <button class="icon-only-button" (click)="checkoutError.set(null)">
+                  <app-icon name="close"></app-icon>
+                </button>
+              </div>
+            }
+
+            <div class="checkout-actions">
+              @if (isRedirecting()) {
+                <app-spinner>Redirecting to secure Stripe Checkout…</app-spinner>
+              } @else {
+                <button
+                  type="button"
+                  class="button pay-btn"
+                  [disabled]="!schoolDetailsComplete()"
+                  (click)="onPurchaseSchoolLicense()"
+                >
+                  <span>
+                    {{ licenseAction() === 'renew' && selectedSchoolDocId() ? 'Renew Selected School License' : 'Register School & Pay License Fee' }}
+                  </span>
+                  <app-icon name="arrow_forward"></app-icon>
+                </button>
+              }
+            </div>
+          </div>
+        } @else {
+          <div class="empty-notice">
+            <p>School license rates are currently being configured. Please check back shortly.</p>
+          </div>
+        }
       </div>
     }
-  </app-step-card>
-
-  <!-- Step 3: School Affiliation Fee & Checkout -->
-  <app-step-card
-    [number]="StepPayment"
-    title="School License Fee"
-    [state]="flow.stateOf(StepPayment)"
-    [expanded]="flow.current() === StepPayment"
-    [editable]="false"
-  >
-
-      @if (productsLoading()) {
-        <app-spinner>Loading school license rates...</app-spinner>
-      } @else if (productsError()) {
-        <div class="error-container">
-          <span class="error-message">{{ productsError() }}</span>
-          <button class="icon-only-button" (click)="loadProducts()">
-            <app-icon name="refresh"></app-icon>
-          </button>
-        </div>
-      } @else if (selectedPrice(); as price) {
-        <div class="membership-options-grid">
-          <div class="option-card selected">
-            <div class="option-title">1-Year School Affiliation License</div>
-            <div class="rate-price">
-              {{ formatPrice(price) }}
-            </div>
-            <div class="rate-desc">
-              Annual school affiliation fee. Valid for 1 full year from current expiration date (or starting today for new schools).
-            </div>
-          </div>
-        </div>
-
-        <div class="checkout-section">
-          @if (checkoutError()) {
-            <div class="error-container">
-              <span class="error-message">{{ checkoutError() }}</span>
-              <button class="icon-only-button" (click)="checkoutError.set(null)">
-                <app-icon name="close"></app-icon>
-              </button>
-            </div>
-          }
-
-          <div class="checkout-actions">
-            @if (isRedirecting()) {
-              <app-spinner>Redirecting to secure Stripe Checkout…</app-spinner>
-            } @else {
-              <button
-                type="button"
-                class="button pay-btn"
-                [disabled]="!schoolDetailsComplete()"
-                (click)="onPurchaseSchoolLicense()"
-              >
-                <span>
-                  {{ licenseAction() === 'renew' && selectedSchoolDocId() ? 'Renew Selected School License' : 'Register School & Pay License Fee' }}
-                </span>
-                <app-icon name="arrow_forward"></app-icon>
-              </button>
-            }
-          </div>
-        </div>
-      } @else {
-        <div class="empty-notice">
-          <p>School license rates are currently being configured. Please check back shortly.</p>
-        </div>
-      }
   </app-step-card>
 </div>

--- a/src/app/school-license-purchase/school-license-purchase.scss
+++ b/src/app/school-license-purchase/school-license-purchase.scss
@@ -425,8 +425,6 @@ app-autocomplete {
 
 .checkout-section {
   margin-top: 1rem;
-  border-top: 1px solid v.$separator-color;
-  padding-top: 1.25rem;
 }
 
 .checkout-actions {

--- a/src/app/school-license-purchase/school-license-purchase.ts
+++ b/src/app/school-license-purchase/school-license-purchase.ts
@@ -139,7 +139,6 @@ export class SchoolLicensePurchaseComponent {
   // ── Guided flow. See step-flow.ts. ──
   readonly StepAccount = 1;
   readonly StepSchool = 2;
-  readonly StepPayment = 3;
 
   /**
    * Step 2 is complete once there is a school to charge for: either one picked
@@ -157,29 +156,13 @@ export class SchoolLicensePurchaseComponent {
     );
   });
 
-  /**
-   * Renewing with no schools on record counts as "complete" for the checkout
-   * button, so without an explicit Continue the school step could be skipped
-   * before the user has chosen or described the school being licensed.
-   */
-  private schoolStepAcknowledged = signal(false);
-
   flow = new StepFlow(
     computed(() => {
       if (!this.isLoggedIn()) return this.StepAccount;
-      if (!this.isActiveMember()) return this.StepSchool;
-      if (!this.schoolDetailsComplete()) return this.StepSchool;
-      if (!this.schoolStepAcknowledged()) return this.StepSchool;
-      return this.StepPayment;
+      return this.StepSchool;
     }),
-    ['Account', 'School', 'Payment'],
+    ['Account', 'School'],
   );
-
-  /** "Continue" on the school step: accept the school and go to payment. */
-  continueFromSchoolStep(): void {
-    this.schoolStepAcknowledged.set(true);
-    this.flow.resume();
-  }
 
   accountSummary = computed(() => {
     const u = this.user();

--- a/src/app/settings/content-cache/content-cache.ts
+++ b/src/app/settings/content-cache/content-cache.ts
@@ -108,12 +108,18 @@ export class ContentCacheComponent implements OnInit, OnDestroy {
         try {
             const clearFn = httpsCallable<
                 void,
-                { success: boolean; deletedCount: number }
+                { success: boolean; deletedCount: number; keptCount: number }
             >(this.functions, 'clearContentCache');
 
             const result = await clearFn();
+            // Only Squarespace-sourced posts are cache; any posts authored in
+            // the app are kept, so report both numbers.
+            const { deletedCount, keptCount } = result.data;
             this.resultMessage.set(
-                `Cache cleared: ${result.data.deletedCount} items deleted.`,
+                `Cache cleared: ${deletedCount} cached items deleted.` +
+                (keptCount
+                    ? ` ${keptCount} authored item(s) kept.`
+                    : ''),
             );
         } catch (error) {
             console.error('Cache clear failed:', error);

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1238,6 +1238,15 @@ button.menu-item {
   }
 }
 
+// A step that ends in payment rather than a Continue button: the fee card,
+// any error, and the pay action stack down the card instead of competing for
+// one right-aligned row.
+.step-footer.checkout {
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: flex-start;
+}
+
 .step-todo-hint {
   margin: 0;
   margin-right: auto;


### PR DESCRIPTION
All outstanding work on the branch, in two commits.

## `fix(auth)`: let a failed sign-in say so, and offer a way out

Reported as "I can't log in again with a password, and nothing tells me why", plus "the whole page flashes".

Both are the same bug. `app.html` rendered **nothing at all** while `loginStatus` was `LoggingIn`, which destroyed `<app-inline-auth>` on every attempt — so a rejected password took its own error message down with the component before it could be read, and a successful one blanked the page on the way through.

- The sign-in box stays mounted for the duration of a request.
- The spinner replaces only the messages and buttons of the current step; the email and password stay on screen, disabled.
- New `auth-error-messages.ts` maps every Firebase code to a human sentence (sign-in, sign-up, Google, reset) instead of showing a raw `auth/invalid-credential`.
- **"Forgotten your password? Email me a password reset link"** now stands on the password step at all times, not only after a wrong guess, and is emphasised when the failure is one a reset would fix — rate limiting included.
- "An account already exists ... reset it below" finally has the two ways in underneath it.

Verified live against the project: a rejected password now leaves the box in place, keeps the typed password, and reads *"That email and password don't match an account. If you're not sure of your password, send yourself a reset link below."*

## `feat`: checkout, backups, and event `sourceId`

Three strands kept in one commit because they share `data-model.ts`.

**Checkout** — the purchase flows (Become a Member, Next Grading, Instructor and School licences) had a Payment step that only restated the choice made on the step before. The fee, any error, and the pay action now live on the choosing step; each flow loses a click.

**Backup** — `BACKUP_COLLECTIONS` covered a fraction of the authored data. It now also takes `videos`, `video_grants` and `statistics`, walks the member sub-collection groups by collection-group query (a top-level `.get()` never saw them), and records the full document path so parents are recoverable. `BlogPostSourceKind` / `blogPostSourceKind()` give the Squarespace sync, `clearContentCache` and the backup one shared definition of which blog posts are disposable — an unrecognised kind is never deleted.

**Events** — the Google Calendar sync is gone, so `EventSourceKind`, `IlcEvent.kind` / `.sourceId`, and the lookups and form fields reading them are removed. Documents predating the removal still carry `kind` in Firestore; the type records why it stays unmodelled.

## Testing

- `pnpm run test:once` — 876 passed (3 new: the box stays mounted while `LoggingIn`; the typed password survives an in-flight sign-in; the message and reset link appear on a rejected password)
- `pnpm run test:functions` — 378 passed
- `pnpm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)